### PR TITLE
Refine Android build

### DIFF
--- a/infra/conf/trojan.go
+++ b/infra/conf/trojan.go
@@ -144,7 +144,7 @@ func (c *TrojanServerConfig) Build() (proto.Message, error) {
 				switch fb.Dest[0] {
 				case '@', '/':
 					fb.Type = "unix"
-					if fb.Dest[0] == '@' && len(fb.Dest) > 1 && fb.Dest[1] == '@' && runtime.GOOS == "linux" {
+					if fb.Dest[0] == '@' && len(fb.Dest) > 1 && fb.Dest[1] == '@' && (runtime.GOOS == "linux" || runtime.GOOS == "android") {
 						fullAddr := make([]byte, len(syscall.RawSockaddrUnix{}.Path)) // may need padding to work with haproxy
 						copy(fullAddr, fb.Dest[1:])
 						fb.Dest = string(fullAddr)

--- a/infra/conf/vless.go
+++ b/infra/conf/vless.go
@@ -93,7 +93,7 @@ func (c *VLessInboundConfig) Build() (proto.Message, error) {
 				switch fb.Dest[0] {
 				case '@', '/':
 					fb.Type = "unix"
-					if fb.Dest[0] == '@' && len(fb.Dest) > 1 && fb.Dest[1] == '@' && runtime.GOOS == "linux" {
+					if fb.Dest[0] == '@' && len(fb.Dest) > 1 && fb.Dest[1] == '@' && (runtime.GOOS == "linux" || runtime.GOOS == "android") {
 						fullAddr := make([]byte, len(syscall.RawSockaddrUnix{}.Path)) // may need padding to work with haproxy
 						copy(fullAddr, fb.Dest[1:])
 						fb.Dest = string(fullAddr)

--- a/testing/scenarios/transport_test.go
+++ b/testing/scenarios/transport_test.go
@@ -136,8 +136,8 @@ func TestHTTPConnectionHeader(t *testing.T) {
 }
 
 func TestDomainSocket(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Not supported on windows")
+	if runtime.GOOS == "windows" || runtime.GOOS == "android" {
+		t.Skip("Not supported on windows and android")
 		return
 	}
 	tcpServer := tcp.Server{

--- a/transport/internet/domainsocket/listener_test.go
+++ b/transport/internet/domainsocket/listener_test.go
@@ -1,4 +1,5 @@
 // +build !windows
+// +build !android
 
 package domainsocket_test
 

--- a/transport/internet/system_listener.go
+++ b/transport/internet/system_listener.go
@@ -54,7 +54,7 @@ func (dl *DefaultListener) Listen(ctx context.Context, addr net.Addr, sockopt *S
 		lc.Control = nil
 		network = addr.Network()
 		address = addr.Name
-		if runtime.GOOS == "linux" && address[0] == '@' {
+		if (runtime.GOOS == "linux" || runtime.GOOS == "android") && address[0] == '@' {
 			// linux abstract unix domain socket is lockfree
 			if len(address) > 1 && address[1] == '@' {
 				// but may need padding to work with haproxy


### PR DESCRIPTION
- domain socket tests create UDS in `/tmp/*`, which is not supported by Android
- allow abstract UDS with padding on Android