### PR TITLE
Load JSON internally by default

### DIFF
--- a/main/distro/all/all.go
+++ b/main/distro/all/all.go
@@ -59,9 +59,9 @@ import (
 
 	// JSON config support. Choose only one from the two below.
 	// The following line loads JSON from v2ctl
-	_ "v2ray.com/core/main/json"
+	// _ "v2ray.com/core/main/json"
 	// The following line loads JSON internally
-	// _ "v2ray.com/core/main/jsonem"
+	_ "v2ray.com/core/main/jsonem"
 
 	// Load config from file or http(s)
 	_ "v2ray.com/core/main/confloader/external"


### PR DESCRIPTION
In runtime, v2ray calls v2ctl ONLY to load json file. 
V2ray should work perfectly fine when json is loaded internally, that way v2ctl is NOT needed to run it.
V2ctl is still provided so no feature is missing. Binary size remains unchanged. 
There is no good reason not to do it.