### PR TITLE
Apply routing for non-local DoH requests

### DIFF
--- a/app/dns/dohdns.go
+++ b/app/dns/dohdns.go
@@ -236,8 +236,7 @@ func (s *DoHNameServer) sendQuery(ctx context.Context, domain string, option IPO
 			}
 
 			dnsCtx = session.ContextWithContent(dnsCtx, &session.Content{
-				Protocol:      "https",
-				SkipRoutePick: true,
+				Protocol: "https",
 			})
 
 			// forced to use mux for DOH

--- a/app/dns/dohdns.go
+++ b/app/dns/dohdns.go
@@ -213,6 +213,10 @@ func (s *DoHNameServer) newReqID() uint16 {
 func (s *DoHNameServer) sendQuery(ctx context.Context, domain string, option IPOption) {
 	newError(s.name, " querying: ", domain).AtInfo().WriteToLog(session.ExportIDToError(ctx))
 
+	if s.name + "." == "DOH//" + domain {
+		 newError(s.name, " tries to resolve itself! Use IP or set \"hosts\" instead.").AtError().WriteToLog(session.ExportIDToError(ctx))
+		 return
+	}
 	reqs := buildReqMsgs(domain, option, s.newReqID, genEDNS0Options(s.clientIP))
 
 	var deadline time.Time


### PR DESCRIPTION
This regression was introduced in 04a0c0493449441020351bff47930c357618222a, and prevents routing rules from being applied to DoH server(s).