### PR TITLE
🕳 Prevent trailing whitespaces in logs

### DIFF
--- a/common/log/access.go
+++ b/common/log/access.go
@@ -36,19 +36,23 @@ func (m *AccessMessage) String() string {
 	builder.WriteString(string(m.Status))
 	builder.WriteByte(' ')
 	builder.WriteString(serial.ToString(m.To))
-	builder.WriteByte(' ')
+
 	if len(m.Detour) > 0 {
-		builder.WriteByte('[')
+		builder.WriteString(" [")
 		builder.WriteString(m.Detour)
-		builder.WriteString("] ")
+		builder.WriteByte(']')
 	}
-	builder.WriteString(serial.ToString(m.Reason))
+
+	if reason := serial.ToString(m.Reason); len(reason) > 0 {
+		builder.WriteString(" ")
+		builder.WriteString(reason)
+	}
 
 	if len(m.Email) > 0 {
-		builder.WriteString("email:")
+		builder.WriteString(" email: ")
 		builder.WriteString(m.Email)
-		builder.WriteByte(' ')
 	}
+
 	return builder.String()
 }
 

--- a/common/serial/string.go
+++ b/common/serial/string.go
@@ -8,7 +8,7 @@ import (
 // ToString serialize an arbitrary value into string.
 func ToString(v interface{}) string {
 	if v == nil {
-		return " "
+		return ""
 	}
 
 	switch value := v.(type) {


### PR DESCRIPTION
This PR eliminates the trailing whitespace in logger outputs.