### PR TITLE
fix: implement Close of pipe.Reader

### DIFF
--- a/transport/pipe/reader.go
+++ b/transport/pipe/reader.go
@@ -25,3 +25,8 @@ func (r *Reader) ReadMultiBufferTimeout(d time.Duration) (buf.MultiBuffer, error
 func (r *Reader) Interrupt() {
 	r.pipe.Interrupt()
 }
+
+// Close implements io.Closer. After the pipe is closed, writing to the pipe will return io.ErrClosedPipe, while reading will return io.EOF.
+func (r *Reader) Close() error {
+	return r.pipe.Close()
+}


### PR DESCRIPTION
感谢Xray群admin

解决了我的使用场景里mux会多跑流量的BUG，场景有限不敢确定彻底解决，但没实现肯定是个BUG。

可能相关

#672
[v2ray/v2ray-core#1963](https://github.com/v2ray/v2ray-core/issues/1963)
[v2ray/v2ray-core#1969](https://github.com/v2ray/v2ray-core/issues/1969)
[v2ray/v2ray-core#2194](https://github.com/v2ray/v2ray-core/issues/2194)
[v2ray/v2ray-core#2412](https://github.com/v2ray/v2ray-core/issues/2412)
[v2fly/v2ray-core#168](https://github.com/v2fly/v2ray-core/pull/168)