### PR TITLE
fix bug not matching routing rules

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -260,12 +260,7 @@ func sniffer(ctx context.Context, cReader *cachedReader) (SniffResult, error) {
 func (d *DefaultDispatcher) routedDispatch(ctx context.Context, link *transport.Link, destination net.Destination) {
 	var handler outbound.Handler
 
-	skipRoutePick := false
-	if content := session.ContentFromContext(ctx); content != nil {
-		skipRoutePick = content.SkipRoutePick
-	}
-
-	if d.router != nil && !skipRoutePick {
+	if d.router != nil {
 		if route, err := d.router.PickRoute(routing_session.AsRoutingContext(ctx)); err == nil {
 			tag := route.GetOutboundTag()
 			if h := d.ohm.GetHandler(tag); h != nil {

--- a/app/dns/nameserver_doh.go
+++ b/app/dns/nameserver_doh.go
@@ -230,8 +230,8 @@ func (s *DoHNameServer) sendQuery(ctx context.Context, domain string, clientIP n
 			}
 
 			dnsCtx = session.ContextWithContent(dnsCtx, &session.Content{
-				Protocol:      "https",
-				SkipDNSResove: true,
+				Protocol:       "https",
+				SkipDNSResolve: true,
 			})
 
 			// forced to use mux for DOH

--- a/app/dns/nameserver_doh.go
+++ b/app/dns/nameserver_doh.go
@@ -231,7 +231,7 @@ func (s *DoHNameServer) sendQuery(ctx context.Context, domain string, clientIP n
 
 			dnsCtx = session.ContextWithContent(dnsCtx, &session.Content{
 				Protocol:      "https",
-				SkipRoutePick: true,
+				SkipDNSResove: true,
 			})
 
 			// forced to use mux for DOH

--- a/app/dns/nameserver_quic.go
+++ b/app/dns/nameserver_quic.go
@@ -177,7 +177,7 @@ func (s *QUICNameServer) sendQuery(ctx context.Context, domain string, clientIP 
 
 			dnsCtx = session.ContextWithContent(dnsCtx, &session.Content{
 				Protocol:      "quic",
-				SkipRoutePick: true,
+				SkipDNSResove: true,
 			})
 
 			var cancel context.CancelFunc

--- a/app/dns/nameserver_quic.go
+++ b/app/dns/nameserver_quic.go
@@ -176,8 +176,8 @@ func (s *QUICNameServer) sendQuery(ctx context.Context, domain string, clientIP 
 			}
 
 			dnsCtx = session.ContextWithContent(dnsCtx, &session.Content{
-				Protocol:      "quic",
-				SkipDNSResove: true,
+				Protocol:       "quic",
+				SkipDNSResolve: true,
 			})
 
 			var cancel context.CancelFunc

--- a/app/router/command/config.go
+++ b/app/router/command/config.go
@@ -28,6 +28,12 @@ func (c routingContext) GetTargetPort() net.Port {
 	return net.Port(c.RoutingContext.GetTargetPort())
 }
 
+// GetSkipDNSRoutePick is a mock implimentation here,
+//   SkipDNSRoutePick is set from dns module, not useful if comming from a protobuf object
+func (c routingContext) GetSkipDNSRoutePick() bool {
+	return false
+}
+
 // AsRoutingContext converts a protobuf RoutingContext into an implementation of routing.Context.
 func AsRoutingContext(r *RoutingContext) routing.Context {
 	return routingContext{r}

--- a/app/router/command/config.go
+++ b/app/router/command/config.go
@@ -28,8 +28,9 @@ func (c routingContext) GetTargetPort() net.Port {
 	return net.Port(c.RoutingContext.GetTargetPort())
 }
 
-// GetSkipDNSRoutePick is a mock implementation here,
-//   SkipDNSRoutePick is set from dns module, not useful if coming from a protobuf object
+// GetSkipDNSResolve is a mock implementation here to match the interface,
+// SkipDNSResolve is set from dns module, no use if coming from a protobuf object?
+// TODO: please confirm @Vigilans
 func (c routingContext) GetSkipDNSResolve() bool {
 	return false
 }

--- a/app/router/command/config.go
+++ b/app/router/command/config.go
@@ -28,8 +28,8 @@ func (c routingContext) GetTargetPort() net.Port {
 	return net.Port(c.RoutingContext.GetTargetPort())
 }
 
-// GetSkipDNSRoutePick is a mock implimentation here,
-//   SkipDNSRoutePick is set from dns module, not useful if comming from a protobuf object
+// GetSkipDNSRoutePick is a mock implementation here,
+//   SkipDNSRoutePick is set from dns module, not useful if coming from a protobuf object
 func (c routingContext) GetSkipDNSRoutePick() bool {
 	return false
 }

--- a/app/router/command/config.go
+++ b/app/router/command/config.go
@@ -30,7 +30,7 @@ func (c routingContext) GetTargetPort() net.Port {
 
 // GetSkipDNSRoutePick is a mock implementation here,
 //   SkipDNSRoutePick is set from dns module, not useful if coming from a protobuf object
-func (c routingContext) GetSkipDNSRoutePick() bool {
+func (c routingContext) GetSkipDNSResolve() bool {
 	return false
 }
 

--- a/app/router/router.go
+++ b/app/router/router.go
@@ -9,7 +9,6 @@ import (
 
 	"v2ray.com/core"
 	"v2ray.com/core/common"
-	"v2ray.com/core/common/session"
 	"v2ray.com/core/features/dns"
 	"v2ray.com/core/features/outbound"
 	"v2ray.com/core/features/routing"
@@ -87,10 +86,7 @@ func (r *Router) pickRouteInternal(ctx routing.Context) (*Rule, routing.Context,
 	// SkipRoutePick is set from DNS DOH module.
 	// the remote server specified is a domain name,
 	// this prevents cycle resolving dead loop
-	skipDNSRoutePick := false
-	if content := session.ContentFromContext(ctx); content != nil {
-		skipDNSRoutePick = content.SkipRoutePick
-	}
+	skipDNSRoutePick := ctx.GetSkipDNSRoutePick()
 
 	if r.domainStrategy == Config_IpOnDemand && !skipDNSRoutePick {
 		ctx = routing_dns.ContextWithDNSClient(ctx, r.dns)

--- a/app/router/router.go
+++ b/app/router/router.go
@@ -83,12 +83,12 @@ func (r *Router) PickRoute(ctx routing.Context) (routing.Route, error) {
 
 func (r *Router) pickRouteInternal(ctx routing.Context) (*Rule, routing.Context, error) {
 
-	// SkipRoutePick is set from DNS DOH module.
-	// the remote server specified is a domain name,
+	// SkipDNSResolve is set from DNS module.
+	// the DOH remote server maybe a domain name,
 	// this prevents cycle resolving dead loop
-	skipDNSRoutePick := ctx.GetSkipDNSRoutePick()
+	skipDNSResolve := ctx.GetSkipDNSResolve()
 
-	if r.domainStrategy == Config_IpOnDemand && !skipDNSRoutePick {
+	if r.domainStrategy == Config_IpOnDemand && !skipDNSResolve {
 		ctx = routing_dns.ContextWithDNSClient(ctx, r.dns)
 	}
 
@@ -98,7 +98,7 @@ func (r *Router) pickRouteInternal(ctx routing.Context) (*Rule, routing.Context,
 		}
 	}
 
-	if r.domainStrategy != Config_IpIfNonMatch || len(ctx.GetTargetDomain()) == 0 || skipDNSRoutePick {
+	if r.domainStrategy != Config_IpIfNonMatch || len(ctx.GetTargetDomain()) == 0 || skipDNSResolve {
 		return nil, ctx, common.ErrNoClue
 	}
 

--- a/common/session/session.go
+++ b/common/session/session.go
@@ -68,7 +68,7 @@ type Content struct {
 
 	Attributes map[string]string
 
-	SkipDNSResove bool
+	SkipDNSResolve bool
 }
 
 // Sockopt is the settings for socket connection.

--- a/common/session/session.go
+++ b/common/session/session.go
@@ -68,7 +68,7 @@ type Content struct {
 
 	Attributes map[string]string
 
-	SkipRoutePick bool
+	SkipDNSResove bool
 }
 
 // Sockopt is the settings for socket connection.

--- a/features/routing/context.go
+++ b/features/routing/context.go
@@ -38,6 +38,6 @@ type Context interface {
 	// GetAttributes returns extra attributes from the conneciont content.
 	GetAttributes() map[string]string
 
-	// GetSkipDNSResolve returns a flag switch for weather skip dns resovle during route pick.
+	// GetSkipDNSResolve returns a flag switch for weather skip dns resolve during route pick.
 	GetSkipDNSResolve() bool
 }

--- a/features/routing/context.go
+++ b/features/routing/context.go
@@ -37,4 +37,7 @@ type Context interface {
 
 	// GetAttributes returns extra attributes from the conneciont content.
 	GetAttributes() map[string]string
+
+	// GetSkipDNSRoutePick returns a flag switch for weather skipping route resolving.
+	GetSkipDNSRoutePick() bool
 }

--- a/features/routing/context.go
+++ b/features/routing/context.go
@@ -38,6 +38,6 @@ type Context interface {
 	// GetAttributes returns extra attributes from the conneciont content.
 	GetAttributes() map[string]string
 
-	// GetSkipDNSRoutePick returns a flag switch for weather skipping route resolving.
-	GetSkipDNSRoutePick() bool
+	// GetSkipDNSResolve returns a flag switch for weather skip dns resovle during route pick.
+	GetSkipDNSResolve() bool
 }

--- a/features/routing/session/context.go
+++ b/features/routing/session/context.go
@@ -109,12 +109,12 @@ func (ctx *Context) GetAttributes() map[string]string {
 	return ctx.Content.Attributes
 }
 
-// GetSkipDNSRoutePick implements routing.Context.
+// GetSkipDNSResolve implements routing.Context.
 func (ctx *Context) GetSkipDNSResolve() bool {
 	if ctx.Content == nil {
 		return false
 	}
-	return ctx.Content.SkipDNSResove
+	return ctx.Content.SkipDNSResolve
 }
 
 // AsRoutingContext creates a context from context.context with session info.

--- a/features/routing/session/context.go
+++ b/features/routing/session/context.go
@@ -109,6 +109,14 @@ func (ctx *Context) GetAttributes() map[string]string {
 	return ctx.Content.Attributes
 }
 
+// GetSkipDNSRoutePick implements routing.Context.
+func (ctx *Context) GetSkipDNSRoutePick() bool {
+	if ctx.Content == nil {
+		return false
+	}
+	return ctx.Content.SkipRoutePick
+}
+
 // AsRoutingContext creates a context from context.context with session info.
 func AsRoutingContext(ctx context.Context) routing.Context {
 	return &Context{

--- a/features/routing/session/context.go
+++ b/features/routing/session/context.go
@@ -110,11 +110,11 @@ func (ctx *Context) GetAttributes() map[string]string {
 }
 
 // GetSkipDNSRoutePick implements routing.Context.
-func (ctx *Context) GetSkipDNSRoutePick() bool {
+func (ctx *Context) GetSkipDNSResolve() bool {
 	if ctx.Content == nil {
 		return false
 	}
-	return ctx.Content.SkipRoutePick
+	return ctx.Content.SkipDNSResove
 }
 
 // AsRoutingContext creates a context from context.context with session info.


### PR DESCRIPTION
`SkipRoutePick` is set from DNS DOH module, previously it had the most high priority that skips out all the routing rules, to prevent 
prevents resolving dead loop. 

But actually only need to skip out the DNS client part inside the matcher.
