### PR TITLE
add build for android on github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,10 @@ jobs:
           - goos: linux
             goarch: mips
           # END MIPS
+          # BEGIN Android
+          - goos: android
+            goarch: arm64
+          # END Android
           # END Other architectures
       fail-fast: false
 

--- a/release/friendly-filenames.json
+++ b/release/friendly-filenames.json
@@ -18,5 +18,6 @@
   "openbsd-amd64": { "friendlyName": "openbsd-64" },
   "windows-amd64": { "friendlyName": "windows-64" },
   "windows-386": { "friendlyName": "windows-32" },
-  "windows-arm7": { "friendlyName": "windows-arm32-v7a" }
+  "windows-arm7": { "friendlyName": "windows-arm32-v7a" },
+  "android-arm64": { "friendlyName": "android-arm64-v8a" }
 }


### PR DESCRIPTION
reference #491 

added an additional build for android arm64 on github actions
working fine on my branch, see: [action](https://github.com/young-zy/v2ray-core-1/actions/runs/419022296)