### PR TITLE
VMess Proposal AEAD Based Packet Length

### DIFF
--- a/common/drain/drain.go
+++ b/common/drain/drain.go
@@ -1,0 +1,10 @@
+package drain
+
+import "io"
+
+//go:generate go run github.com/v2fly/v2ray-core/v4/common/errors/errorgen
+
+type Drainer interface {
+	AcknowledgeReceive(size int)
+	Drain(reader io.Reader) error
+}

--- a/common/drain/drainer.go
+++ b/common/drain/drainer.go
@@ -1,0 +1,62 @@
+package drain
+
+import (
+	"io"
+	"io/ioutil"
+
+	"github.com/v2fly/v2ray-core/v4/common/dice"
+)
+
+type BehaviorSeedLimitedDrainer struct {
+	DrainSize int
+}
+
+func NewBehaviorSeedLimitedDrainer(behaviorSeed int64, drainFoundation, maxBaseDrainSize, maxRandDrain int) (Drainer, error) {
+	behaviorRand := dice.NewDeterministicDice(behaviorSeed)
+	BaseDrainSize := behaviorRand.Roll(maxBaseDrainSize)
+	RandDrainMax := behaviorRand.Roll(maxRandDrain) + 1
+	RandDrainRolled := dice.Roll(RandDrainMax)
+	DrainSize := drainFoundation + BaseDrainSize + RandDrainRolled
+	return &BehaviorSeedLimitedDrainer{DrainSize: DrainSize}, nil
+}
+
+func (d *BehaviorSeedLimitedDrainer) AcknowledgeReceive(size int) {
+	d.DrainSize -= size
+}
+
+func (d *BehaviorSeedLimitedDrainer) Drain(reader io.Reader) error {
+	if d.DrainSize > 0 {
+		err := drainReadN(reader, d.DrainSize)
+		if err == nil {
+			return newError("drained connection")
+		}
+		return newError("unable to drain connection").Base(err)
+	}
+	return nil
+}
+
+func drainReadN(reader io.Reader, n int) error {
+	_, err := io.CopyN(ioutil.Discard, reader, int64(n))
+	return err
+}
+
+func WithError(drainer Drainer, reader io.Reader, err error) error {
+	drainErr := drainer.Drain(reader)
+	if drainErr == nil {
+		return err
+	}
+	return newError(drainErr).Base(err)
+}
+
+type NopDrainer struct{}
+
+func (n NopDrainer) AcknowledgeReceive(size int) {
+}
+
+func (n NopDrainer) Drain(reader io.Reader) error {
+	return nil
+}
+
+func NewNopDrainer() Drainer {
+	return &NopDrainer{}
+}

--- a/common/drain/errors.generated.go
+++ b/common/drain/errors.generated.go
@@ -1,0 +1,9 @@
+package drain
+
+import "github.com/v2fly/v2ray-core/v4/common/errors"
+
+type errPathObjHolder struct{}
+
+func newError(values ...interface{}) *errors.Error {
+	return errors.New(values...).WithPathObj(errPathObjHolder{})
+}

--- a/common/protocol/headers.go
+++ b/common/protocol/headers.go
@@ -38,6 +38,8 @@ const (
 	RequestOptionChunkMasking bitmask.Byte = 0x04
 
 	RequestOptionGlobalPadding bitmask.Byte = 0x08
+
+	RequestOptionAuthenticatedLength bitmask.Byte = 0x10
 )
 
 type RequestHeader struct {

--- a/infra/conf/vmess.go
+++ b/infra/conf/vmess.go
@@ -14,9 +14,10 @@ import (
 )
 
 type VMessAccount struct {
-	ID       string `json:"id"`
-	AlterIds uint16 `json:"alterId"`
-	Security string `json:"security"`
+	ID          string `json:"id"`
+	AlterIds    uint16 `json:"alterId"`
+	Security    string `json:"security"`
+	Experiments string `json:"experiments"`
 }
 
 // Build implements Buildable
@@ -42,6 +43,7 @@ func (a *VMessAccount) Build() *vmess.Account {
 		SecuritySettings: &protocol.SecurityConfig{
 			Type: st,
 		},
+		TestsEnabled: a.Experiments,
 	}
 }
 

