### PR TITLE
Infra: use customized goimports

### DIFF
--- a/format.go
+++ b/format.go
@@ -1,4 +1,4 @@
 package core
 
-//go:generate go install -v golang.org/x/tools/cmd/goimports@latest
+//go:generate go install -v github.com/v2fly/tools/cmd/goimports@latest
 //go:generate go run ./infra/vformat/

--- a/infra/vformat/main.go
+++ b/infra/vformat/main.go
@@ -154,7 +154,8 @@ func main() {
 		filename := filepath.Base(path)
 		if strings.HasSuffix(filename, ".go") &&
 			!strings.HasSuffix(filename, ".pb.go") &&
-			!strings.Contains(dir, filepath.Join("testing", "mocks")) {
+			!strings.Contains(dir, filepath.Join("testing", "mocks")) &&
+			!strings.Contains(path, filepath.Join("main", "distro", "all", "all.go")) {
 			rawFilesSlice = append(rawFilesSlice, path)
 		}
 
@@ -171,6 +172,7 @@ func main() {
 
 	goimportsArgs := []string{
 		"-w",
+		"-r",
 		"-local", "github.com/v2fly/v2ray-core",
 	}
 


### PR DESCRIPTION
Use customized `goimports` utility to remove empty lines in go `import` blocks