### PR TITLE
Add support for merging/overwriting routing configurations when using multiple config files

### DIFF
--- a/infra/conf/v2ray.go
+++ b/infra/conf/v2ray.go
@@ -390,9 +390,6 @@ func (c *Config) Override(o *Config, fn string) {
 	if o.LogConfig != nil {
 		c.LogConfig = o.LogConfig
 	}
-	if o.RouterConfig != nil {
-		c.RouterConfig = o.RouterConfig
-	}
 	if o.DNSConfig != nil {
 		c.DNSConfig = o.DNSConfig
 	}
@@ -471,6 +468,25 @@ func (c *Config) Override(o *Config, fn string) {
 			}
 		} else {
 			c.OutboundConfigs = o.OutboundConfigs
+		}
+	}
+
+	if o.RouterConfig != nil {
+		if c.RouterConfig != nil {
+			if len(o.RouterConfig.RuleList) > 0 {
+				c.RouterConfig.RuleList = append(c.RouterConfig.RuleList, o.RouterConfig.RuleList...)
+			}
+			if o.RouterConfig.DomainStrategy != nil {
+				c.RouterConfig.DomainStrategy = o.RouterConfig.DomainStrategy
+			}
+			if len(o.RouterConfig.Balancers) > 0 {
+				c.RouterConfig.Balancers = append(c.RouterConfig.Balancers, o.RouterConfig.Balancers...)
+			}
+			if o.RouterConfig.DomainMatcher != "" {
+				c.RouterConfig.DomainMatcher = o.RouterConfig.DomainMatcher
+			}
+		} else {
+			c.RouterConfig = o.RouterConfig
 		}
 	}
 }


### PR DESCRIPTION
If multiple config files are specified in the command line, the routing configurations will be overwritten in current implementation.

This is not flexible. For example, I have different routing rules for office and home use, but they also have common part, so I have routings_common.json, routings_home.json and routings_office.json. At office I use `-c routings_common.json -c routings_office.json` while at home I use `-c routings_common.json -c routings_home.json`. This wont work since the previous one will be overwritten. This PR can solve this problem.