--- a/proxy/vmess/account.go
+++ b/proxy/vmess/account.go
@@ -3,6 +3,8 @@
 package vmess
 
 import (
+	"strings"
+
 	"github.com/v2fly/v2ray-core/v4/common/dice"
 	"github.com/v2fly/v2ray-core/v4/common/protocol"
 	"github.com/v2fly/v2ray-core/v4/common/uuid"
@@ -16,6 +18,8 @@ type MemoryAccount struct {
 	AlterIDs []*protocol.ID
 	// Security type of the account. Used for client connections.
 	Security protocol.SecurityType
+
+	AuthenticatedLengthExperiment bool
 }
 
 // AnyValidID returns an ID that is either the main ID or one of the alternative IDs if any.
@@ -43,9 +47,14 @@ func (a *Account) AsAccount() (protocol.Account, error) {
 		return nil, newError("failed to parse ID").Base(err).AtError()
 	}
 	protoID := protocol.NewID(id)
+	var AuthenticatedLength bool
+	if strings.Contains(a.TestsEnabled, "AuthenticatedLength") {
+		AuthenticatedLength = true
+	}
 	return &MemoryAccount{
-		ID:       protoID,
-		AlterIDs: protocol.NewAlterIDs(protoID, uint16(a.AlterId)),
-		Security: a.SecuritySettings.GetSecurityType(),
+		ID:                            protoID,
+		AlterIDs:                      protocol.NewAlterIDs(protoID, uint16(a.AlterId)),
+		Security:                      a.SecuritySettings.GetSecurityType(),
+		AuthenticatedLengthExperiment: AuthenticatedLength,
 	}, nil
 }

--- a/proxy/vmess/account.go
+++ b/proxy/vmess/account.go
@@ -20,6 +20,7 @@ type MemoryAccount struct {
 	Security protocol.SecurityType
 
 	AuthenticatedLengthExperiment bool
+	NoTerminationSignal           bool
 }
 
 // AnyValidID returns an ID that is either the main ID or one of the alternative IDs if any.
@@ -47,14 +48,18 @@ func (a *Account) AsAccount() (protocol.Account, error) {
 		return nil, newError("failed to parse ID").Base(err).AtError()
 	}
 	protoID := protocol.NewID(id)
-	var AuthenticatedLength bool
+	var AuthenticatedLength, NoTerminationSignal bool
 	if strings.Contains(a.TestsEnabled, "AuthenticatedLength") {
 		AuthenticatedLength = true
+	}
+	if strings.Contains(a.TestsEnabled, "NoTerminationSignal") {
+		NoTerminationSignal = true
 	}
 	return &MemoryAccount{
 		ID:                            protoID,
 		AlterIDs:                      protocol.NewAlterIDs(protoID, uint16(a.AlterId)),
 		Security:                      a.SecuritySettings.GetSecurityType(),
 		AuthenticatedLengthExperiment: AuthenticatedLength,
+		NoTerminationSignal:           NoTerminationSignal,
 	}, nil
 }

