### PR TITLE
fix: vprotogen in windows

### DIFF
--- a/proto.go
+++ b/proto.go
@@ -1,5 +1,7 @@
 package core
 
+import "path/filepath"
+
 //go:generate go install -v google.golang.org/protobuf/cmd/protoc-gen-go
 //go:generate go install -v google.golang.org/grpc/cmd/protoc-gen-go-grpc
 //go:generate go install -v github.com/gogo/protobuf/protoc-gen-gofast
@@ -7,4 +9,4 @@ package core
 
 // ProtoFilesUsingProtocGenGoFast is the map of Proto files
 // that use `protoc-gen-gofast` to generate pb.go files
-var ProtoFilesUsingProtocGenGoFast = map[string]bool{"proxy/vless/encoding/addons.proto": true}
+var ProtoFilesUsingProtocGenGoFast = map[string]bool{filepath.Join("proxy", "vless", "encoding", "addons.proto"): true}


### PR DESCRIPTION
This PR: 修复在 Windows 环境中不使用正确的工具生成`grpc code`的问题。

在 Windows 中 filepath.Walk 得到的path是`proxy\vless\encodin\addons.proto`，而`ProtoFilesUsingProtocGenGoFast`的key是`proxy/vless/encoding/addons.proto`。