### PR TITLE
Fix: Append nil to ipIndexMap when appending default local name server

### DIFF
--- a/app/dns/server.go
+++ b/app/dns/server.go
@@ -229,6 +229,7 @@ func New(ctx context.Context, config *Config) (*Server, error) {
 
 	if len(server.clients) == 0 {
 		server.clients = append(server.clients, NewLocalNameServer())
+		server.ipIndexMap = append(server.ipIndexMap, nil)
 	}
 
 	return server, nil


### PR DESCRIPTION
#148 Fixes the panic, but the root cause of the panic is: the `ipIndexMap` array is designed to be consistent with `clients` array in length. When `servers` is an empty array, a localhost nameserver is appended, but `ipIndexMap` isn't changed, thus the consistency is broken.