### PR TITLE
Fix: v2ray.location.asset env not working

### DIFF
--- a/app/router/condition_geoip_test.go
+++ b/app/router/condition_geoip_test.go
@@ -2,6 +2,7 @@ package router_test
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,8 +26,8 @@ func init() {
 
 	os.Setenv("v2ray.location.asset", tempPath)
 
-	if _, err := os.Stat(platform.GetAssetLocation("geoip.dat")); err != nil && errors.Is(err, os.ErrNotExist) {
-		if _, err := os.Stat(geoipPath); err != nil && errors.Is(err, os.ErrNotExist) {
+	if _, err := os.Stat(platform.GetAssetLocation("geoip.dat")); err != nil && errors.Is(err, fs.ErrNotExist) {
+		if _, err := os.Stat(geoipPath); err != nil && errors.Is(err, fs.ErrNotExist) {
 			common.Must(os.MkdirAll(tempPath, 0755))
 			geoipBytes, err := common.FetchHTTPContent(geoipURL)
 			common.Must(err)

--- a/app/router/condition_test.go
+++ b/app/router/condition_test.go
@@ -2,6 +2,7 @@ package router_test
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -32,8 +33,8 @@ func init() {
 
 	os.Setenv("v2ray.location.asset", tempPath)
 
-	if _, err := os.Stat(platform.GetAssetLocation("geoip.dat")); err != nil && errors.Is(err, os.ErrNotExist) {
-		if _, err := os.Stat(geoipPath); err != nil && errors.Is(err, os.ErrNotExist) {
+	if _, err := os.Stat(platform.GetAssetLocation("geoip.dat")); err != nil && errors.Is(err, fs.ErrNotExist) {
+		if _, err := os.Stat(geoipPath); err != nil && errors.Is(err, fs.ErrNotExist) {
 			common.Must(os.MkdirAll(tempPath, 0755))
 			geoipBytes, err := common.FetchHTTPContent(geoipURL)
 			common.Must(err)
@@ -41,8 +42,8 @@ func init() {
 		}
 	}
 
-	if _, err := os.Stat(platform.GetAssetLocation("geosite.dat")); err != nil && errors.Is(err, os.ErrNotExist) {
-		if _, err := os.Stat(geositePath); err != nil && errors.Is(err, os.ErrNotExist) {
+	if _, err := os.Stat(platform.GetAssetLocation("geosite.dat")); err != nil && errors.Is(err, fs.ErrNotExist) {
+		if _, err := os.Stat(geositePath); err != nil && errors.Is(err, fs.ErrNotExist) {
 			common.Must(os.MkdirAll(tempPath, 0755))
 			geositeBytes, err := common.FetchHTTPContent(geositeURL)
 			common.Must(err)

--- a/common/platform/others.go
+++ b/common/platform/others.go
@@ -4,6 +4,7 @@ package platform
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 )
@@ -33,7 +34,7 @@ func GetAssetLocation(file string) string {
 		filepath.Join("/usr/share/v2ray/", file),
 		filepath.Join("/opt/share/v2ray/", file),
 	} {
-		if _, err := os.Stat(p); err != nil && errors.Is(os.ErrNotExist, err) {
+		if _, err := os.Stat(p); err != nil && errors.Is(err, fs.ErrNotExist) {
 			continue
 		}
 

--- a/infra/conf/dns_test.go
+++ b/infra/conf/dns_test.go
@@ -3,6 +3,7 @@ package conf_test
 import (
 	"encoding/json"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,8 +28,8 @@ func init() {
 
 	os.Setenv("v2ray.location.asset", tempPath)
 
-	if _, err := os.Stat(platform.GetAssetLocation("geoip.dat")); err != nil && errors.Is(err, os.ErrNotExist) {
-		if _, err := os.Stat(geoipPath); err != nil && errors.Is(err, os.ErrNotExist) {
+	if _, err := os.Stat(platform.GetAssetLocation("geoip.dat")); err != nil && errors.Is(err, fs.ErrNotExist) {
+		if _, err := os.Stat(geoipPath); err != nil && errors.Is(err, fs.ErrNotExist) {
 			common.Must(os.MkdirAll(tempPath, 0755))
 			geoipBytes, err := common.FetchHTTPContent(geoipURL)
 			common.Must(err)
@@ -36,8 +37,8 @@ func init() {
 		}
 	}
 
-	if _, err := os.Stat(platform.GetAssetLocation("geosite.dat")); err != nil && errors.Is(err, os.ErrNotExist) {
-		if _, err := os.Stat(geositePath); err != nil && errors.Is(err, os.ErrNotExist) {
+	if _, err := os.Stat(platform.GetAssetLocation("geosite.dat")); err != nil && errors.Is(err, fs.ErrNotExist) {
+		if _, err := os.Stat(geositePath); err != nil && errors.Is(err, fs.ErrNotExist) {
 			common.Must(os.MkdirAll(tempPath, 0755))
 			geositeBytes, err := common.FetchHTTPContent(geositeURL)
 			common.Must(err)

--- a/infra/conf/router_test.go
+++ b/infra/conf/router_test.go
@@ -3,6 +3,7 @@ package conf_test
 import (
 	"encoding/json"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,8 +28,8 @@ func init() {
 
 	os.Setenv("v2ray.location.asset", tempPath)
 
-	if _, err := os.Stat(platform.GetAssetLocation("geoip.dat")); err != nil && errors.Is(err, os.ErrNotExist) {
-		if _, err := os.Stat(geoipPath); err != nil && errors.Is(err, os.ErrNotExist) {
+	if _, err := os.Stat(platform.GetAssetLocation("geoip.dat")); err != nil && errors.Is(err, fs.ErrNotExist) {
+		if _, err := os.Stat(geoipPath); err != nil && errors.Is(err, fs.ErrNotExist) {
 			common.Must(os.MkdirAll(tempPath, 0755))
 			geoipBytes, err := common.FetchHTTPContent(geoipURL)
 			common.Must(err)


### PR DESCRIPTION
PR #869 introduces a bug that leads to failure to read geo files paths from `v2ray.location.asset` environment variable.