### PR TITLE
fix: json field tag syntax

### DIFF
--- a/infra/conf/dns_proxy.go
+++ b/infra/conf/dns_proxy.go
@@ -7,9 +7,9 @@ import (
 )
 
 type DnsOutboundConfig struct {
-	Network Network  `json:network`
-	Address *Address `json:address`
-	Port    uint16   `json:port`
+	Network Network  `json:"network"`
+	Address *Address `json:"address"`
+	Port    uint16   `json:"port"`
 }
 
 func (c *DnsOutboundConfig) Build() (proto.Message, error) {


### PR DESCRIPTION
`go vet` complains the following errors:
```
$ cd $GOPATH/src/v2ray.com/core/infra/conf
$ go vet
# v2ray.com/core/infra/conf
./dns_proxy.go:10:2: struct field tag `json:network` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
./dns_proxy.go:11:2: struct field tag `json:address` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
./dns_proxy.go:12:2: struct field tag `json:port` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
```

The `DnsOutboundConfig` fileld tags are missing double quotes.