### PR TITLE
fix QUIC disconnecting issue

### DIFF
--- a/transport/internet/quic/dialer.go
+++ b/transport/internet/quic/dialer.go
@@ -153,6 +153,7 @@ func (s *clientSessions) openConnection(destAddr net.Addr, config *Config, tlsCo
 		ConnectionIDLength:   12,
 		HandshakeIdleTimeout: time.Second * 8,
 		MaxIdleTimeout:       time.Second * 30,
+		KeepAlive:            true,
 	}
 
 	conn, err := wrapSysConn(rawConn, config)

--- a/transport/internet/quic/hub.go
+++ b/transport/internet/quic/hub.go
@@ -110,6 +110,7 @@ func Listen(ctx context.Context, address net.Address, port net.Port, streamSetti
 		MaxIdleTimeout:        time.Second * 45,
 		MaxIncomingStreams:    32,
 		MaxIncomingUniStreams: -1,
+		KeepAlive:             true,
 	}
 
 	conn, err := wrapSysConn(rawConn, config)


### PR DESCRIPTION
当前QUIC传输协议每30秒无数据传输就会断开连接，影响许多推送服务的稳定性，并造成一定的资源消耗。
解决方法很简单，协商参数中加上`KeepAlive:true`即可。