### PR TITLE
Fix ALPN being set to h2 by default when using TCP

### DIFF
--- a/transport/internet/tcp/hub.go
+++ b/transport/internet/tcp/hub.go
@@ -71,7 +71,7 @@ func ListenTCP(ctx context.Context, address net.Address, port net.Port, streamSe
 	l.listener = listener
 
 	if config := tls.ConfigFromStreamSettings(streamSettings); config != nil {
-		l.tlsConfig = config.GetTLSConfig(tls.WithNextProto("h2"))
+		l.tlsConfig = config.GetTLSConfig()
 	}
 
 	if tcpSettings.HeaderSettings != nil {


### PR DESCRIPTION
https://github.com/XTLS/Xray-core/issues/242#issuecomment-778889586