### PR TITLE
Android 默认 DNS  不再需要配置文件

### DIFF
--- a/infra/conf/dns.go
+++ b/infra/conf/dns.go
@@ -160,10 +160,6 @@ func (c *DNSConfig) Build() (*dns.Config, error) {
 		config.NameServer = append(config.NameServer, ns)
 	}
 
-	if BootstrapDNS() {
-		newError("Bootstrap DNS: ", bootstrapDNS).AtWarning().WriteToLog()
-	}
-
 	if c.Hosts != nil && len(c.Hosts) > 0 {
 		domains := make([]string, 0, len(c.Hosts))
 		for domain := range c.Hosts {

--- a/infra/conf/dns_bootstrap.go
+++ b/infra/conf/dns_bootstrap.go
@@ -1,9 +1,0 @@
-// +build !android
-
-package conf
-
-const bootstrapDNS = ""
-
-func BootstrapDNS() bool {
-	return false
-}

--- a/infra/conf/dns_bootstrap_android.go
+++ b/infra/conf/dns_bootstrap_android.go
@@ -7,12 +7,11 @@ import (
 	"net"
 )
 
-const bootstrapDNS = "8.8.8.8:53"
-
-func BootstrapDNS() bool {
+func init() {
+	const bootstrapDNS = "8.8.8.8:53"
 	var dialer net.Dialer
 	net.DefaultResolver = &net.Resolver{
-		PreferGo: false,
+		PreferGo: true,
 		Dial: func(context context.Context, _, _ string) (net.Conn, error) {
 			conn, err := dialer.DialContext(context, "udp", bootstrapDNS)
 			if err != nil {
@@ -21,5 +20,5 @@ func BootstrapDNS() bool {
 			return conn, nil
 		},
 	}
-	return true
+	newError("Bootstrap DNS: ", bootstrapDNS).AtWarning().WriteToLog()
 }


### PR DESCRIPTION
#572 当时是想着可以从已有的内置 DNS 中选择一个 DNS 作为 Android 默认的 DNS，但是后来就直接定为了 `8.8.8.8:53` 导致不需要内置 DNS 的用户会出现需要配置文件中填写 `"dns":{}` 才可以让代码生效的情况(https://github.com/v2fly/v2ray-core/discussions/692)

让其为 init 函数可以提高该操作的优先级，以防止某些用到 `net.DefaultResolver` 的函数在此更改前就已初始化而导致问题复现(https://github.com/v2ray/v2ray-core/issues/1909)

此更改依然仅对 Android 生效，不会影响其他的平台