### PR TITLE
feat: shouldSniffDomain for Sniffer

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -271,7 +271,8 @@ func sniffer(ctx context.Context, cReader *cachedReader, metadataOnly bool) (Sni
 
 				cReader.Cache(payload)
 				if !payload.IsEmpty() {
-					result, err := sniffer.Sniff(ctx, payload.Bytes())
+					shouldSniffDomain := (metadataErr != nil)
+					result, err := sniffer.Sniff(ctx, payload.Bytes(), shouldSniffDomain)
 					if err != common.ErrNoClue {
 						return result, err
 					}

--- a/app/dispatcher/fakednssniffer.go
+++ b/app/dispatcher/fakednssniffer.go
@@ -13,19 +13,19 @@ import (
 )
 
 // newFakeDNSSniffer Create a Fake DNS metadata sniffer
-func newFakeDNSSniffer(ctx context.Context) (protocolSnifferWithMetadata, error) {
+func newFakeDNSSniffer(ctx context.Context) (snifferWithMetadata, error) {
 	var fakeDNSEngine dns.FakeDNSEngine
 	err := core.RequireFeatures(ctx, func(fdns dns.FakeDNSEngine) {
 		fakeDNSEngine = fdns
 	})
 	if err != nil {
-		return protocolSnifferWithMetadata{}, err
+		return snifferWithMetadata{}, err
 	}
 	if fakeDNSEngine == nil {
 		errNotInit := newError("FakeDNSEngine is not initialized, but such a sniffer is used").AtError()
-		return protocolSnifferWithMetadata{}, errNotInit
+		return snifferWithMetadata{}, errNotInit
 	}
-	return protocolSnifferWithMetadata{protocolSniffer: func(ctx context.Context, bytes []byte) (SniffResult, error) {
+	return snifferWithMetadata{domainSniffer: func(ctx context.Context, bytes []byte) (SniffResult, error) {
 		Target := session.OutboundFromContext(ctx).Target
 		if Target.Network == net.Network_TCP || Target.Network == net.Network_UDP {
 			domainFromFakeDNS := fakeDNSEngine.GetDomainFromFakeDNS(Target.Address)
@@ -34,6 +34,8 @@ func newFakeDNSSniffer(ctx context.Context) (protocolSnifferWithMetadata, error)
 				return &fakeDNSSniffResult{domainName: domainFromFakeDNS}, nil
 			}
 		}
+		return nil, common.ErrNoClue
+	}, protocolSniffer: func(ctx context.Context, bytes []byte) (SniffResult, error) {
 		return nil, common.ErrNoClue
 	}, metadataSniffer: true}, nil
 }

--- a/app/dispatcher/sniffer.go
+++ b/app/dispatcher/sniffer.go
@@ -16,9 +16,12 @@ type SniffResult interface {
 	Domain() string
 }
 
+type domainSniffer func(context.Context, []byte) (SniffResult, error)
+
 type protocolSniffer func(context.Context, []byte) (SniffResult, error)
 
-type protocolSnifferWithMetadata struct {
+type snifferWithMetadata struct {
+	domainSniffer   domainSniffer
 	protocolSniffer protocolSniffer
 	// A Metadata sniffer will be invoked on connection establishment only, with nil body,
 	// for both TCP and UDP connections
@@ -27,15 +30,15 @@ type protocolSnifferWithMetadata struct {
 }
 
 type Sniffer struct {
-	sniffer []protocolSnifferWithMetadata
+	sniffer []snifferWithMetadata
 }
 
 func NewSniffer(ctx context.Context) *Sniffer {
 	ret := &Sniffer{
-		sniffer: []protocolSnifferWithMetadata{
-			{func(c context.Context, b []byte) (SniffResult, error) { return http.SniffHTTP(b) }, false},
-			{func(c context.Context, b []byte) (SniffResult, error) { return tls.SniffTLS(b) }, false},
-			{func(c context.Context, b []byte) (SniffResult, error) { return bittorrent.SniffBittorrent(b) }, false},
+		sniffer: []snifferWithMetadata{
+			{func(c context.Context, b []byte) (SniffResult, error) { return http.SniffDomainHTTP(b) }, func(c context.Context, b []byte) (SniffResult, error) { return http.SniffProtocolHTTP(b) }, false},
+			{func(c context.Context, b []byte) (SniffResult, error) { return tls.SniffDomainTLS(b) }, func(c context.Context, b []byte) (SniffResult, error) { return tls.SniffProtocolTLS(b) }, false},
+			{func(c context.Context, b []byte) (SniffResult, error) { return bittorrent.SniffDomainBittorrent(b) }, func(c context.Context, b []byte) (SniffResult, error) { return bittorrent.SniffProtocolBittorrent(b) }, false},
 		},
 	}
 	if sniffer, err := newFakeDNSSniffer(ctx); err == nil {
@@ -46,14 +49,22 @@ func NewSniffer(ctx context.Context) *Sniffer {
 
 var errUnknownContent = newError("unknown content")
 
-func (s *Sniffer) Sniff(c context.Context, payload []byte) (SniffResult, error) {
-	var pendingSniffer []protocolSnifferWithMetadata
+func (s *Sniffer) Sniff(c context.Context, payload []byte, shouldSniffDomain bool) (SniffResult, error) {
+	var pendingSniffer []snifferWithMetadata
 	for _, si := range s.sniffer {
-		s := si.protocolSniffer
+		sd := si.domainSniffer
+		sp := si.protocolSniffer
 		if si.metadataSniffer {
 			continue
 		}
-		result, err := s(c, payload)
+		
+		var result SniffResult
+		var err error
+		if shouldSniffDomain {
+			result, err = sd(c, payload)
+		} else {
+			result, err = sp(c, payload)
+		}
 		if err == common.ErrNoClue {
 			pendingSniffer = append(pendingSniffer, si)
 			continue
@@ -73,9 +84,9 @@ func (s *Sniffer) Sniff(c context.Context, payload []byte) (SniffResult, error) 
 }
 
 func (s *Sniffer) SniffMetadata(c context.Context) (SniffResult, error) {
-	var pendingSniffer []protocolSnifferWithMetadata
+	var pendingSniffer []snifferWithMetadata
 	for _, si := range s.sniffer {
-		s := si.protocolSniffer
+		s := si.domainSniffer
 		if !si.metadataSniffer {
 			pendingSniffer = append(pendingSniffer, si)
 			continue

--- a/app/dispatcher/sniffer.go
+++ b/app/dispatcher/sniffer.go
@@ -57,7 +57,7 @@ func (s *Sniffer) Sniff(c context.Context, payload []byte, shouldSniffDomain boo
 		if si.metadataSniffer {
 			continue
 		}
-		
+
 		var result SniffResult
 		var err error
 		if shouldSniffDomain {

--- a/common/protocol/bittorrent/bittorrent.go
+++ b/common/protocol/bittorrent/bittorrent.go
@@ -19,14 +19,22 @@ func (h *SniffHeader) Domain() string {
 
 var errNotBittorrent = errors.New("not bittorrent header")
 
-func SniffBittorrent(b []byte) (*SniffHeader, error) {
+func SniffProtocolBittorrent(b []byte) (*SniffHeader, error) {
+	h := &SniffHeader{}
+
 	if len(b) < 20 {
 		return nil, common.ErrNoClue
 	}
 
 	if b[0] == 19 && string(b[1:20]) == "BitTorrent protocol" {
-		return &SniffHeader{}, nil
+		return h, nil
 	}
 
 	return nil, errNotBittorrent
+}
+
+func SniffDomainBittorrent(b []byte) (*SniffHeader, error) {
+	h, err := SniffProtocolBittorrent(b)
+
+	return h, err
 }

--- a/common/protocol/http/sniff.go
+++ b/common/protocol/http/sniff.go
@@ -56,13 +56,22 @@ func beginWithHTTPMethod(b []byte) error {
 	return errNotHTTPMethod
 }
 
-func SniffHTTP(b []byte) (*SniffHeader, error) {
+func SniffProtocolHTTP(b []byte) (*SniffHeader, error) {
 	if err := beginWithHTTPMethod(b); err != nil {
 		return nil, err
 	}
 
 	sh := &SniffHeader{
 		version: HTTP1,
+	}
+
+	return sh, nil
+}
+
+func SniffDomainHTTP(b []byte) (*SniffHeader, error) {
+	sh, err := SniffProtocolHTTP(b)
+	if err != nil {
+		return nil, err
 	}
 
 	headers := bytes.Split(b, []byte{'\n'})

--- a/common/protocol/http/sniff_test.go
+++ b/common/protocol/http/sniff_test.go
@@ -88,7 +88,7 @@ first_name=John&last_name=Doe&action=Submit`,
 	}
 
 	for _, test := range cases {
-		header, err := SniffHTTP([]byte(test.input))
+		header, err := SniffDomainHTTP([]byte(test.input))
 		if test.err {
 			if err == nil {
 				t.Errorf("Expect error but nil, in test: %v", test)

--- a/common/protocol/tls/sniff.go
+++ b/common/protocol/tls/sniff.go
@@ -121,7 +121,7 @@ func ReadClientHello(data []byte, h *SniffHeader) error {
 	return errNotTLS
 }
 
-func SniffTLS(b []byte) (*SniffHeader, error) {
+func SniffProtocolTLS(b []byte) (*SniffHeader, error) {
 	if len(b) < 5 {
 		return nil, common.ErrNoClue
 	}
@@ -138,9 +138,20 @@ func SniffTLS(b []byte) (*SniffHeader, error) {
 	}
 
 	h := &SniffHeader{}
-	err := ReadClientHello(b[5:5+headerLen], h)
-	if err == nil {
-		return h, nil
+
+	return h, nil
+}
+
+func SniffDomainTLS(b []byte) (*SniffHeader, error) {
+	h, err := SniffProtocolTLS(b)
+	if err != nil {
+		return nil, err
 	}
-	return nil, err
+
+	headerLen := int(binary.BigEndian.Uint16(b[3:5]))
+	err = ReadClientHello(b[5:5+headerLen], h)
+	if err != nil {
+		return nil, err
+	}
+	return h, nil
 }

--- a/common/protocol/tls/sniff_test.go
+++ b/common/protocol/tls/sniff_test.go
@@ -144,7 +144,7 @@ func TestTLSHeaders(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		header, err := SniffTLS(test.input)
+		header, err := SniffDomainTLS(test.input)
 		if test.err {
 			if err == nil {
 				t.Errorf("Exepct error but nil in test %v", test)


### PR DESCRIPTION
v2fly/v2ray-core#406 may designed to quickly return result of FakeDNSSniffer only when metadataOnly true.

this is an opinion to ensure do not do domain sniff twice when metadataOnly false, as for v2fly/v2ray-core#697 

while on current process, domain sniff of FakeDNS makes nothing, it's simply duplicated.

same pull: xtls/xray-core#436 