### PR TITLE
Fix: remove AA header flag in DNS query

### DIFF
--- a/proxy/dns/dns.go
+++ b/proxy/dns/dns.go
@@ -244,7 +244,6 @@ func (h *Handler) handleIPQuery(id uint16, qType dnsmessage.Type, domain string,
 		RecursionAvailable: true,
 		RecursionDesired:   true,
 		Response:           true,
-		Authoritative:      true,
 	})
 	builder.EnableCompression()
 	common.Must(builder.StartQuestions())


### PR DESCRIPTION
Fixes #340