### PR TITLE
fix stdin type mismatch in windows

### DIFF
--- a/infra/conf/command/command.go
+++ b/infra/conf/command/command.go
@@ -3,6 +3,7 @@ package command
 //go:generate errorgen
 
 import (
+	"bufio"
 	"os"
 
 	"github.com/golang/protobuf/proto"
@@ -27,7 +28,7 @@ func (c *ConfigCommand) Description() control.Description {
 }
 
 func (c *ConfigCommand) Execute(args []string) error {
-	pbConfig, err := serial.LoadJSONConfig(os.Stdin)
+	pbConfig, err := serial.LoadJSONConfig(bufio.NewReader(os.Stdin))
 	if err != nil {
 		return newError("failed to parse json config").Base(err)
 	}


### PR DESCRIPTION
fix https://github.com/v2ray/v2ray-core/issues/1666
os.Stdin in windows does not compatible with TeeReader. 

This bug is triggered only when config.json is relatively large, eg 10k. I looked around find that in early version of go there's such issue: https://github.com/golang/go/issues/13697 `// Windows can't read bytes over max of int16. `

In recent version this code moved to https://github.com/golang/go/blob/master/src/internal/poll/fd_windows.go

In v2ray, this reader is passed to https://github.com/v2fly/v2ray-core/blob/1a7b2337f81cbdbe7da06d5cf5c916de899ef372/common/buf/io.go#L49 and generated a `SingleReader`,  https://github.com/v2fly/v2ray-core/blob/1a7b2337f81cbdbe7da06d5cf5c916de899ef372/common/buf/reader.go#L157   which reads one buffer at a time, thus excceed the windows stdin limit.

Wrapping the `os.Stdin` with `bufio.NewReader` is a common usage when comes to reading mass data from stdin, avoiding environmental problems.
