### PR TITLE
Fix: return ErrEmptyResponse for fakedns

### DIFF
--- a/app/dns/nameserver_fakedns.go
+++ b/app/dns/nameserver_fakedns.go
@@ -8,6 +8,7 @@ import (
 	core "github.com/v2fly/v2ray-core/v4"
 	"github.com/v2fly/v2ray-core/v4/common/net"
 	"github.com/v2fly/v2ray-core/v4/features/dns"
+	dns_feature "github.com/v2fly/v2ray-core/v4/features/dns"
 )
 
 type FakeDNSServer struct {
@@ -44,5 +45,8 @@ func (f *FakeDNSServer) QueryIP(ctx context.Context, domain string, _ net.IP, op
 
 	newError(f.Name(), " got answer: ", domain, " -> ", ips).AtInfo().WriteToLog()
 
-	return netIP, nil
+	if len(netIP) > 0 {
+		return netIP, nil
+	}
+	return nil, dns_feature.ErrEmptyResponse
 }

--- a/app/dns/nameserver_fakedns.go
+++ b/app/dns/nameserver_fakedns.go
@@ -8,7 +8,6 @@ import (
 	core "github.com/v2fly/v2ray-core/v4"
 	"github.com/v2fly/v2ray-core/v4/common/net"
 	"github.com/v2fly/v2ray-core/v4/features/dns"
-	dns_feature "github.com/v2fly/v2ray-core/v4/features/dns"
 )
 
 type FakeDNSServer struct {
@@ -48,5 +47,5 @@ func (f *FakeDNSServer) QueryIP(ctx context.Context, domain string, _ net.IP, op
 	if len(netIP) > 0 {
 		return netIP, nil
 	}
-	return nil, dns_feature.ErrEmptyResponse
+	return nil, dns.ErrEmptyResponse
 }


### PR DESCRIPTION
fix https://github.com/v2fly/v2ray-core/issues/919#issuecomment-822294415

return ErrEmptyResponse when fakedns get 0 result