### PR TITLE
Add UnregisterChannel & Modify unregistering logic

### DIFF
--- a/app/stats/stats.go
+++ b/app/stats/stats.go
@@ -130,11 +130,11 @@ func (m *Manager) RegisterCounter(name string) (stats.Counter, error) {
 func (m *Manager) UnregisterCounter(name string) error {
 	m.access.Lock()
 	defer m.access.Unlock()
-	if _, found := m.counters[name]; !found {
-		return newError("Counter ", name, " was not found.")
+
+	if _, found := m.counters[name]; found {
+		newError("remove counter ", name).AtDebug().WriteToLog()
+		delete(m.counters, name)
 	}
-	newError("remove counter ", name).AtDebug().WriteToLog()
-	delete(m.counters, name)
 	return nil
 }
 
@@ -174,6 +174,18 @@ func (m *Manager) RegisterChannel(name string) (stats.Channel, error) {
 	m.channels[name] = c
 	go c.Start()
 	return c, nil
+}
+
+// UnregisterChannel implements stats.Manager.
+func (m *Manager) UnregisterChannel(name string) error {
+	m.access.Lock()
+	defer m.access.Unlock()
+
+	if _, found := m.channels[name]; found {
+		newError("remove channel ", name).AtDebug().WriteToLog()
+		delete(m.channels, name)
+	}
+	return nil
 }
 
 // GetChannel implements stats.Manager.

--- a/features/stats/stats.go
+++ b/features/stats/stats.go
@@ -38,12 +38,15 @@ type Manager interface {
 
 	// RegisterCounter registers a new counter to the manager. The identifier string must not be empty, and unique among other counters.
 	RegisterCounter(string) (Counter, error)
+	// UnregisterCounter unregisters a counter from the manager by its identifier.
 	UnregisterCounter(string) error
 	// GetCounter returns a counter by its identifier.
 	GetCounter(string) Counter
 
 	// RegisterChannel registers a new channel to the manager. The identifier string must not be empty, and unique among other channels.
 	RegisterChannel(string) (Channel, error)
+	// UnregisterCounter unregisters a channel from the manager by its identifier.
+	UnregisterChannel(string) error
 	// GetChannel returns a channel by its identifier.
 	GetChannel(string) Channel
 }
@@ -90,7 +93,7 @@ func (NoopManager) RegisterCounter(string) (Counter, error) {
 
 // UnregisterCounter implements Manager.
 func (NoopManager) UnregisterCounter(string) error {
-	return newError("not implemented")
+	return nil
 }
 
 // GetCounter implements Manager.
@@ -101,6 +104,11 @@ func (NoopManager) GetCounter(string) Counter {
 // RegisterChannel implements Manager.
 func (NoopManager) RegisterChannel(string) (Channel, error) {
 	return nil, newError("not implemented")
+}
+
+// UnregisterChannel implements Manager.
+func (NoopManager) UnregisterChannel(string) error {
+	return nil
 }
 
 // GetChannel implements Manager.


### PR DESCRIPTION
`Unregister` function should not return error when unregistering a counter/channel that's not in manager. This will cause double unregistering fails with error.