### PR TITLE
VLESS UDP over TCP struct breaking change

### DIFF
--- a/proxy/vless/encoding/addons.go
+++ b/proxy/vless/encoding/addons.go
@@ -76,7 +76,7 @@ func DecodeHeaderAddons(buffer *buf.Buffer, reader io.Reader) (*Addons, error) {
 func EncodeBodyAddons(writer io.Writer, request *protocol.RequestHeader, addons *Addons) buf.Writer {
 
 	switch addons.Flow {
-	case vless.XRO:
+	default:
 
 		if request.Command == protocol.RequestCommandUDP {
 			return NewMultiLengthPacketWriter(writer.(buf.Writer))
@@ -92,7 +92,7 @@ func EncodeBodyAddons(writer io.Writer, request *protocol.RequestHeader, addons 
 func DecodeBodyAddons(reader io.Reader, request *protocol.RequestHeader, addons *Addons) buf.Reader {
 
 	switch addons.Flow {
-	case vless.XRO:
+	default:
 
 		if request.Command == protocol.RequestCommandUDP {
 			return NewLengthPacketReader(reader)
@@ -197,7 +197,7 @@ func (r *LengthPacketReader) ReadMultiBuffer() (buf.MultiBuffer, error) {
 	mb := make(buf.MultiBuffer, 0, length/buf.Size+1)
 	for length > 0 {
 		size := length
-		if length > buf.Size {
+		if size > buf.Size {
 			size = buf.Size
 		}
 		length -= size

--- a/proxy/vless/inbound/inbound.go
+++ b/proxy/vless/inbound/inbound.go
@@ -386,7 +386,7 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection i
 	account := request.User.Account.(*vless.MemoryAccount)
 
 	responseAddons := &encoding.Addons{
-		Flow: requestAddons.Flow,
+		//Flow: requestAddons.Flow,
 	}
 
 	switch requestAddons.Flow {
@@ -396,7 +396,7 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection i
 			case protocol.RequestCommandMux:
 				return newError(vless.XRO + " doesn't support Mux").AtWarning()
 			case protocol.RequestCommandUDP:
-				//return newError(vless.XRO + " doesn't support UDP").AtWarning()
+				return newError(vless.XRO + " doesn't support UDP").AtWarning()
 			case protocol.RequestCommandTCP:
 				if xtlsConn, ok := iConn.(*xtls.Conn); ok {
 					xtlsConn.RPRX = true

--- a/proxy/vless/outbound/outbound.go
+++ b/proxy/vless/outbound/outbound.go
@@ -135,7 +135,7 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 			if requestAddons.Flow == vless.XRO && request.Port == 443 {
 				return newError(vless.XRO + " stopped UDP/443").AtWarning()
 			}
-			requestAddons.Flow = vless.XRO
+			requestAddons.Flow = ""
 		case protocol.RequestCommandTCP:
 			if xtlsConn, ok := iConn.(*xtls.Conn); ok {
 				xtlsConn.RPRX = true


### PR DESCRIPTION
具体改变：每个 UDP 载荷前加两字节长度的 length，最大值为 2048-2=2046。若不使用 Mux，服务端与客户端均需升级至 v4.30.0+。这是 VLESS 公测版（0）协议结构本身唯一一次 breaking change，正式版（1）的服务端预计会长期同时支持该版本，第三方客户端的实现应当尽快跟进。