### PR TITLE
Routing Context: Fix GetUser() & Use string for Attributes Value

### DIFF
--- a/app/router/condition.go
+++ b/app/router/condition.go
@@ -288,17 +288,11 @@ func NewAttributeMatcher(code string) (*AttributeMatcher, error) {
 	}, nil
 }
 
-func (m *AttributeMatcher) Match(attrs map[string]interface{}) bool {
+// Match implements attributes matching.
+func (m *AttributeMatcher) Match(attrs map[string]string) bool {
 	attrsDict := new(starlark.Dict)
 	for key, value := range attrs {
-		var starValue starlark.Value
-		switch value := value.(type) {
-		case string:
-			starValue = starlark.String(value)
-		}
-		if starValue != nil {
-			attrsDict.SetKey(starlark.String(key), starValue)
-		}
+		attrsDict.SetKey(starlark.String(key), starlark.String(value))
 	}
 
 	predefined := make(starlark.StringDict)

--- a/app/router/condition_test.go
+++ b/app/router/condition_test.go
@@ -313,7 +313,7 @@ func TestRoutingRule(t *testing.T) {
 			},
 			test: []ruleTest{
 				{
-					input:  withContent(&session.Content{Protocol: "http/1.1", Attributes: map[string]interface{}{":path": "/test/1"}}),
+					input:  withContent(&session.Content{Protocol: "http/1.1", Attributes: map[string]string{":path": "/test/1"}}),
 					output: true,
 				},
 			},

--- a/common/session/session.go
+++ b/common/session/session.go
@@ -53,6 +53,7 @@ type Outbound struct {
 	Gateway net.Address
 }
 
+// SniffingRequest controls the behavior of content sniffing.
 type SniffingRequest struct {
 	OverrideDestinationForProtocol []string
 	Enabled                        bool
@@ -65,7 +66,7 @@ type Content struct {
 
 	SniffingRequest SniffingRequest
 
-	Attributes map[string]interface{}
+	Attributes map[string]string
 
 	SkipRoutePick bool
 }
@@ -76,16 +77,18 @@ type Sockopt struct {
 	Mark int32
 }
 
-func (c *Content) SetAttribute(name string, value interface{}) {
+// SetAttribute attachs additional string attributes to content.
+func (c *Content) SetAttribute(name string, value string) {
 	if c.Attributes == nil {
-		c.Attributes = make(map[string]interface{})
+		c.Attributes = make(map[string]string)
 	}
 	c.Attributes[name] = value
 }
 
-func (c *Content) Attribute(name string) interface{} {
+// Attribute retrieves additional string attributes from content.
+func (c *Content) Attribute(name string) string {
 	if c.Attributes == nil {
-		return nil
+		return ""
 	}
 	return c.Attributes[name]
 }

--- a/features/routing/context.go
+++ b/features/routing/context.go
@@ -6,7 +6,7 @@ import (
 
 // Context is a feature to store connection information for routing.
 //
-// v2ray:api:beta
+// v2ray:api:stable
 type Context interface {
 	// GetInboundTag returns the tag of the inbound the connection was from.
 	GetInboundTag() string
@@ -36,5 +36,5 @@ type Context interface {
 	GetUser() string
 
 	// GetAttributes returns extra attributes from the conneciont content.
-	GetAttributes() map[string]interface{}
+	GetAttributes() map[string]string
 }

--- a/features/routing/session/context.go
+++ b/features/routing/session/context.go
@@ -95,14 +95,14 @@ func (ctx *Context) GetProtocol() string {
 
 // GetUser implements routing.Context.
 func (ctx *Context) GetUser() string {
-	if ctx.Inbound == nil {
+	if ctx.Inbound == nil || ctx.Inbound.User == nil {
 		return ""
 	}
 	return ctx.Inbound.User.Email
 }
 
 // GetAttributes implements routing.Context.
-func (ctx *Context) GetAttributes() map[string]interface{} {
+func (ctx *Context) GetAttributes() map[string]string {
 	if ctx.Content == nil {
 		return nil
 	}


### PR DESCRIPTION
#### Fix GetUser()

Fixes https://github.com/v2fly/v2ray-core/issues/184

I suddenly decided to use email string instead of `*protocol.MemoryUser` for `Context.GetUser()` just before the merging of https://github.com/v2fly/v2ray-core/pull/108. This change didn't get well considered and reviewed and eventually caused the error in #184.

This PR adds nil check for `session.Inbound.User`. (I got really screwed by golang's NPE problem and nil check mechanism...) 

#### Use string for GetAttributes()'s value

This modification was well reviewed, that no attribute is really saved in `interface{}`. They're all set as string and used as string, saving them as string directly can help a lot of things, like the serialization of gRPC API's routing stats.