### PR TITLE
Update quic-go mod version

### DIFF
--- a/app/dns/nameserver_quic.go
+++ b/app/dns/nameserver_quic.go
@@ -362,7 +362,7 @@ func (s *QUICNameServer) getSession() (quic.Session, error) {
 func (s *QUICNameServer) openSession() (quic.Session, error) {
 	tlsConfig := tls.Config{}
 	quicConfig := &quic.Config{
-		HandshakeTimeout: handshakeTimeout,
+		HandshakeIdleTimeout: handshakeTimeout,
 	}
 
 	session, err := quic.DialAddrContext(context.Background(), s.destination.NetAddr(), tlsConfig.GetTLSConfig(tls.WithNextProto("http/1.1", http2.NextProtoTLS, NextProtoDQ)), quicConfig)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.4
 	github.com/gorilla/websocket v1.4.2
-	github.com/lucas-clemente/quic-go v0.19.3
+	github.com/lucas-clemente/quic-go v0.7.1-0.20210106030544-d1c5297c0bd9
 	github.com/miekg/dns v1.1.35
 	github.com/pires/go-proxyproto v0.3.3
 	github.com/seiflotfy/cuckoofilter v0.0.0-20201222105146-bc6005554a0c

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lucas-clemente/quic-go v0.7.1-0.20210106030544-d1c5297c0bd9 h1:LYaW3REByVdEzRaG6sX4ZX4+K4s9lTvW2Qh0cjspEYY=
+github.com/lucas-clemente/quic-go v0.7.1-0.20210106030544-d1c5297c0bd9/go.mod h1:Cxx5SWK/K2dp7TA7qsnIHgF43e3NAufUDcSb9jTpL68=
 github.com/lucas-clemente/quic-go v0.19.3 h1:eCDQqvGBB+kCTkA0XrAFtNe81FMa0/fn4QSoeAbmiF4=
 github.com/lucas-clemente/quic-go v0.19.3/go.mod h1:ADXpNbTQjq1hIzCpB+y/k5iz4n4z4IwqoLb94Kh5Hu8=
 github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
@@ -105,6 +107,8 @@ github.com/marten-seemann/qtls v0.10.0 h1:ECsuYUKalRL240rRD4Ri33ISb7kAQ3qGDlrrl5
 github.com/marten-seemann/qtls v0.10.0/go.mod h1:UvMd1oaYDACI99/oZUYLzMCkBXQVT0aGm99sJhbT8hs=
 github.com/marten-seemann/qtls-go1-15 v0.1.1 h1:LIH6K34bPVttyXnUWixk0bzH6/N07VxbSabxn5A5gZQ=
 github.com/marten-seemann/qtls-go1-15 v0.1.1/go.mod h1:GyFwywLKkRt+6mfU99csTEY1joMZz5vmB1WNZH3P81I=
+github.com/marten-seemann/qtls-go1-16 v0.1.0-beta.1.1 h1:CWVWoLCcdfarQRGgWi2b9ILKhc5v8MXtfs3bz9dmE00=
+github.com/marten-seemann/qtls-go1-16 v0.1.0-beta.1.1/go.mod h1:gNpI2Ol+lRS3WwSOtIUUtRwZEQMXjYK+dQSBFbethAk=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/miekg/dns v1.1.35 h1:oTfOaDH+mZkdcgdIjH6yBajRGtIwcwcaR+rt23ZSrJs=

--- a/transport/internet/quic/dialer.go
+++ b/transport/internet/quic/dialer.go
@@ -149,9 +149,9 @@ func (s *clientSessions) openConnection(destAddr net.Addr, config *Config, tlsCo
 	}
 
 	quicConfig := &quic.Config{
-		ConnectionIDLength: 12,
-		HandshakeTimeout:   time.Second * 8,
-		MaxIdleTimeout:     time.Second * 30,
+		ConnectionIDLength:   12,
+		HandshakeIdleTimeout: time.Second * 8,
+		MaxIdleTimeout:       time.Second * 30,
 	}
 
 	conn, err := wrapSysConn(rawConn, config)

--- a/transport/internet/quic/hub.go
+++ b/transport/internet/quic/hub.go
@@ -105,7 +105,7 @@ func Listen(ctx context.Context, address net.Address, port net.Port, streamSetti
 
 	quicConfig := &quic.Config{
 		ConnectionIDLength:    12,
-		HandshakeTimeout:      time.Second * 8,
+		HandshakeIdleTimeout:  time.Second * 8,
 		MaxIdleTimeout:        time.Second * 45,
 		MaxIncomingStreams:    32,
 		MaxIncomingUniStreams: -1,


### PR DESCRIPTION
Since Apple Silicon(aka M1) will be supported from `go-1.16beta1`. We have to upgrade the dependency `github.com/lucas-clemente/quic-go` to latest version lucas-clemente/quic-go@d1c5297c0bd9.

So, the commit is a temporary hack before next official release of `lucas-clemente/quic-go`.