### PR TITLE
Fix http outbound to get correct TLS negotiated protocol when "stats" setting exists

### DIFF
--- a/proxy/http/client.go
+++ b/proxy/http/client.go
@@ -197,8 +197,13 @@ func setUpHTTPTunnel(ctx context.Context, dest net.Destination, target string, u
 		return nil, err
 	}
 
+	iConn := rawConn
+	if statConn, ok := iConn.(*internet.StatCouterConnection); ok {
+		iConn = statConn.Connection
+	}
+
 	nextProto := ""
-	if tlsConn, ok := rawConn.(*tls.Conn); ok {
+	if tlsConn, ok := iConn.(*tls.Conn); ok {
 		if err := tlsConn.Handshake(); err != nil {
 			rawConn.Close()
 			return nil, err

--- a/proxy/http/client.go
+++ b/proxy/http/client.go
@@ -71,6 +71,7 @@ func (c *Client) Process(ctx context.Context, link *transport.Link, dialer inter
 		return newError("target not specified.")
 	}
 	target := outbound.Target
+	targetAddr := target.NetAddr()
 
 	if target.Network == net.Network_UDP {
 		return newError("UDP is not supported by HTTP outbound")
@@ -83,9 +84,8 @@ func (c *Client) Process(ctx context.Context, link *transport.Link, dialer inter
 		server := c.serverPicker.PickServer()
 		dest := server.Destination()
 		user = server.PickUser()
-		targetAddr := target.NetAddr()
 
-		netConn, err := setUpHttpTunnel(ctx, dest, targetAddr, user, dialer)
+		netConn, err := setUpHTTPTunnel(ctx, dest, targetAddr, user, dialer)
 		if netConn != nil {
 			conn = internet.Connection(netConn)
 		}
@@ -125,27 +125,22 @@ func (c *Client) Process(ctx context.Context, link *transport.Link, dialer inter
 	return nil
 }
 
-// setUpHttpTunnel will create a socket tunnel via HTTP CONNECT method
-func setUpHttpTunnel(ctx context.Context, dest net.Destination, target string, user *protocol.MemoryUser, dialer internet.Dialer) (net.Conn, error) {
-	req := (&http.Request{
-		Method: "CONNECT",
+// setUpHTTPTunnel will create a socket tunnel via HTTP CONNECT method
+func setUpHTTPTunnel(ctx context.Context, dest net.Destination, target string, user *protocol.MemoryUser, dialer internet.Dialer) (net.Conn, error) {
+	req := &http.Request{
+		Method: http.MethodConnect,
 		URL:    &url.URL{Host: target},
-		Header: make(http.Header),
+		Header: http.Header{"Proxy-Connection": []string{"Keep-Alive"}},
 		Host:   target,
-	}).WithContext(ctx)
+	}
 
 	if user != nil && user.Account != nil {
 		account := user.Account.(*Account)
 		auth := account.GetUsername() + ":" + account.GetPassword()
 		req.Header.Set("Proxy-Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(auth)))
 	}
-	req.Header.Set("Proxy-Connection", "Keep-Alive")
 
-	connectHttp1 := func(rawConn net.Conn) (net.Conn, error) {
-		req.Proto = "HTTP/1.1"
-		req.ProtoMajor = 1
-		req.ProtoMinor = 1
-
+	connectHTTP1 := func(rawConn net.Conn) (net.Conn, error) {
 		err := req.Write(rawConn)
 		if err != nil {
 			rawConn.Close()
@@ -165,10 +160,7 @@ func setUpHttpTunnel(ctx context.Context, dest net.Destination, target string, u
 		return rawConn, nil
 	}
 
-	connectHttp2 := func(rawConn net.Conn, h2clientConn *http2.ClientConn) (net.Conn, error) {
-		req.Proto = "HTTP/2.0"
-		req.ProtoMajor = 2
-		req.ProtoMinor = 0
+	connectHTTP2 := func(rawConn net.Conn, h2clientConn *http2.ClientConn) (net.Conn, error) {
 		pr, pw := io.Pipe()
 		req.Body = pr
 
@@ -182,24 +174,21 @@ func setUpHttpTunnel(ctx context.Context, dest net.Destination, target string, u
 			rawConn.Close()
 			return nil, newError("Proxy responded with non 200 code: " + resp.Status)
 		}
-		return newHttp2Conn(rawConn, pw, resp.Body), nil
+		return newHTTP2Conn(rawConn, pw, resp.Body), nil
 	}
 
 	cachedH2Mutex.Lock()
 	defer cachedH2Mutex.Unlock()
 
 	if cachedConn, found := cachedH2Conns[dest]; found {
-		if cachedConn.rawConn != nil && cachedConn.h2Conn != nil {
-			rc := cachedConn.rawConn
-			cc := cachedConn.h2Conn
-			if cc.CanTakeNewRequest() {
-				proxyConn, err := connectHttp2(rc, cc)
-				if err != nil {
-					return nil, err
-				}
-
-				return proxyConn, nil
+		rc, cc := cachedConn.rawConn, cachedConn.h2Conn
+		if cc.CanTakeNewRequest() {
+			proxyConn, err := connectHTTP2(rc, cc)
+			if err != nil {
+				return nil, err
 			}
+
+			return proxyConn, nil
 		}
 	}
 
@@ -218,10 +207,8 @@ func setUpHttpTunnel(ctx context.Context, dest net.Destination, target string, u
 	}
 
 	switch nextProto {
-	case "":
-		fallthrough
-	case "http/1.1":
-		return connectHttp1(rawConn)
+	case "", "http/1.1":
+		return connectHTTP1(rawConn)
 	case "h2":
 		t := http2.Transport{}
 		h2clientConn, err := t.NewClientConn(rawConn)
@@ -230,7 +217,7 @@ func setUpHttpTunnel(ctx context.Context, dest net.Destination, target string, u
 			return nil, err
 		}
 
-		proxyConn, err := connectHttp2(rawConn, h2clientConn)
+		proxyConn, err := connectHTTP2(rawConn, h2clientConn)
 		if err != nil {
 			rawConn.Close()
 			return nil, err
@@ -251,7 +238,7 @@ func setUpHttpTunnel(ctx context.Context, dest net.Destination, target string, u
 	}
 }
 
-func newHttp2Conn(c net.Conn, pipedReqBody *io.PipeWriter, respBody io.ReadCloser) net.Conn {
+func newHTTP2Conn(c net.Conn, pipedReqBody *io.PipeWriter, respBody io.ReadCloser) net.Conn {
 	return &http2Conn{Conn: c, in: pipedReqBody, out: respBody}
 }
 
@@ -271,18 +258,6 @@ func (h *http2Conn) Write(p []byte) (n int, err error) {
 
 func (h *http2Conn) Close() error {
 	h.in.Close()
-	return h.out.Close()
-}
-
-func (h *http2Conn) CloseConn() error {
-	return h.Conn.Close()
-}
-
-func (h *http2Conn) CloseWrite() error {
-	return h.in.Close()
-}
-
-func (h *http2Conn) CloseRead() error {
 	return h.out.Close()
 }
 


### PR DESCRIPTION
Sorry to open a new pull request, because I forgot to do some change in the old one (#73)