### PR TITLE
fix fall back to abstract unix domain socket in vless and trojan

### DIFF
--- a/infra/conf/trojan.go
+++ b/infra/conf/trojan.go
@@ -149,7 +149,7 @@ func (c *TrojanServerConfig) Build() (proto.Message, error) {
 				switch fb.Dest[0] {
 				case '@', '/':
 					fb.Type = "unix"
-					if len(fb.Dest) > 1 && fb.Dest[0] == '@' && runtime.GOOS == "linux" && fb.Dest[1] == '@' {
+					if fb.Dest[0] == '@' && len(fb.Dest) > 1 && fb.Dest[1] == '@' && runtime.GOOS == "linux" {
 						fullAddr := make([]byte, len(syscall.RawSockaddrUnix{}.Path)) // may need padding to work in front of haproxy
 						copy(fullAddr, fb.Dest[1:])
 						fb.Dest = string(fullAddr)

--- a/infra/conf/trojan.go
+++ b/infra/conf/trojan.go
@@ -150,7 +150,7 @@ func (c *TrojanServerConfig) Build() (proto.Message, error) {
 				case '@', '/':
 					fb.Type = "unix"
 					if len(fb.Dest) > 1 && fb.Dest[0] == '@' && runtime.GOOS == "linux" && fb.Dest[1] == '@' {
-						fullAddr := make([]byte, len(syscall.RawSockaddrUnix{}.Path)) // may need padding to work behind haproxy
+						fullAddr := make([]byte, len(syscall.RawSockaddrUnix{}.Path)) // may need padding to work in front of haproxy
 						copy(fullAddr, fb.Dest[1:])
 						fb.Dest = string(fullAddr)
 					}

--- a/infra/conf/trojan.go
+++ b/infra/conf/trojan.go
@@ -2,7 +2,9 @@ package conf
 
 import (
 	"encoding/json"
+	"runtime"
 	"strconv"
+	"syscall"
 
 	"github.com/golang/protobuf/proto" // nolint: staticcheck
 
@@ -147,6 +149,11 @@ func (c *TrojanServerConfig) Build() (proto.Message, error) {
 				switch fb.Dest[0] {
 				case '@', '/':
 					fb.Type = "unix"
+					if len(fb.Dest) > 1 && fb.Dest[0] == '@' && runtime.GOOS == "linux" && fb.Dest[1] == '@' {
+						fullAddr := make([]byte, len(syscall.RawSockaddrUnix{}.Path)) // may need padding to work behind haproxy
+						copy(fullAddr, fb.Dest[1:])
+						fb.Dest = string(fullAddr)
+					}
 				default:
 					if _, err := strconv.Atoi(fb.Dest); err == nil {
 						fb.Dest = "127.0.0.1:" + fb.Dest

--- a/infra/conf/vless.go
+++ b/infra/conf/vless.go
@@ -104,7 +104,7 @@ func (c *VLessInboundConfig) Build() (proto.Message, error) {
 				switch fb.Dest[0] {
 				case '@', '/':
 					fb.Type = "unix"
-					if len(fb.Dest) > 1 && fb.Dest[0] == '@' && runtime.GOOS == "linux" && fb.Dest[1] == '@' {
+					if fb.Dest[0] == '@' && len(fb.Dest) > 1 && fb.Dest[1] == '@' && runtime.GOOS == "linux" {
 						fullAddr := make([]byte, len(syscall.RawSockaddrUnix{}.Path)) // may need padding to work in front of haproxy
 						copy(fullAddr, fb.Dest[1:])
 						fb.Dest = string(fullAddr)

--- a/infra/conf/vless.go
+++ b/infra/conf/vless.go
@@ -105,7 +105,7 @@ func (c *VLessInboundConfig) Build() (proto.Message, error) {
 				case '@', '/':
 					fb.Type = "unix"
 					if len(fb.Dest) > 1 && fb.Dest[0] == '@' && runtime.GOOS == "linux" && fb.Dest[1] == '@' {
-						fullAddr := make([]byte, len(syscall.RawSockaddrUnix{}.Path)) // may need padding to work behind haproxy
+						fullAddr := make([]byte, len(syscall.RawSockaddrUnix{}.Path)) // may need padding to work in front of haproxy
 						copy(fullAddr, fb.Dest[1:])
 						fb.Dest = string(fullAddr)
 					}


### PR DESCRIPTION
When fall back to abstract unix domain socket which is created by haproxy, the path needs to use the full length of RawSockaddrUnix.Path. So we need an option "padding" in FallbackObject to handle this situation.