### PR TITLE
Optimize rand.Intn(65536) to rand.Int63() >> 47,  before:22.6ns/op, after:18.6ns/op

### DIFF
--- a/common/dice/dice.go
+++ b/common/dice/dice.go
@@ -25,7 +25,7 @@ func RollDeterministic(n int, seed int64) int {
 
 // RollUint16 returns a random uint16 value.
 func RollUint16() uint16 {
-	return uint16(rand.Int31() >> 15)
+	return uint16(rand.Int63() >> 47)
 }
 
 func RollUint64() uint64 {

--- a/common/dice/dice.go
+++ b/common/dice/dice.go
@@ -25,7 +25,7 @@ func RollDeterministic(n int, seed int64) int {
 
 // RollUint16 returns a random uint16 value.
 func RollUint16() uint16 {
-	return uint16(rand.Intn(65536))
+	return uint16(rand.Int31() >> 15)
 }
 
 func RollUint64() uint64 {

--- a/common/dice/dice_test.go
+++ b/common/dice/dice_test.go
@@ -3,6 +3,7 @@ package dice_test
 import (
 	"math/rand"
 	"testing"
+	"time"
 
 	. "v2ray.com/core/common/dice"
 )
@@ -28,5 +29,21 @@ func BenchmarkIntn1(b *testing.B) {
 func BenchmarkIntn20(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		rand.Intn(20)
+	}
+}
+
+func BenchmarkInt31(b *testing.B) {
+	rand.Seed(time.Now().Unix())
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = uint16(rand.Int31() >> 15)
+	}
+}
+
+func BenchmarkIntn(b *testing.B) {
+	rand.Seed(time.Now().Unix())
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = uint16(rand.Intn(65536))
 	}
 }

--- a/common/dice/dice_test.go
+++ b/common/dice/dice_test.go
@@ -3,7 +3,6 @@ package dice_test
 import (
 	"math/rand"
 	"testing"
-	"time"
 
 	. "v2ray.com/core/common/dice"
 )
@@ -33,24 +32,18 @@ func BenchmarkIntn20(b *testing.B) {
 }
 
 func BenchmarkInt31(b *testing.B) {
-	rand.Seed(time.Now().Unix())
-	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = uint16(rand.Int31() >> 15)
 	}
 }
 
 func BenchmarkInt63(b *testing.B) {
-	rand.Seed(time.Now().Unix())
-	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = uint16(rand.Int63() >> 47)
 	}
 }
 
 func BenchmarkIntn(b *testing.B) {
-	rand.Seed(time.Now().Unix())
-	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = uint16(rand.Intn(65536))
 	}

--- a/common/dice/dice_test.go
+++ b/common/dice/dice_test.go
@@ -40,6 +40,14 @@ func BenchmarkInt31(b *testing.B) {
 	}
 }
 
+func BenchmarkInt63(b *testing.B) {
+	rand.Seed(time.Now().Unix())
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = uint16(rand.Int63() >> 47)
+	}
+}
+
 func BenchmarkIntn(b *testing.B) {
 	rand.Seed(time.Now().Unix())
 	b.ResetTimer()


### PR DESCRIPTION
Heavily inspired by math/rand. with ~20% performance improvement (BenchmarkInt31 vs. BenchmarkIntn).

\# go test -bench=. -benchmem -run=none
goos: darwin
goarch: amd64
pkg: v2ray.com/core/common/dice
BenchmarkRoll1-4    	1000000000	         0.329 ns/op	       0 B/op	       0 allocs/op
BenchmarkRoll20-4   	43471560	        24.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkIntn1-4    	52293325	        22.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkIntn20-4   	46995854	        24.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkInt31-4    	62762128	        18.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkIntn-4     	52576292	        22.6 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	v2ray.com/core/common/dice	9.313s