### PR TITLE
Move setting of SO_REUSEPORT out of applyInboundSocketOptions

### DIFF
--- a/transport/internet/sockopt_darwin.go
+++ b/transport/internet/sockopt_darwin.go
@@ -50,3 +50,11 @@ func applyInboundSocketOptions(network string, fd uintptr, config *SocketConfig)
 func bindAddr(fd uintptr, address []byte, port uint32) error {
 	return nil
 }
+
+func setReuseAddr(fd uintptr) error {
+	return nil
+}
+
+func setReusePort(fd uintptr) error {
+	return nil
+}

--- a/transport/internet/sockopt_freebsd.go
+++ b/transport/internet/sockopt_freebsd.go
@@ -188,15 +188,8 @@ func applyInboundSocketOptions(network string, fd uintptr, config *SocketConfig)
 }
 
 func bindAddr(fd uintptr, ip []byte, port uint32) error {
-	if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1); err != nil {
-		return newError("failed to set resuse_addr").Base(err).AtWarning()
-	}
-
-	if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, soReUsePortLB, 1); err != nil {
-		if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, soReUsePort, 1); err != nil {
-			return newError("failed to set resuse_port").Base(err).AtWarning()
-		}
-	}
+	setReuseAddr(fd)
+	setReusePort(fd)
 
 	var sockaddr syscall.Sockaddr
 
@@ -218,4 +211,20 @@ func bindAddr(fd uintptr, ip []byte, port uint32) error {
 	}
 
 	return syscall.Bind(int(fd), sockaddr)
+}
+
+func setReuseAddr(fd uintptr) error {
+	if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1); err != nil {
+		return newError("failed to set SO_REUSEADDR").Base(err).AtWarning()
+	}
+	return nil
+}
+
+func setReusePort(fd uintptr) error {
+	if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, soReUsePortLB, 1); err != nil {
+		if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, soReUsePort, 1); err != nil {
+			return newError("failed to set SO_REUSEPORT").Base(err).AtWarning()
+		}
+	}
+	return nil
 }

--- a/transport/internet/sockopt_linux.go
+++ b/transport/internet/sockopt_linux.go
@@ -16,11 +16,11 @@ const (
 
 func bindAddr(fd uintptr, ip []byte, port uint32) error {
 	if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1); err != nil {
-		return newError("failed to set resuse_addr").Base(err).AtWarning()
+		return newError("failed to set SO_REUSEADDR").Base(err).AtWarning()
 	}
 
 	if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, unix.SO_REUSEPORT, 1); err != nil {
-		return newError("failed to set resuse_port").Base(err).AtWarning()
+		return newError("failed to set SO_REUSEPORT").Base(err).AtWarning()
 	}
 
 	var sockaddr syscall.Sockaddr
@@ -105,10 +105,6 @@ func applyInboundSocketOptions(network string, fd uintptr, config *SocketConfig)
 		if err1 != nil && err2 != nil {
 			return err1
 		}
-	}
-
-	if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, unix.SO_REUSEPORT, 1); err != nil {
-		return newError("failed to set SO_REUSEPORT").Base(err).AtWarning()
 	}
 
 	return nil

--- a/transport/internet/sockopt_linux.go
+++ b/transport/internet/sockopt_linux.go
@@ -15,13 +15,8 @@ const (
 )
 
 func bindAddr(fd uintptr, ip []byte, port uint32) error {
-	if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1); err != nil {
-		return newError("failed to set SO_REUSEADDR").Base(err).AtWarning()
-	}
-
-	if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, unix.SO_REUSEPORT, 1); err != nil {
-		return newError("failed to set SO_REUSEPORT").Base(err).AtWarning()
-	}
+	setReuseAddr(fd)
+	setReusePort(fd)
 
 	var sockaddr syscall.Sockaddr
 
@@ -107,5 +102,19 @@ func applyInboundSocketOptions(network string, fd uintptr, config *SocketConfig)
 		}
 	}
 
+	return nil
+}
+
+func setReuseAddr(fd uintptr) error {
+	if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1); err != nil {
+		return newError("failed to set SO_REUSEADDR").Base(err).AtWarning()
+	}
+	return nil
+}
+
+func setReusePort(fd uintptr) error {
+	if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, unix.SO_REUSEPORT, 1); err != nil {
+		return newError("failed to set SO_REUSEPORT").Base(err).AtWarning()
+	}
 	return nil
 }

--- a/transport/internet/sockopt_other.go
+++ b/transport/internet/sockopt_other.go
@@ -13,3 +13,11 @@ func applyInboundSocketOptions(network string, fd uintptr, config *SocketConfig)
 func bindAddr(fd uintptr, ip []byte, port uint32) error {
 	return nil
 }
+
+func setReuseAddr(fd uintptr) error {
+	return nil
+}
+
+func setReusePort(fd uintptr) error {
+	return nil
+}

--- a/transport/internet/sockopt_windows.go
+++ b/transport/internet/sockopt_windows.go
@@ -46,3 +46,11 @@ func applyInboundSocketOptions(network string, fd uintptr, config *SocketConfig)
 func bindAddr(fd uintptr, ip []byte, port uint32) error {
 	return nil
 }
+
+func setReuseAddr(fd uintptr) error {
+	return nil
+}
+
+func setReusePort(fd uintptr) error {
+	return nil
+}

--- a/transport/internet/system_listener.go
+++ b/transport/internet/system_listener.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"syscall"
 
-	"golang.org/x/sys/unix"
 	"v2ray.com/core/common/net"
 	"v2ray.com/core/common/session"
 )
@@ -28,9 +27,7 @@ func getControlFunc(ctx context.Context, sockopt *SocketConfig, controllers []co
 				}
 			}
 
-			if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, unix.SO_REUSEPORT, 1); err != nil {
-				newError("failed to set SO_REUSEPORT").Base(err).AtWarning()
-			}
+			setReusePort(fd)
 
 			for _, controller := range controllers {
 				if err := controller(network, address, fd); err != nil {


### PR DESCRIPTION
Fix #69
Fix https://github.com/v2ray/v2ray-core/issues/1971

https://github.com/v2ray/v2ray-core/pull/2228 最初的意愿或许是将`SO_REUSEPORT`的设置放到一个合适的始终会被调用的地方。但`applyInboundSocketOptions`及相关函数的设计关注`Sockopt`应为非空，从而使得`Sockopt`未设置时，设置`SO_REUSEPORT`的代码并不会被执行。

这个PR将与`SocketConfig`无关的`SO_REUSEPORT`设置移至`applyInboundSocketOptions`外面，同时取消对`getControlFunc`的检查（检查的目的是为了不注册一个空的Control函数，但现在有一个必定要执行的`SO_REUSEPORT`了）。