### PR TITLE
kcp: removing annoying NewAEADAESGCMBasedOnSeed hint

### DIFF
--- a/transport/internet/kcp/config.go
+++ b/transport/internet/kcp/config.go
@@ -4,8 +4,6 @@ package kcp
 
 import (
 	"crypto/cipher"
-	"fmt"
-
 	"v2ray.com/core/common"
 	"v2ray.com/core/transport/internet"
 )
@@ -63,7 +61,6 @@ func (c *Config) GetReadBufferSize() uint32 {
 // GetSecurity returns the security settings.
 func (c *Config) GetSecurity() (cipher.AEAD, error) {
 	if c.Seed != nil {
-		fmt.Println("=========NewAEADAESGCMBasedOnSeed Used============")
 		return NewAEADAESGCMBasedOnSeed(c.Seed.Seed), nil
 	}
 	return NewSimpleAuthenticator(), nil


### PR DESCRIPTION
It's very annoying to see many meaningless `NewAEADAESGCMBasedOnSeed` lines, once per connection, in v2ray core logs. This PR/commit will remove this.

-----

<table><tr><th>Before</th><th>After</th></tr><tr><td>
<img src="https://user-images.githubusercontent.com/7822648/93708588-1c697580-fb6a-11ea-8396-bd4f089dfded.png"></td>

<td><img src="https://user-images.githubusercontent.com/7822648/93708585-17a4c180-fb6a-11ea-9b7c-e3e0b3c07de9.png"></td>
</tr></table>
