### PR TITLE
Fix: new cert issuing is incorrectly delayed

### DIFF
--- a/common/protocol/tls/cert/cert.go
+++ b/common/protocol/tls/cert/cert.go
@@ -142,7 +142,7 @@ func Generate(parent *Certificate, opts ...Option) (*Certificate, error) {
 	template := &x509.Certificate{
 		SerialNumber:          serialNumber,
 		NotBefore:             time.Now().Add(time.Hour * -1),
-		NotAfter:              time.Now().Add(time.Hour + time.Minute * 2),
+		NotAfter:              time.Now().Add(time.Hour + time.Minute*2),
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,

--- a/common/protocol/tls/cert/cert.go
+++ b/common/protocol/tls/cert/cert.go
@@ -142,7 +142,7 @@ func Generate(parent *Certificate, opts ...Option) (*Certificate, error) {
 	template := &x509.Certificate{
 		SerialNumber:          serialNumber,
 		NotBefore:             time.Now().Add(time.Hour * -1),
-		NotAfter:              time.Now().Add(time.Hour),
+		NotAfter:              time.Now().Add(time.Hour + time.Minute * 2),
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,

--- a/common/protocol/tls/cert/cert.go
+++ b/common/protocol/tls/cert/cert.go
@@ -142,7 +142,7 @@ func Generate(parent *Certificate, opts ...Option) (*Certificate, error) {
 	template := &x509.Certificate{
 		SerialNumber:          serialNumber,
 		NotBefore:             time.Now().Add(time.Hour * -1),
-		NotAfter:              time.Now().Add(time.Hour + time.Minute*2),
+		NotAfter:              time.Now().Add(time.Hour),
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,

--- a/transport/internet/tls/config.go
+++ b/transport/internet/tls/config.go
@@ -69,7 +69,7 @@ func isCertificateExpired(c *tls.Certificate) bool {
 	}
 
 	// If leaf is not there, the certificate is probably not used yet. We trust user to provide a valid certificate.
-	return c.Leaf != nil && c.Leaf.NotAfter.Before(time.Now().Add(time.Minute * 2))
+	return c.Leaf != nil && c.Leaf.NotAfter.Before(time.Now().Add(time.Minute*2))
 }
 
 func issueCertificate(rawCA *Certificate, domain string) (*tls.Certificate, error) {

--- a/transport/internet/tls/config.go
+++ b/transport/internet/tls/config.go
@@ -69,7 +69,7 @@ func isCertificateExpired(c *tls.Certificate) bool {
 	}
 
 	// If leaf is not there, the certificate is probably not used yet. We trust user to provide a valid certificate.
-	return c.Leaf != nil && c.Leaf.NotAfter.Before(time.Now().Add(-time.Minute))
+	return c.Leaf != nil && c.Leaf.NotAfter.Before(time.Now().Add(time.Minute * 2))
 }
 
 func issueCertificate(rawCA *Certificate, domain string) (*tls.Certificate, error) {

--- a/transport/internet/tls/config.go
+++ b/transport/internet/tls/config.go
@@ -122,11 +122,9 @@ func getGetCertificateFunc(c *tls.Config, ca []*Certificate) func(hello *tls.Cli
 				cert := certificate
 				if !isCertificateExpired(&cert) {
 					newCerts = append(newCerts, cert)
-				} else {
-					if cert.Leaf != nil {
-						expTime := cert.Leaf.NotAfter.Format(time.RFC3339)
-						newError("old certificate for ", domain, " (expire on ", expTime, ") revoked").AtInfo().WriteToLog()
-					}
+				} else if cert.Leaf != nil {
+					expTime := cert.Leaf.NotAfter.Format(time.RFC3339)
+					newError("old certificate for ", domain, " (expire on ", expTime, ") revoked").AtInfo().WriteToLog()
 				}
 			}
 


### PR DESCRIPTION
Fix #997 
P.S. 因为VMess协议允许Server/Client的时间误差为90s，因此为了保证在该时间误差下生成的证书依旧可用，我将生成证书的提前时间从1分钟增加为2分钟。同时将证书的有效期也延长为1小时2分钟，这样在大量连接的情况下，证书生成间隔为约整1小时，便于从日志中找出相关问题。