### PR TITLE
Routing: Implement Route interface as Router's result

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -266,7 +266,8 @@ func (d *DefaultDispatcher) routedDispatch(ctx context.Context, link *transport.
 	}
 
 	if d.router != nil && !skipRoutePick {
-		if tag, err := d.router.PickRoute(routing_session.AsRoutingContext(ctx)); err == nil {
+		if route, err := d.router.PickRoute(routing_session.AsRoutingContext(ctx)); err == nil {
+			tag := route.GetOutboundTag()
 			if h := d.ohm.GetHandler(tag); h != nil {
 				newError("taking detour [", tag, "] for [", destination, "]").WriteToLog(session.ExportIDToError(ctx))
 				handler = h

--- a/app/router/router.go
+++ b/app/router/router.go
@@ -9,23 +9,11 @@ import (
 
 	"v2ray.com/core"
 	"v2ray.com/core/common"
-	"v2ray.com/core/common/net"
 	"v2ray.com/core/features/dns"
 	"v2ray.com/core/features/outbound"
 	"v2ray.com/core/features/routing"
+	routing_dns "v2ray.com/core/features/routing/dns"
 )
-
-func init() {
-	common.Must(common.RegisterConfig((*Config)(nil), func(ctx context.Context, config interface{}) (interface{}, error) {
-		r := new(Router)
-		if err := core.RequireFeatures(ctx, func(d dns.Client, ohm outbound.Manager) error {
-			return r.Init(config.(*Config), d, ohm)
-		}); err != nil {
-			return nil, err
-		}
-		return r, nil
-	}))
-}
 
 // Router is an implementation of routing.Router.
 type Router struct {
@@ -33,6 +21,13 @@ type Router struct {
 	rules          []*Rule
 	balancers      map[string]*Balancer
 	dns            dns.Client
+}
+
+// Route is an implementation of routing.Route.
+type Route struct {
+	routing.Context
+	outboundGroupTags []string
+	outboundTag       string
 }
 
 // Init initializes the Router.
@@ -74,39 +69,43 @@ func (r *Router) Init(config *Config, d dns.Client, ohm outbound.Manager) error 
 }
 
 // PickRoute implements routing.Router.
-func (r *Router) PickRoute(ctx routing.Context) (string, error) {
-	rule, err := r.pickRouteInternal(ctx)
+func (r *Router) PickRoute(ctx routing.Context) (routing.Route, error) {
+	rule, ctx, err := r.pickRouteInternal(ctx)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return rule.GetTag()
+	tag, err := rule.GetTag()
+	if err != nil {
+		return nil, err
+	}
+	return &Route{Context: ctx, outboundTag: tag}, nil
 }
 
-func (r *Router) pickRouteInternal(ctx routing.Context) (*Rule, error) {
+func (r *Router) pickRouteInternal(ctx routing.Context) (*Rule, routing.Context, error) {
 	if r.domainStrategy == Config_IpOnDemand {
-		ctx = ContextWithDNSClient(ctx, r.dns)
+		ctx = routing_dns.ContextWithDNSClient(ctx, r.dns)
 	}
 
 	for _, rule := range r.rules {
 		if rule.Apply(ctx) {
-			return rule, nil
+			return rule, ctx, nil
 		}
 	}
 
 	if r.domainStrategy != Config_IpIfNonMatch || len(ctx.GetTargetDomain()) == 0 {
-		return nil, common.ErrNoClue
+		return nil, ctx, common.ErrNoClue
 	}
 
-	ctx = ContextWithDNSClient(ctx, r.dns)
+	ctx = routing_dns.ContextWithDNSClient(ctx, r.dns)
 
 	// Try applying rules again if we have IPs.
 	for _, rule := range r.rules {
 		if rule.Apply(ctx) {
-			return rule, nil
+			return rule, ctx, nil
 		}
 	}
 
-	return nil, common.ErrNoClue
+	return nil, ctx, common.ErrNoClue
 }
 
 // Start implements common.Runnable.
@@ -124,34 +123,24 @@ func (*Router) Type() interface{} {
 	return routing.RouterType()
 }
 
-// ContextWithDNSClient creates a new routing context with domain resolving capability. Resolved domain IPs can be retrieved by GetTargetIPs().
-func ContextWithDNSClient(ctx routing.Context, client dns.Client) routing.Context {
-	return &resolvableContext{Context: ctx, dnsClient: client}
+// GetOutboundGroupTags implements routing.Route.
+func (r *Route) GetOutboundGroupTags() []string {
+	return r.outboundGroupTags
 }
 
-type resolvableContext struct {
-	routing.Context
-	dnsClient   dns.Client
-	resolvedIPs []net.IP
+// GetOutboundTag implements routing.Route.
+func (r *Route) GetOutboundTag() string {
+	return r.outboundTag
 }
 
-func (ctx *resolvableContext) GetTargetIPs() []net.IP {
-	if ips := ctx.Context.GetTargetIPs(); len(ips) != 0 {
-		return ips
-	}
-
-	if len(ctx.resolvedIPs) > 0 {
-		return ctx.resolvedIPs
-	}
-
-	if domain := ctx.GetTargetDomain(); len(domain) != 0 {
-		ips, err := ctx.dnsClient.LookupIP(domain)
-		if err == nil {
-			ctx.resolvedIPs = ips
-			return ips
+func init() {
+	common.Must(common.RegisterConfig((*Config)(nil), func(ctx context.Context, config interface{}) (interface{}, error) {
+		r := new(Router)
+		if err := core.RequireFeatures(ctx, func(d dns.Client, ohm outbound.Manager) error {
+			return r.Init(config.(*Config), d, ohm)
+		}); err != nil {
+			return nil, err
 		}
-		newError("resolve ip for ", domain).Base(err).WriteToLog()
-	}
-
-	return nil
+		return r, nil
+	}))
 }

--- a/app/router/router_test.go
+++ b/app/router/router_test.go
@@ -45,9 +45,9 @@ func TestSimpleRouter(t *testing.T) {
 	}))
 
 	ctx := session.ContextWithOutbound(context.Background(), &session.Outbound{Target: net.TCPDestination(net.DomainAddress("v2ray.com"), 80)})
-	tag, err := r.PickRoute(routing_session.AsRoutingContext(ctx))
+	route, err := r.PickRoute(routing_session.AsRoutingContext(ctx))
 	common.Must(err)
-	if tag != "test" {
+	if tag := route.GetOutboundTag(); tag != "test" {
 		t.Error("expect tag 'test', bug actually ", tag)
 	}
 }
@@ -86,9 +86,9 @@ func TestSimpleBalancer(t *testing.T) {
 	}))
 
 	ctx := session.ContextWithOutbound(context.Background(), &session.Outbound{Target: net.TCPDestination(net.DomainAddress("v2ray.com"), 80)})
-	tag, err := r.PickRoute(routing_session.AsRoutingContext(ctx))
+	route, err := r.PickRoute(routing_session.AsRoutingContext(ctx))
 	common.Must(err)
-	if tag != "test" {
+	if tag := route.GetOutboundTag(); tag != "test" {
 		t.Error("expect tag 'test', bug actually ", tag)
 	}
 }
@@ -121,9 +121,9 @@ func TestIPOnDemand(t *testing.T) {
 	common.Must(r.Init(config, mockDns, nil))
 
 	ctx := session.ContextWithOutbound(context.Background(), &session.Outbound{Target: net.TCPDestination(net.DomainAddress("v2ray.com"), 80)})
-	tag, err := r.PickRoute(routing_session.AsRoutingContext(ctx))
+	route, err := r.PickRoute(routing_session.AsRoutingContext(ctx))
 	common.Must(err)
-	if tag != "test" {
+	if tag := route.GetOutboundTag(); tag != "test" {
 		t.Error("expect tag 'test', bug actually ", tag)
 	}
 }
@@ -156,9 +156,9 @@ func TestIPIfNonMatchDomain(t *testing.T) {
 	common.Must(r.Init(config, mockDns, nil))
 
 	ctx := session.ContextWithOutbound(context.Background(), &session.Outbound{Target: net.TCPDestination(net.DomainAddress("v2ray.com"), 80)})
-	tag, err := r.PickRoute(routing_session.AsRoutingContext(ctx))
+	route, err := r.PickRoute(routing_session.AsRoutingContext(ctx))
 	common.Must(err)
-	if tag != "test" {
+	if tag := route.GetOutboundTag(); tag != "test" {
 		t.Error("expect tag 'test', bug actually ", tag)
 	}
 }
@@ -190,9 +190,9 @@ func TestIPIfNonMatchIP(t *testing.T) {
 	common.Must(r.Init(config, mockDns, nil))
 
 	ctx := session.ContextWithOutbound(context.Background(), &session.Outbound{Target: net.TCPDestination(net.LocalHostIP, 80)})
-	tag, err := r.PickRoute(routing_session.AsRoutingContext(ctx))
+	route, err := r.PickRoute(routing_session.AsRoutingContext(ctx))
 	common.Must(err)
-	if tag != "test" {
+	if tag := route.GetOutboundTag(); tag != "test" {
 		t.Error("expect tag 'test', bug actually ", tag)
 	}
 }

--- a/features/routing/dns/context.go
+++ b/features/routing/dns/context.go
@@ -1,0 +1,44 @@
+package dns
+
+//go:generate errorgen
+
+import (
+	"v2ray.com/core/common/net"
+	"v2ray.com/core/features/dns"
+	"v2ray.com/core/features/routing"
+)
+
+// ResolvableContext is an implementation of routing.Context, with domain resolving capability.
+type ResolvableContext struct {
+	routing.Context
+	dnsClient   dns.Client
+	resolvedIPs []net.IP
+}
+
+// GetTargetIPs overrides original routing.Context's implementation.
+func (ctx *ResolvableContext) GetTargetIPs() []net.IP {
+	if ips := ctx.Context.GetTargetIPs(); len(ips) != 0 {
+		return ips
+	}
+
+	if len(ctx.resolvedIPs) > 0 {
+		return ctx.resolvedIPs
+	}
+
+	if domain := ctx.GetTargetDomain(); len(domain) != 0 {
+		ips, err := ctx.dnsClient.LookupIP(domain)
+		if err == nil {
+			ctx.resolvedIPs = ips
+			return ips
+		}
+		newError("resolve ip for ", domain).Base(err).WriteToLog()
+	}
+
+	return nil
+}
+
+// ContextWithDNSClient creates a new routing context with domain resolving capability.
+// Resolved domain IPs can be retrieved by GetTargetIPs().
+func ContextWithDNSClient(ctx routing.Context, client dns.Client) routing.Context {
+	return &ResolvableContext{Context: ctx, dnsClient: client}
+}

--- a/features/routing/dns/errors.generated.go
+++ b/features/routing/dns/errors.generated.go
@@ -1,0 +1,9 @@
+package dns
+
+import "v2ray.com/core/common/errors"
+
+type errPathObjHolder struct{}
+
+func newError(values ...interface{}) *errors.Error {
+	return errors.New(values...).WithPathObj(errPathObjHolder{})
+}

--- a/features/routing/router.go
+++ b/features/routing/router.go
@@ -7,12 +7,26 @@ import (
 
 // Router is a feature to choose an outbound tag for the given request.
 //
-// v2ray:api:beta
+// v2ray:api:stable
 type Router interface {
 	features.Feature
 
-	// PickRoute returns a tag of an OutboundHandler based on the given context.
-	PickRoute(ctx Context) (string, error)
+	// PickRoute returns a route decision based on the given routing context.
+	PickRoute(ctx Context) (Route, error)
+}
+
+// Route is the routing result of Router feature.
+//
+// v2ray:api:stable
+type Route interface {
+	// A Route is also a routing context.
+	Context
+
+	// GetOutboundGroupTags returns the detoured outbound group tags in sequence before a final outbound is chosen.
+	GetOutboundGroupTags() []string
+
+	// GetOutboundTag returns the tag of the outbound the connection was dispatched to.
+	GetOutboundTag() string
 }
 
 // RouterType return the type of Router interface. Can be used to implement common.HasType.
@@ -31,8 +45,8 @@ func (DefaultRouter) Type() interface{} {
 }
 
 // PickRoute implements Router.
-func (DefaultRouter) PickRoute(ctx Context) (string, error) {
-	return "", common.ErrNoClue
+func (DefaultRouter) PickRoute(ctx Context) (Route, error) {
+	return nil, common.ErrNoClue
 }
 
 // Start implements common.Runnable.


### PR DESCRIPTION
For now, routing result (return value of `Router.PickRoute`) is the tag of the outbound. To provide richer information to the client, this PR implements a new interface `Route` as the result of `Router.PickRoute`.
```go
// PickRoute returns a route decision based on the given routing context.
PickRoute(ctx Context) (Route, error)
```

A `Route` is a routing context with the outbound decision information attached:
```go
type Route interface {
	// A Route is also a routing context.
	Context

	// GetOutboundGroupTags returns the detoured outbound group tags in sequence before a final outbound is chosen.
	GetOutboundGroupTags() []string

	// GetOutboundTag returns the tag of the outbound the connection was dispatched to.
	GetOutboundTag() string
}
```
Here, `OutboundGroup` is a concept managing a group of outbounds and pick one during routing by specific logics, e.g., a balancer is an outbound group. `OutboundGroupTags` is a routing chain of outbound groups before a final outbound is chosen. This new concept will be adopted in future PRs, for now only empty array is returned.

With the new interface, following features and fixes are made possible:
* When one routing decision is made, broadcast this route interface to stats service and use it as routing stats.
* Record balancer tags in `access.log`.
* Simple way to record sniffed domain instead of source IP in `access.log`.
* A more intelligent routing logic? Maybe this interface could be of help for the routing issue in UDP fullcone.