### PR TITLE
Update Golang version to 1.14.4

### DIFF
--- a/azure-pipelines.template.yml
+++ b/azure-pipelines.template.yml
@@ -9,7 +9,7 @@ jobs:
   - checkout: self
   - task: GoTool@0
     inputs:
-      version: '1.13'
+      version: '1.14'
   - script: |
       go test -p 1 -v -timeout 30m ./...
     workingDirectory: '$(Build.SourcesDirectory)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ jobs:
   - checkout: self
   - task: GoTool@0
     inputs:
-      version: '1.14.1'
+      version: '1.14.4'
   - script: |
       bash ./testing/coverage/coverall
     workingDirectory: '$(Build.SourcesDirectory)'
@@ -66,7 +66,7 @@ jobs:
   - checkout: self
   - task: GoTool@0
     inputs:
-      version: '1.14.1'
+      version: '1.14.4'
   - script: |
       mkdir triggersrc
       ls -I "triggersrc" | xargs cp -rf -t triggersrc


### PR DESCRIPTION
前几天我就看了 Azure Pipelines 关于 Golang 的文档，发现尚不支持如“latest”这样的版本声明方式

或许以后可以自动化这个常规流程