### PR TITLE
some typo fixes

### DIFF
--- a/common/buf/buffer_test.go
+++ b/common/buf/buffer_test.go
@@ -22,7 +22,7 @@ func TestBufferClear(t *testing.T) {
 
 	buffer.Clear()
 	if buffer.Len() != 0 {
-		t.Error("expect 0 lenght, but got ", buffer.Len())
+		t.Error("expect 0 length, but got ", buffer.Len())
 	}
 }
 

--- a/common/mux/server.go
+++ b/common/mux/server.go
@@ -35,7 +35,7 @@ func (s *Server) Type() interface{} {
 	return s.dispatcher.Type()
 }
 
-// Dispatch impliments routing.Dispatcher
+// Dispatch implements routing.Dispatcher
 func (s *Server) Dispatch(ctx context.Context, dest net.Destination) (*transport.Link, error) {
 	if dest.Address != muxCoolAddress {
 		return s.dispatcher.Dispatch(ctx, dest)

--- a/features/stats/stats.go
+++ b/features/stats/stats.go
@@ -22,7 +22,7 @@ type Counter interface {
 type Manager interface {
 	features.Feature
 
-	// RegisterCounter registers a new counter to the manager. The identifier string must not be emtpy, and unique among other counters.
+	// RegisterCounter registers a new counter to the manager. The identifier string must not be empty, and unique among other counters.
 	RegisterCounter(string) (Counter, error)
 	// GetCounter returns a counter by its identifier.
 	GetCounter(string) Counter


### PR DESCRIPTION
note: there are other typos in external/ folder.
considering the fact that the folder "will be removed in future", I skipped those typos.

details: https://goreportcard.com/report/github.com/v2fly/v2ray-core#misspell