### PR TITLE
Chore: just build deb package on some cases to save space quota

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
       - v*
+    paths:
+      - ".github/workflows/deb.yml"
+      - "release/debian/*"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:


### PR DESCRIPTION
Just build debian package on push event after changing the following paths or files to save GitHub organization free space quota:

```
.github/workflows/deb.yml
release/debian/*
```