--- a/proxy/vmess/encoding/auth.go
+++ b/proxy/vmess/encoding/auth.go
@@ -5,6 +5,8 @@ import (
 	"encoding/binary"
 	"hash/fnv"
 
+	"github.com/v2fly/v2ray-core/v4/common/crypto"
+
 	"golang.org/x/crypto/sha3"
 
 	"github.com/v2fly/v2ray-core/v4/common"
@@ -116,4 +118,12 @@ func (s *ShakeSizeParser) NextPaddingLen() uint16 {
 
 func (s *ShakeSizeParser) MaxPaddingLen() uint16 {
 	return 64
+}
+
+type AEADSizeParser struct {
+	crypto.AEADChunkSizeParser
+}
+
+func NewAEADSizeParser(auth *crypto.AEADAuthenticator) *AEADSizeParser {
+	return &AEADSizeParser{crypto.AEADChunkSizeParser{Auth: auth}}
 }

--- a/proxy/vmess/encoding/encoding_test.go
+++ b/proxy/vmess/encoding/encoding_test.go
@@ -43,7 +43,7 @@ func TestRequestSerialization(t *testing.T) {
 	}
 
 	buffer := buf.New()
-	client := NewClientSession(context.TODO(), true, protocol.DefaultIDHash)
+	client := NewClientSession(context.TODO(), true, protocol.DefaultIDHash, 0)
 	common.Must(client.EncodeRequestHeader(expectedRequest, buffer))
 
 	buffer2 := buf.New()
@@ -93,7 +93,7 @@ func TestInvalidRequest(t *testing.T) {
 	}
 
 	buffer := buf.New()
-	client := NewClientSession(context.TODO(), true, protocol.DefaultIDHash)
+	client := NewClientSession(context.TODO(), true, protocol.DefaultIDHash, 0)
 	common.Must(client.EncodeRequestHeader(expectedRequest, buffer))
 
 	buffer2 := buf.New()
@@ -134,7 +134,7 @@ func TestMuxRequest(t *testing.T) {
 	}
 
 	buffer := buf.New()
-	client := NewClientSession(context.TODO(), true, protocol.DefaultIDHash)
+	client := NewClientSession(context.TODO(), true, protocol.DefaultIDHash, 0)
 	common.Must(client.EncodeRequestHeader(expectedRequest, buffer))
 
 	buffer2 := buf.New()

--- a/proxy/vmess/encoding/server.go
+++ b/proxy/vmess/encoding/server.go
@@ -360,6 +360,17 @@ func (s *ServerSession) DecodeRequestBody(request *protocol.RequestHeader, reade
 			NonceGenerator:          GenerateChunkNonce(s.requestBodyIV[:], uint32(aead.NonceSize())),
 			AdditionalDataGenerator: crypto.GenerateEmptyBytes(),
 		}
+		if request.Option.Has(protocol.RequestOptionAuthenticatedLength) {
+			AuthenticatedLengthKey := vmessaead.KDF16(s.requestBodyKey[:], "auth_len")
+			AuthenticatedLengthKeyAEAD := crypto.NewAesGcm(AuthenticatedLengthKey)
+
+			lengthAuth := &crypto.AEADAuthenticator{
+				AEAD:                    AuthenticatedLengthKeyAEAD,
+				NonceGenerator:          GenerateChunkNonce(s.requestBodyIV[:], uint32(aead.NonceSize())),
+				AdditionalDataGenerator: crypto.GenerateEmptyBytes(),
+			}
+			sizeParser = NewAEADSizeParser(lengthAuth)
+		}
 		return crypto.NewAuthenticationReader(auth, sizeParser, reader, request.Command.TransferType(), padding)
 
 	case protocol.SecurityType_CHACHA20_POLY1305:
@@ -369,6 +380,18 @@ func (s *ServerSession) DecodeRequestBody(request *protocol.RequestHeader, reade
 			AEAD:                    aead,
 			NonceGenerator:          GenerateChunkNonce(s.requestBodyIV[:], uint32(aead.NonceSize())),
 			AdditionalDataGenerator: crypto.GenerateEmptyBytes(),
+		}
+		if request.Option.Has(protocol.RequestOptionAuthenticatedLength) {
+			AuthenticatedLengthKey := vmessaead.KDF16(s.requestBodyKey[:], "auth_len")
+			AuthenticatedLengthKeyAEAD, err := chacha20poly1305.New(GenerateChacha20Poly1305Key(AuthenticatedLengthKey))
+			common.Must(err)
+
+			lengthAuth := &crypto.AEADAuthenticator{
+				AEAD:                    AuthenticatedLengthKeyAEAD,
+				NonceGenerator:          GenerateChunkNonce(s.requestBodyIV[:], uint32(aead.NonceSize())),
+				AdditionalDataGenerator: crypto.GenerateEmptyBytes(),
+			}
+			sizeParser = NewAEADSizeParser(lengthAuth)
 		}
 		return crypto.NewAuthenticationReader(auth, sizeParser, reader, request.Command.TransferType(), padding)
 
@@ -478,6 +501,17 @@ func (s *ServerSession) EncodeResponseBody(request *protocol.RequestHeader, writ
 			NonceGenerator:          GenerateChunkNonce(s.responseBodyIV[:], uint32(aead.NonceSize())),
 			AdditionalDataGenerator: crypto.GenerateEmptyBytes(),
 		}
+		if request.Option.Has(protocol.RequestOptionAuthenticatedLength) {
+			AuthenticatedLengthKey := vmessaead.KDF16(s.requestBodyKey[:], "auth_len")
+			AuthenticatedLengthKeyAEAD := crypto.NewAesGcm(AuthenticatedLengthKey)
+
+			lengthAuth := &crypto.AEADAuthenticator{
+				AEAD:                    AuthenticatedLengthKeyAEAD,
+				NonceGenerator:          GenerateChunkNonce(s.requestBodyIV[:], uint32(aead.NonceSize())),
+				AdditionalDataGenerator: crypto.GenerateEmptyBytes(),
+			}
+			sizeParser = NewAEADSizeParser(lengthAuth)
+		}
 		return crypto.NewAuthenticationWriter(auth, sizeParser, writer, request.Command.TransferType(), padding)
 
 	case protocol.SecurityType_CHACHA20_POLY1305:
@@ -487,6 +521,18 @@ func (s *ServerSession) EncodeResponseBody(request *protocol.RequestHeader, writ
 			AEAD:                    aead,
 			NonceGenerator:          GenerateChunkNonce(s.responseBodyIV[:], uint32(aead.NonceSize())),
 			AdditionalDataGenerator: crypto.GenerateEmptyBytes(),
+		}
+		if request.Option.Has(protocol.RequestOptionAuthenticatedLength) {
+			AuthenticatedLengthKey := vmessaead.KDF16(s.requestBodyKey[:], "auth_len")
+			AuthenticatedLengthKeyAEAD, err := chacha20poly1305.New(GenerateChacha20Poly1305Key(AuthenticatedLengthKey))
+			common.Must(err)
+
+			lengthAuth := &crypto.AEADAuthenticator{
+				AEAD:                    AuthenticatedLengthKeyAEAD,
+				NonceGenerator:          GenerateChunkNonce(s.requestBodyIV[:], uint32(aead.NonceSize())),
+				AdditionalDataGenerator: crypto.GenerateEmptyBytes(),
+			}
+			sizeParser = NewAEADSizeParser(lengthAuth)
 		}
 		return crypto.NewAuthenticationWriter(auth, sizeParser, writer, request.Command.TransferType(), padding)
 

--- a/proxy/vmess/inbound/inbound.go
+++ b/proxy/vmess/inbound/inbound.go
@@ -203,7 +203,9 @@ func transferResponse(timer signal.ActivityUpdater, session *encoding.ServerSess
 		return err
 	}
 
-	if request.Option.Has(protocol.RequestOptionChunkStream) {
+	account := request.User.Account.(*vmess.MemoryAccount)
+
+	if request.Option.Has(protocol.RequestOptionChunkStream) && !account.NoTerminationSignal {
 		if err := bodyWriter.WriteMultiBuffer(buf.MultiBuffer{}); err != nil {
 			return err
 		}

--- a/proxy/vmess/outbound/outbound.go
+++ b/proxy/vmess/outbound/outbound.go
@@ -155,7 +155,7 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 			return err
 		}
 
-		if request.Option.Has(protocol.RequestOptionChunkStream) {
+		if request.Option.Has(protocol.RequestOptionChunkStream) && !account.NoTerminationSignal {
 			if err := bodyWriter.WriteMultiBuffer(buf.MultiBuffer{}); err != nil {
 				return err
 			}

--- a/proxy/vmess/outbound/outbound.go
+++ b/proxy/vmess/outbound/outbound.go
@@ -116,6 +116,10 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 		request.Option.Clear(protocol.RequestOptionChunkMasking)
 	}
 
+	if account.AuthenticatedLengthExperiment {
+		request.Option.Set(protocol.RequestOptionAuthenticatedLength)
+	}
+
 	input := link.Reader
 	output := link.Writer
 

--- a/testing/scenarios/vmess_test.go
+++ b/testing/scenarios/vmess_test.go
@@ -1394,3 +1394,111 @@ func TestVMessGCMLengthAuth(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestVMessGCMLengthAuthPlusNoTerminationSignal(t *testing.T) {
+	tcpServer := tcp.Server{
+		MsgProcessor: xor,
+	}
+	dest, err := tcpServer.Start()
+	common.Must(err)
+	defer tcpServer.Close()
+
+	userID := protocol.NewID(uuid.New())
+	serverPort := tcp.PickPort()
+	serverConfig := &core.Config{
+		App: []*serial.TypedMessage{
+			serial.ToTypedMessage(&log.Config{
+				ErrorLogLevel: clog.Severity_Debug,
+				ErrorLogType:  log.LogType_Console,
+			}),
+		},
+		Inbound: []*core.InboundHandlerConfig{
+			{
+				ReceiverSettings: serial.ToTypedMessage(&proxyman.ReceiverConfig{
+					PortRange: net.SinglePortRange(serverPort),
+					Listen:    net.NewIPOrDomain(net.LocalHostIP),
+				}),
+				ProxySettings: serial.ToTypedMessage(&inbound.Config{
+					User: []*protocol.User{
+						{
+							Account: serial.ToTypedMessage(&vmess.Account{
+								Id:           userID.String(),
+								AlterId:      64,
+								TestsEnabled: "AuthenticatedLength|NoTerminationSignal",
+							}),
+						},
+					},
+				}),
+			},
+		},
+		Outbound: []*core.OutboundHandlerConfig{
+			{
+				ProxySettings: serial.ToTypedMessage(&freedom.Config{}),
+			},
+		},
+	}
+
+	clientPort := tcp.PickPort()
+	clientConfig := &core.Config{
+		App: []*serial.TypedMessage{
+			serial.ToTypedMessage(&log.Config{
+				ErrorLogLevel: clog.Severity_Debug,
+				ErrorLogType:  log.LogType_Console,
+			}),
+		},
+		Inbound: []*core.InboundHandlerConfig{
+			{
+				ReceiverSettings: serial.ToTypedMessage(&proxyman.ReceiverConfig{
+					PortRange: net.SinglePortRange(clientPort),
+					Listen:    net.NewIPOrDomain(net.LocalHostIP),
+				}),
+				ProxySettings: serial.ToTypedMessage(&dokodemo.Config{
+					Address: net.NewIPOrDomain(dest.Address),
+					Port:    uint32(dest.Port),
+					NetworkList: &net.NetworkList{
+						Network: []net.Network{net.Network_TCP},
+					},
+				}),
+			},
+		},
+		Outbound: []*core.OutboundHandlerConfig{
+			{
+				ProxySettings: serial.ToTypedMessage(&outbound.Config{
+					Receiver: []*protocol.ServerEndpoint{
+						{
+							Address: net.NewIPOrDomain(net.LocalHostIP),
+							Port:    uint32(serverPort),
+							User: []*protocol.User{
+								{
+									Account: serial.ToTypedMessage(&vmess.Account{
+										Id:      userID.String(),
+										AlterId: 64,
+										SecuritySettings: &protocol.SecurityConfig{
+											Type: protocol.SecurityType_AES128_GCM,
+										},
+										TestsEnabled: "AuthenticatedLength|NoTerminationSignal",
+									}),
+								},
+							},
+						},
+					},
+				}),
+			},
+		},
+	}
+
+	servers, err := InitializeServerConfigs(serverConfig, clientConfig)
+	if err != nil {
+		t.Fatal("Failed to initialize all servers: ", err.Error())
+	}
+	defer CloseAllServers(servers)
+
+	var errg errgroup.Group
+	for i := 0; i < 10; i++ {
+		errg.Go(testTCPConn(clientPort, 10240*1024, time.Second*40))
+	}
+
+	if err := errg.Wait(); err != nil {
+		t.Error(err)
+	}
+}

--- a/testing/scenarios/vmess_test.go
+++ b/testing/scenarios/vmess_test.go
@@ -1287,3 +1287,110 @@ func TestVMessZero(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestVMessGCMLengthAuth(t *testing.T) {
+	tcpServer := tcp.Server{
+		MsgProcessor: xor,
+	}
+	dest, err := tcpServer.Start()
+	common.Must(err)
+	defer tcpServer.Close()
+
+	userID := protocol.NewID(uuid.New())
+	serverPort := tcp.PickPort()
+	serverConfig := &core.Config{
+		App: []*serial.TypedMessage{
+			serial.ToTypedMessage(&log.Config{
+				ErrorLogLevel: clog.Severity_Debug,
+				ErrorLogType:  log.LogType_Console,
+			}),
+		},
+		Inbound: []*core.InboundHandlerConfig{
+			{
+				ReceiverSettings: serial.ToTypedMessage(&proxyman.ReceiverConfig{
+					PortRange: net.SinglePortRange(serverPort),
+					Listen:    net.NewIPOrDomain(net.LocalHostIP),
+				}),
+				ProxySettings: serial.ToTypedMessage(&inbound.Config{
+					User: []*protocol.User{
+						{
+							Account: serial.ToTypedMessage(&vmess.Account{
+								Id:      userID.String(),
+								AlterId: 64,
+							}),
+						},
+					},
+				}),
+			},
+		},
+		Outbound: []*core.OutboundHandlerConfig{
+			{
+				ProxySettings: serial.ToTypedMessage(&freedom.Config{}),
+			},
+		},
+	}
+
+	clientPort := tcp.PickPort()
+	clientConfig := &core.Config{
+		App: []*serial.TypedMessage{
+			serial.ToTypedMessage(&log.Config{
+				ErrorLogLevel: clog.Severity_Debug,
+				ErrorLogType:  log.LogType_Console,
+			}),
+		},
+		Inbound: []*core.InboundHandlerConfig{
+			{
+				ReceiverSettings: serial.ToTypedMessage(&proxyman.ReceiverConfig{
+					PortRange: net.SinglePortRange(clientPort),
+					Listen:    net.NewIPOrDomain(net.LocalHostIP),
+				}),
+				ProxySettings: serial.ToTypedMessage(&dokodemo.Config{
+					Address: net.NewIPOrDomain(dest.Address),
+					Port:    uint32(dest.Port),
+					NetworkList: &net.NetworkList{
+						Network: []net.Network{net.Network_TCP},
+					},
+				}),
+			},
+		},
+		Outbound: []*core.OutboundHandlerConfig{
+			{
+				ProxySettings: serial.ToTypedMessage(&outbound.Config{
+					Receiver: []*protocol.ServerEndpoint{
+						{
+							Address: net.NewIPOrDomain(net.LocalHostIP),
+							Port:    uint32(serverPort),
+							User: []*protocol.User{
+								{
+									Account: serial.ToTypedMessage(&vmess.Account{
+										Id:      userID.String(),
+										AlterId: 64,
+										SecuritySettings: &protocol.SecurityConfig{
+											Type: protocol.SecurityType_AES128_GCM,
+										},
+										TestsEnabled: "AuthenticatedLength",
+									}),
+								},
+							},
+						},
+					},
+				}),
+			},
+		},
+	}
+
+	servers, err := InitializeServerConfigs(serverConfig, clientConfig)
+	if err != nil {
+		t.Fatal("Failed to initialize all servers: ", err.Error())
+	}
+	defer CloseAllServers(servers)
+
+	var errg errgroup.Group
+	for i := 0; i < 10; i++ {
+		errg.Go(testTCPConn(clientPort, 10240*1024, time.Second*40))
+	}
+
+	if err := errg.Wait(); err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
Currently, the Packet Length of VMess is masked but unauthenticated.  This is not currently being used for attacking VMess based proxy, but could make it harder to diagnose issues in the other part of the project.
The design of the new AEAD Based Packet Length:
The previous Shake based packet length is replaced with:
Shadowsockets AEAD like AEAD Encrypted Length, with the key derived from traffic encryption key. The nonce for the AEAD Encrypted Length is same with the data key.

感谢 @rprx 提供的问题报告。