### PR TITLE
feat: export (const.)core.v2rayKey

### DIFF
--- a/context.go
+++ b/context.go
@@ -9,12 +9,12 @@ import (
 // V2rayKey is the key type of Instance in Context, exported for test.
 type V2rayKey int
 
-// v2rayKey is the key value of Instance in Context, exported for test.
-const v2rayKey V2rayKey = 1
+// V2rayKeyValue is the key value of Instance in Context, exported for test.
+const V2rayKeyValue V2rayKey = 1
 
 // FromContext returns an Instance from the given context, or nil if the context doesn't contain one.
 func FromContext(ctx context.Context) *Instance {
-	if s, ok := ctx.Value(v2rayKey).(*Instance); ok {
+	if s, ok := ctx.Value(V2rayKeyValue).(*Instance); ok {
 		return s
 	}
 	return nil

--- a/context.go
+++ b/context.go
@@ -9,6 +9,7 @@ import (
 // V2rayKey is the key type of Instance in Context, exported for test.
 type V2rayKey int
 
+// v2rayKey is the key value of Instance in Context, exported for test.
 const v2rayKey V2rayKey = 1
 
 // FromContext returns an Instance from the given context, or nil if the context doesn't contain one.

--- a/functions.go
+++ b/functions.go
@@ -16,7 +16,7 @@ import (
 func CreateObject(v *Instance, config interface{}) (interface{}, error) {
 	var ctx context.Context
 	if v != nil {
-		ctx = context.WithValue(v.ctx, v2rayKey, v)
+		ctx = context.WithValue(v.ctx, V2rayKeyValue, v)
 	}
 	return common.CreateObject(ctx, config)
 }


### PR DESCRIPTION
as for v2fly/v2ray-core#698 

ctx initialization for core.Dial() requires this, as from core.RequireFeatures() introduced in dispatcher.newFakeDNSSniffer().

 ```golang
 ctx = context.WithValue(ctx, vcore.V2rayKeyValue, p.v)
 ```
