### PR TITLE
Add sniffer enhancement related to Fake DNS 

### DIFF
--- a/app/dns/fakedns/fake.go
+++ b/app/dns/fakedns/fake.go
@@ -117,7 +117,13 @@ func (fkdns *Holder) GetDomainFromFakeDNS(ip net.Address) string {
 	if k, ok := fkdns.domainToIP.GetKeyFromValue(ip); ok {
 		return k.(string)
 	}
+	newError("A fake ip request to ", ip, ", however there is no matching domain name in fake DNS").AtInfo().WriteToLog()
 	return ""
+}
+
+// GetFakeIPRange return fake IP range from configuration
+func (fkdns *Holder) GetFakeIPRange() *gonet.IPNet {
+	return fkdns.ipRange
 }
 
 func init() {

--- a/app/dns/fakedns/fakedns_test.go
+++ b/app/dns/fakedns/fakedns_test.go
@@ -20,7 +20,7 @@ func TestFakeDnsHolderCreateMapping(t *testing.T) {
 	common.Must(err)
 
 	addr := fkdns.GetFakeIPForDomain("fakednstest.v2fly.org")
-	assert.Equal(t, "240.0.0.0", addr[0].IP().String())
+	assert.Equal(t, "240.", addr[0].IP().String()[0:4])
 }
 
 func TestFakeDnsHolderCreateMappingMany(t *testing.T) {
@@ -28,33 +28,27 @@ func TestFakeDnsHolderCreateMappingMany(t *testing.T) {
 	common.Must(err)
 
 	addr := fkdns.GetFakeIPForDomain("fakednstest.v2fly.org")
-	assert.Equal(t, "240.0.0.0", addr[0].IP().String())
+	assert.Equal(t, "240.", addr[0].IP().String()[0:4])
 
 	addr2 := fkdns.GetFakeIPForDomain("fakednstest2.v2fly.org")
-	assert.Equal(t, "240.0.0.1", addr2[0].IP().String())
+	assert.Equal(t, "240.", addr2[0].IP().String()[0:4])
+	assert.NotEqual(t, addr[0].IP().String(), addr2[0].IP().String())
 }
 
 func TestFakeDnsHolderCreateMappingManyAndResolve(t *testing.T) {
 	fkdns, err := NewFakeDNSHolder()
 	common.Must(err)
 
-	{
-		addr := fkdns.GetFakeIPForDomain("fakednstest.v2fly.org")
-		assert.Equal(t, "240.0.0.0", addr[0].IP().String())
-	}
+	addr := fkdns.GetFakeIPForDomain("fakednstest.v2fly.org")
+	addr2 := fkdns.GetFakeIPForDomain("fakednstest2.v2fly.org")
 
 	{
-		addr2 := fkdns.GetFakeIPForDomain("fakednstest2.v2fly.org")
-		assert.Equal(t, "240.0.0.1", addr2[0].IP().String())
-	}
-
-	{
-		result := fkdns.GetDomainFromFakeDNS(net.ParseAddress("240.0.0.0"))
+		result := fkdns.GetDomainFromFakeDNS(addr[0])
 		assert.Equal(t, "fakednstest.v2fly.org", result)
 	}
 
 	{
-		result := fkdns.GetDomainFromFakeDNS(net.ParseAddress("240.0.0.1"))
+		result := fkdns.GetDomainFromFakeDNS(addr2[0])
 		assert.Equal(t, "fakednstest2.v2fly.org", result)
 	}
 }
@@ -64,10 +58,8 @@ func TestFakeDnsHolderCreateMappingManySingleDomain(t *testing.T) {
 	common.Must(err)
 
 	addr := fkdns.GetFakeIPForDomain("fakednstest.v2fly.org")
-	assert.Equal(t, "240.0.0.0", addr[0].IP().String())
-
 	addr2 := fkdns.GetFakeIPForDomain("fakednstest.v2fly.org")
-	assert.Equal(t, "240.0.0.0", addr2[0].IP().String())
+	assert.Equal(t, addr[0].IP().String(), addr2[0].IP().String())
 }
 
 func TestFakeDnsHolderCreateMappingAndRollOver(t *testing.T) {
@@ -81,32 +73,25 @@ func TestFakeDnsHolderCreateMappingAndRollOver(t *testing.T) {
 
 	common.Must(err)
 
-	{
-		addr := fkdns.GetFakeIPForDomain("fakednstest.v2fly.org")
-		assert.Equal(t, "240.0.0.0", addr[0].IP().String())
-	}
-
-	{
-		addr2 := fkdns.GetFakeIPForDomain("fakednstest2.v2fly.org")
-		assert.Equal(t, "240.0.0.1", addr2[0].IP().String())
-	}
+	addr := fkdns.GetFakeIPForDomain("fakednstest.v2fly.org")
+	addr2 := fkdns.GetFakeIPForDomain("fakednstest2.v2fly.org")
 
 	for i := 0; i <= 8192; i++ {
 		{
-			result := fkdns.GetDomainFromFakeDNS(net.ParseAddress("240.0.0.0"))
+			result := fkdns.GetDomainFromFakeDNS(addr[0])
 			assert.Equal(t, "fakednstest.v2fly.org", result)
 		}
 
 		{
-			result := fkdns.GetDomainFromFakeDNS(net.ParseAddress("240.0.0.1"))
+			result := fkdns.GetDomainFromFakeDNS(addr2[0])
 			assert.Equal(t, "fakednstest2.v2fly.org", result)
 		}
 
 		{
 			uuid := uuid.New()
 			domain := uuid.String() + ".fakednstest.v2fly.org"
-			addr := fkdns.GetFakeIPForDomain(domain)
-			rsaddr := addr[0].IP().String()
+			tempAddr := fkdns.GetFakeIPForDomain(domain)
+			rsaddr := tempAddr[0].IP().String()
 
 			result := fkdns.GetDomainFromFakeDNS(net.ParseAddress(rsaddr))
 			assert.Equal(t, domain, result)

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -9,6 +9,7 @@ import (
 type Lru interface {
 	Get(key interface{}) (value interface{}, ok bool)
 	GetKeyFromValue(value interface{}) (key interface{}, ok bool)
+	PeekKeyFromValue(value interface{}) (key interface{}, ok bool) // Peek means check but NOT bring to top
 	Put(key, value interface{})
 }
 
@@ -49,6 +50,14 @@ func (l lru) GetKeyFromValue(value interface{}) (key interface{}, ok bool) {
 	if k, ok := l.valueToElement.Load(value); ok {
 		element := k.(*list.Element)
 		l.doubleLinkedlist.MoveBefore(element, l.doubleLinkedlist.Front())
+		return element.Value.(lruElement).key, true
+	}
+	return nil, false
+}
+
+func (l lru) PeekKeyFromValue(value interface{}) (key interface{}, ok bool) {
+	if k, ok := l.valueToElement.Load(value); ok {
+		element := k.(*list.Element)
 		return element.Value.(lruElement).key, true
 	}
 	return nil, false

--- a/common/cache/lru_test.go
+++ b/common/cache/lru_test.go
@@ -57,12 +57,29 @@ func TestGetKeyFromValue(t *testing.T) {
 	lru := NewLru(2)
 	lru.Put(3, 3)
 	lru.Put(2, 2)
+	lru.GetKeyFromValue(3)
 	lru.Put(1, 1)
-	v, ok := lru.GetKeyFromValue(3)
+	v, ok := lru.GetKeyFromValue(2)
 	if ok {
 		t.Error("should get nil", v)
 	}
-	v, _ = lru.GetKeyFromValue(2)
+	v, _ = lru.GetKeyFromValue(3)
+	if v != 3 {
+		t.Error("should get 3", v)
+	}
+}
+
+func TestPeekKeyFromValue(t *testing.T) {
+	lru := NewLru(2)
+	lru.Put(3, 3)
+	lru.Put(2, 2)
+	lru.PeekKeyFromValue(3)
+	lru.Put(1, 1)
+	v, ok := lru.PeekKeyFromValue(3)
+	if ok {
+		t.Error("should get nil", v)
+	}
+	v, _ = lru.PeekKeyFromValue(2)
 	if v != 2 {
 		t.Error("should get 2", v)
 	}

--- a/features/dns/fakedns.go
+++ b/features/dns/fakedns.go
@@ -1,6 +1,8 @@
 package dns
 
 import (
+	gonet "net"
+
 	"github.com/v2fly/v2ray-core/v4/common/net"
 	"github.com/v2fly/v2ray-core/v4/features"
 )
@@ -9,4 +11,5 @@ type FakeDNSEngine interface {
 	features.Feature
 	GetFakeIPForDomain(domain string) []net.Address
 	GetDomainFromFakeDNS(ip net.Address) string
+	GetFakeIPRange() *gonet.IPNet
 }


### PR DESCRIPTION
I have been thinking of for the cache/mapping loss when core is rebooted. Also got some idea from the initial user of the current fake DNS.
Basically the idea is to use the existing sniffers (HTTP, TLS) when the domain name cannot be recovered. When it works, logs will be like:
```
31872-31976/com.v2ray.ang I/GoLog: [Info] v2ray.com/core/app/dns: returning fake IP 240.0.0.2 for domain baidu.com
...reboot...
2020-11-29 22:55:56.300 31872-31976/com.v2ray.ang I/GoLog: [Info] [1895565757] v2ray.com/core/proxy/socks: TCP Connect request to tcp:240.0.0.2:80
2020-11-29 22:55:56.300 31872-31976/com.v2ray.ang I/GoLog: [Info] v2ray.com/core/app/dns/fakedns: A fake ip request to 240.0.0.2, however there is no matching domain name in fake DNS
2020-11-29 22:55:56.300 31872-31976/com.v2ray.ang I/GoLog: [Info] [1895565757] v2ray.com/core/app/dispatcher: Using sniffer http1 since the fake DNS missed
2020-11-29 22:55:56.300 31872-31976/com.v2ray.ang I/GoLog: [Info] [1895565757] v2ray.com/core/app/dispatcher: sniffed domain: baidu.com
2020-11-29 22:55:56.300 31872-31976/com.v2ray.ang I/GoLog: [Info] [1895565757] v2ray.com/core/app/dispatcher: taking detour [direct] for [tcp:baidu.com:80]
```