### PR TITLE
Fix: observatory starts with empty config & fails to close

### DIFF
--- a/app/observatory/observer.go
+++ b/app/observatory/observer.go
@@ -44,13 +44,18 @@ func (o *Observer) Type() interface{} {
 }
 
 func (o *Observer) Start() error {
-	o.finished = done.New()
-	go o.background()
+	if o.config != nil && len(o.config.SubjectSelector) != 0 {
+		o.finished = done.New()
+		go o.background()
+	}
 	return nil
 }
 
 func (o *Observer) Close() error {
-	return o.finished.Close()
+	if o.finished != nil {
+		return o.finished.Close()
+	}
+	return nil
 }
 
 func (o *Observer) background() {

--- a/infra/conf/observatory.go
+++ b/infra/conf/observatory.go
@@ -10,6 +10,6 @@ type ObservatoryConfig struct {
 	SubjectSelector []string `json:"subjectSelector"`
 }
 
-func (o ObservatoryConfig) Build() (proto.Message, error) {
+func (o *ObservatoryConfig) Build() (proto.Message, error) {
 	return &observatory.Config{SubjectSelector: o.SubjectSelector}, nil
 }


### PR DESCRIPTION
Fix following edge case:

```json
{
  "observatory": {}
}
```