### PR TITLE
Apply sockopt from inbound config to dokodemo tproxy's response connection

### DIFF
--- a/app/proxyman/inbound/inbound.go
+++ b/app/proxyman/inbound/inbound.go
@@ -150,6 +150,13 @@ func NewHandler(ctx context.Context, config *core.InboundHandlerConfig) (inbound
 		return nil, newError("not a ReceiverConfig").AtError()
 	}
 
+	streamSettings := receiverSettings.StreamSettings
+	if streamSettings != nil && streamSettings.SocketSettings != nil {
+		ctx = session.ContextWithSockopt(ctx, &session.Sockopt{
+			Mark: streamSettings.SocketSettings.Mark,
+		})
+	}
+
 	allocStrategy := receiverSettings.AllocationStrategy
 	if allocStrategy == nil || allocStrategy.Type == proxyman.AllocationStrategy_Always {
 		return NewAlwaysOnInboundHandler(ctx, tag, receiverSettings, proxySettings)

--- a/common/session/context.go
+++ b/common/session/context.go
@@ -10,6 +10,7 @@ const (
 	outboundSessionKey
 	contentSessionKey
 	muxPreferedSessionKey
+	sockoptSessionKey
 )
 
 // ContextWithID returns a new context with the given ID.
@@ -69,4 +70,17 @@ func MuxPreferedFromContext(ctx context.Context) bool {
 		return val
 	}
 	return false
+}
+
+// ContextWithSockopt returns a new context with Socket configs included
+func ContextWithSockopt(ctx context.Context, s *Sockopt) context.Context {
+	return context.WithValue(ctx, sockoptSessionKey, s)
+}
+
+// SockoptFromContext returns Socket configs in this context, or nil if not contained.
+func SockoptFromContext(ctx context.Context) *Sockopt {
+	if sockopt, ok := ctx.Value(sockoptSessionKey).(*Sockopt); ok {
+		return sockopt
+	}
+	return nil
 }

--- a/common/session/session.go
+++ b/common/session/session.go
@@ -72,6 +72,12 @@ type Content struct {
 	SkipRoutePick bool
 }
 
+// Sockopt is the settings for socket connection.
+type Sockopt struct {
+	// Mark of the socket connection.
+	Mark int32
+}
+
 func (c *Content) SetAttribute(name string, value interface{}) {
 	if c.Attributes == nil {
 		c.Attributes = make(map[string]interface{})

--- a/proxy/dokodemo/dokodemo.go
+++ b/proxy/dokodemo/dokodemo.go
@@ -27,7 +27,7 @@ func init() {
 	common.Must(common.RegisterConfig((*Config)(nil), func(ctx context.Context, config interface{}) (interface{}, error) {
 		d := new(DokodemoDoor)
 		err := core.RequireFeatures(ctx, func(pm policy.Manager) error {
-			return d.Init(config.(*Config), pm)
+			return d.Init(config.(*Config), pm, session.SockoptFromContext(ctx))
 		})
 		return d, err
 	}))
@@ -38,10 +38,11 @@ type DokodemoDoor struct {
 	config        *Config
 	address       net.Address
 	port          net.Port
+	sockopt       *session.Sockopt
 }
 
 // Init initializes the DokodemoDoor instance with necessary parameters.
-func (d *DokodemoDoor) Init(config *Config, pm policy.Manager) error {
+func (d *DokodemoDoor) Init(config *Config, pm policy.Manager, sockopt *session.Sockopt) error {
 	if (config.NetworkList == nil || len(config.NetworkList.Network) == 0) && len(config.Networks) == 0 {
 		return newError("no network specified")
 	}
@@ -49,6 +50,7 @@ func (d *DokodemoDoor) Init(config *Config, pm policy.Manager) error {
 	d.address = config.GetPredefinedAddress()
 	d.port = net.Port(config.Port)
 	d.policyManager = pm
+	d.sockopt = sockopt
 
 	return nil
 }
@@ -164,6 +166,9 @@ func (d *DokodemoDoor) Process(ctx context.Context, network net.Network, conn in
 			if dest.Address.Family().IsIP() {
 				sockopt.BindAddress = dest.Address.IP()
 				sockopt.BindPort = uint32(dest.Port)
+			}
+			if d.sockopt != nil {
+				sockopt.Mark = d.sockopt.Mark
 			}
 			tConn, err := internet.DialSystem(ctx, net.DestinationFromAddr(conn.RemoteAddr()), sockopt)
 			if err != nil {


### PR DESCRIPTION
Fix #75 

对于 #75 的解决方案是利用Context传递Sockopt至DokodemoDoor的构造过程。这个实现比较微妙，因为实际上调用`Dokodemo.Process(..)`的`tcpworker`与`udpworker`中，已经存了一份StreamSettings了：

https://github.com/v2fly/v2ray-core/blob/45bf57826d8006f2b2b4e2e44f047064cfa05293/app/proxyman/inbound/worker.go#L64-L100

但经过分析后，发现在不改动公开接口的前提下很难将worker的stream settings直接在Process函数中取得。最后改动较小且有效的方案是通过Context传递。但是根据Go官方的理念，Context似乎并不应该被用于传递”可选参数“，同时在Inbound的Process中修改Context的后续影响范围也十分大，因此不应选择在此传入Sockopt。

最后选择了作用域小（构造Inbound前设置Sockopt，Inbound的构造也不会继续将Context传至更深的地方），资源占用小（仅在一次构造中设置Context）的本PR解决方案。

另本打算添加测试Dokodemo TProxy Sockopt的测试代码，但由于Mocks模块里缺少dispatcher与policy manager等模块的mock功能，因而代码编写过于复杂……此外SO_MARK的相关测试也似乎被Skip掉了，故没有继续下去。