### PR TITLE
Add docker.yaml to actions

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -28,43 +28,16 @@ jobs:
         run: |
           echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
 
-      - name: Get image version
-        id: get_image_version
-        run: echo ::set-output name=version::${GITHUB_REF#refs/*/}
-
-      - name: Get image name
-        id: get_image_name
+      - name: Build and push Docker image
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        run: echo ::set-output name=name::$(echo $DOCKER_USERNAME | tr '[:upper:]' '[:lower:]')/v2fly-core
-
-      - name: Get image platform
-        env:
-          PLATFORM: linux/386,linux/amd64,linux/arm/v7,linux/arm64
-        id: get_image_platform
-        run: echo ::set-output name=platform::"$PLATFORM"
-
-      - name: Build and push Docker image (version)
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_IMAGE_NAME: ${{ steps.get_image_name.outputs.name }}
-          DOCKER_IMAGE_VERSION: ${{ steps.get_image_version.outputs.version }}
-          DOCKER_IMAGE_PLATFORM: ${{ steps.get_image_platform.outputs.platform }}
+          DOCKER_IMAGE_PLATFORM: linux/386,linux/amd64,linux/arm/v7,linux/arm64
         run: |
+          DOCKER_IMAGE_NAME=$(echo $DOCKER_USERNAME | tr '[:upper:]' '[:lower:]')/v2fly-core
+          DOCKER_IMAGE_VERSION=${GITHUB_REF#refs/*/}
           docker buildx build \
             --platform "$DOCKER_IMAGE_PLATFORM" \
             --output "type=image,push=true" \
             --tag "$DOCKER_IMAGE_NAME":"$DOCKER_IMAGE_VERSION" \
-            --file ./Dockerfile .
-      
-      - name: Build and push Docker image (latest)
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_IMAGE_NAME: ${{ steps.get_image_name.outputs.name }}
-          DOCKER_IMAGE_PLATFORM: ${{ steps.get_image_platform.outputs.platform }}
-        run: |
-          docker buildx build \
-            --platform "$DOCKER_IMAGE_PLATFORM" \
-            --output "type=image,push=true" \
             --tag "$DOCKER_IMAGE_NAME":latest \
             --file ./Dockerfile .

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,48 @@
+name: Release Docker image
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: crazy-max/ghaction-docker-buildx@v3
+
+      - name: Log in to DockerHub
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
+
+      - name: Get release version
+        id: get_relesase_version
+        run: echo ::set-output name=version::${GITHUB_REF#refs/*/}
+
+      - name: Build and puch Docker image (version)
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          RELEASE_VERSION: ${{ steps.get_relesase_version.outputs.version }}
+        run: |
+          docker buildx build \
+            --platform linux/386,linux/amd64,linux/arm/v7,linux/arm64 \
+            --output "type=image,push=true" \
+            --tag $(echo "${DOCKER_USERNAME}" | tr '[:upper:]' '[:lower:]')/v2fly-core:"$RELEASE_VERSION" \
+            --file ./Dockerfile .
+
+      - name: Build and push Docker image (latest)
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        run: |
+          docker buildx build \
+            --platform linux/386,linux/amd64,linux/arm/v7,linux/arm64 \
+            --output "type=image,push=true" \
+            --tag $(echo "${DOCKER_USERNAME}" | tr '[:upper:]' '[:lower:]')/v2fly-core:latest \
+            --file ./Dockerfile .

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,4 +1,4 @@
-name: Release Docker image
+name: Release Docker Image
 
 on:
   push:
@@ -12,37 +12,59 @@ jobs:
       - name: Set up Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Docker Buildx
-        uses: crazy-max/ghaction-docker-buildx@v3
+      - name: Install Buildx and QEMU
+        run: |
+          export DOCKER_BUILDKIT=1
+          docker build --platform=local -o . git://github.com/docker/buildx
+          mkdir -p ~/.docker/cli-plugins
+          mv buildx ~/.docker/cli-plugins/docker-buildx
+          docker run --rm --privileged multiarch/qemu-user-static:latest --reset -p yes --credential yes
+          docker buildx create --use --name build --node build --driver-opt network=host
 
-      - name: Log in to DockerHub
+      - name: Log in to Docker Hub
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
           echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
 
-      - name: Get release version
-        id: get_relesase_version
+      - name: Get image version
+        id: get_image_version
         run: echo ::set-output name=version::${GITHUB_REF#refs/*/}
 
-      - name: Build and puch Docker image (version)
+      - name: Get image name
+        id: get_image_name
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          RELEASE_VERSION: ${{ steps.get_relesase_version.outputs.version }}
+        run: echo ::set-output name=name::$(echo $DOCKER_USERNAME | tr '[:upper:]' '[:lower:]')/v2fly-core
+
+      - name: Get image platform
+        env:
+          PLATFORM: linux/386,linux/amd64,linux/arm/v7,linux/arm64
+        id: get_image_platform
+        run: echo ::set-output name=platform::"$PLATFORM"
+
+      - name: Build and push Docker image (version)
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_IMAGE_NAME: ${{ steps.get_image_name.outputs.name }}
+          DOCKER_IMAGE_VERSION: ${{ steps.get_image_version.outputs.version }}
+          DOCKER_IMAGE_PLATFORM: ${{ steps.get_image_platform.outputs.platform }}
         run: |
           docker buildx build \
-            --platform linux/386,linux/amd64,linux/arm/v7,linux/arm64 \
+            --platform "$DOCKER_IMAGE_PLATFORM" \
             --output "type=image,push=true" \
-            --tag $(echo "${DOCKER_USERNAME}" | tr '[:upper:]' '[:lower:]')/v2fly-core:"$RELEASE_VERSION" \
+            --tag "$DOCKER_IMAGE_NAME":"$DOCKER_IMAGE_VERSION" \
             --file ./Dockerfile .
-
+      
       - name: Build and push Docker image (latest)
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_IMAGE_NAME: ${{ steps.get_image_name.outputs.name }}
+          DOCKER_IMAGE_PLATFORM: ${{ steps.get_image_platform.outputs.platform }}
         run: |
           docker buildx build \
-            --platform linux/386,linux/amd64,linux/arm/v7,linux/arm64 \
+            --platform "$DOCKER_IMAGE_PLATFORM" \
             --output "type=image,push=true" \
-            --tag $(echo "${DOCKER_USERNAME}" | tr '[:upper:]' '[:lower:]')/v2fly-core:latest \
+            --tag "$DOCKER_IMAGE_NAME":latest \
             --file ./Dockerfile .


### PR DESCRIPTION
Resolved #45. This action will be triggered when the `master` branch commits a `tag` beginning with `v`.

## Description

1. Need to configure `DOCKER_USERNAME` and `DOCKER_ PASSWORD` in `Secrets`. If this commit needs to be merged into upstream `v2ray` in the future, please also keep this in mind.
2. Now supports build Linux 386 / amd64 / armv7 / arm64.
3. The build time is about 12 minutes. Each schema will only be built once, because the `latest` tag will hit the cache.

## Demo

[GitHub Actions](https://github.com/kallydev/v2ray-core/actions?query=workflow%3A%22Release+Docker+image%22)

[Docker Hub](https://hub.docker.com/r/kallydev/v2fly-core/tags)