### PR TITLE
Deprecate legacy VMess header with a planned decommission

### DIFF
--- a/proxy/vmess/encoding/server.go
+++ b/proxy/vmess/encoding/server.go
@@ -191,10 +191,15 @@ func (s *ServerSession) DecodeRequestHeader(reader io.Reader) (*protocol.Request
 		decryptor = bytes.NewReader(aeadData)
 		s.isAEADRequest = true
 
-	case !s.isAEADForced && errorAEAD == vmessaead.ErrNotFound:
+	case errorAEAD == vmessaead.ErrNotFound:
 		userLegacy, timestamp, valid, userValidationError := s.userValidator.Get(buffer.Bytes())
 		if !valid || userValidationError != nil {
 			return nil, drainConnection(newError("invalid user").Base(userValidationError))
+		}
+		if s.isAEADForced {
+			return nil, drainConnection(newError("invalid user: VMessAEAD is enforced and a non VMessAEAD connection is received. You can still disable this security feature with environment variable v2ray.vmess.aead.forced = false . You will not be able to enable legacy header workaround in the future."))
+		} else {
+			newError("Critical Warning: potentially invalid user: a non VMessAEAD connection is received. From 2022 Jan 1st, this kind of connection will be rejected by default. You should update or replace your client software now. ").AtWarning().WriteToLog()
 		}
 		user = userLegacy
 		iv := hashTimestamp(md5.New(), timestamp)

--- a/proxy/vmess/inbound/inbound.go
+++ b/proxy/vmess/inbound/inbound.go
@@ -353,16 +353,26 @@ func (h *Handler) generateCommand(ctx context.Context, request *protocol.Request
 }
 
 var aeadForced = false
+var aeadForced2022 = false
 
 func init() {
 	common.Must(common.RegisterConfig((*Config)(nil), func(ctx context.Context, config interface{}) (interface{}, error) {
 		return New(ctx, config.(*Config))
 	}))
 
-	const defaultFlagValue = "NOT_DEFINED_AT_ALL"
+	var defaultFlagValue = "NOT_DEFINED_AT_ALL"
+
+	if time.Now().Year() >= 2022 {
+		defaultFlagValue = "true_by_default_2022"
+	}
 
 	isAeadForced := platform.NewEnvFlag("v2ray.vmess.aead.forced").GetValue(func() string { return defaultFlagValue })
 	if isAeadForced == "true" {
 		aeadForced = true
+	}
+
+	if isAeadForced == "true_by_default_2022" {
+		aeadForced = true
+		aeadForced2022 = true
 	}
 }


### PR DESCRIPTION
VMessAEAD have been used for a while, and no major issue is discovered and passed necessary security review and adopted recommend change. We can begin to discuss the decommission of legacy VMess header.

This PR is intended to start a discussion on this issue, not a decision to do so unless a consensus is reached.