### PR TITLE
Fix: GetAssetLocation for external geo files

### DIFF
--- a/common/platform/others.go
+++ b/common/platform/others.go
@@ -33,6 +33,7 @@ func GetAssetLocation(file string) string {
 		filepath.Join("/usr/local/share/v2ray/", file),
 		filepath.Join("/usr/share/v2ray/", file),
 		filepath.Join("/opt/share/v2ray/", file),
+		file,
 	} {
 		if _, err := os.Stat(p); err != nil && errors.Is(err, fs.ErrNotExist) {
 			continue

--- a/common/platform/windows.go
+++ b/common/platform/windows.go
@@ -2,7 +2,12 @@
 
 package platform
 
-import "path/filepath"
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
 
 func ExpandEnv(s string) string {
 	// TODO
@@ -23,5 +28,19 @@ func GetToolLocation(file string) string {
 func GetAssetLocation(file string) string {
 	const name = "v2ray.location.asset"
 	assetPath := NewEnvFlag(name).GetValue(getExecutableDir)
-	return filepath.Join(assetPath, file)
+	defPath := filepath.Join(assetPath, file)
+	for _, p := range []string{
+		defPath,
+		file,
+	} {
+		if _, err := os.Stat(p); err != nil && errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+
+		// asset found
+		return p
+	}
+
+	// asset not found, let the caller throw out the error
+	return defPath
 }


### PR DESCRIPTION
Fix `GetAssetLocation` method for external geo files like the following:

```
ext-ip:/path/to/your/customized/geoip.dat:cn
ext:/path/to/your/customized/geoip.dat:custom-cidr
ext:/path/to/your/customized/geosite.dat:custom-list
```