### PR TITLE
Fix the error of missing curl in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # STEP 1 build executable binary
 ############################
 FROM golang:alpine AS builder
-RUN apk update && apk add --no-cache git bash wget
+RUN apk update && apk add --no-cache git bash wget curl
 WORKDIR /go/src/v2ray.com/core
 RUN git clone --progress https://github.com/v2fly/v2ray-core.git . && \
     bash ./release/user-package.sh nosource noconf codename=$(git describe --tags) buildname=docker-fly abpathtgz=/tmp/v2ray.tgz


### PR DESCRIPTION
This error was caused by replacing wget with curl in c7b5d178b7e6c09c846bdbc1f75674ecee3cee11.

```bash
>>> Downloading newest geoip ...
./release/user-package.sh: line 53: curl: command not found
```

https://github.com/v2fly/v2ray-core/blob/34d6818a85ae75040350fb34bfdd6752a2c62420/release/user-package.sh#L51-L57