### PR TITLE
Parse X-Forwarded-For in http transport

### DIFF
--- a/transport/internet/http/hub.go
+++ b/transport/internet/http/hub.go
@@ -9,16 +9,16 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 	"v2ray.com/core/common"
 	"v2ray.com/core/common/net"
+	http_proto "v2ray.com/core/common/protocol/http"
 	"v2ray.com/core/common/serial"
 	"v2ray.com/core/common/session"
 	"v2ray.com/core/common/signal/done"
 	"v2ray.com/core/transport/internet"
 	"v2ray.com/core/transport/internet/tls"
-
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 )
 
 type Listener struct {
@@ -80,6 +80,11 @@ func (l *Listener) ServeHTTP(writer http.ResponseWriter, request *http.Request) 
 			IP:   dest.Address.IP(),
 			Port: int(dest.Port),
 		}
+	}
+
+	forwardedAddrs := http_proto.ParseXForwardedFor(request.Header)
+	if len(forwardedAddrs) > 0 && forwardedAddrs[0].Family().IsIP() {
+		remoteAddr.(*net.TCPAddr).IP = forwardedAddrs[0].IP()
 	}
 
 	done := done.New()

--- a/transport/internet/http/hub.go
+++ b/transport/internet/http/hub.go
@@ -11,6 +11,7 @@ import (
 
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
+
 	"v2ray.com/core/common"
 	"v2ray.com/core/common/net"
 	http_proto "v2ray.com/core/common/protocol/http"


### PR DESCRIPTION
Use X-Forwarded-For header (if present) to get remote address. The WS transport already had this feature 2 years ago. Now with a properly configured reverse proxy, we can log the real client IP when works in H2 or WS transport.