### PR TITLE
Fix parser for shadowsocks cipher "none"

### DIFF
--- a/infra/conf/shadowsocks.go
+++ b/infra/conf/shadowsocks.go
@@ -26,6 +26,8 @@ func cipherFromString(c string) shadowsocks.CipherType {
 		return shadowsocks.CipherType_AES_256_GCM
 	case "chacha20-poly1305", "aead_chacha20_poly1305", "chacha20-ietf-poly1305":
 		return shadowsocks.CipherType_CHACHA20_POLY1305
+	case "none", "plain":
+		return shadowsocks.CipherType_NONE
 	default:
 		return shadowsocks.CipherType_UNKNOWN
 	}


### PR DESCRIPTION
There is a trend to use TLS nowadays. When proxy traffic is wrapped inside TLS, extra encryption typically bring no value. I found v2ray actually support Shadowsocks cipher "none" already. It's just not parsing Json correctly.
I tested this implementation is compatible with other third party clients. I also did a quick test against Socks with no authentication. It looks like Shadowsocks yield a lower RTT.
NOTE: when "none" cipher is used, "password" is not verified. User need to rely on a secure path at transport level like ws or h2.