### PR TITLE
fix: routing rule not applied for DNS Server in TCP:// schema

### DIFF
--- a/app/dns/nameserver_tcp.go
+++ b/app/dns/nameserver_tcp.go
@@ -82,7 +82,7 @@ func baseTCPNameServer(url *url.URL, prefix string) (*TCPNameServer, error) {
 			return nil, err
 		}
 	}
-	dest := net.TCPDestination(net.DomainAddress(url.Hostname()), port)
+	dest := net.TCPDestination(net.ParseAddress(url.Hostname()), port)
 
 	s := &TCPNameServer{
 		destination: dest,


### PR DESCRIPTION
This PR should fix the problem that routing rule is not applied for DNS Server in TCP:// schema. Related Issue: #1143 

### Root cause

```
dest := net.TCPDestination(net.DomainAddress(url.Hostname()), port)
```

The `AddressFamily` for the  `Address` in `dest` here is actually a Domain. During Router's `PickRoute` process, it will match against the **domain** list of the router rule, not the IP list, so the routing rule with IP addresses will never be applied.

### Fix

use `net.ParseAddress` instead, it will return the right type automatically.(Although the address here is supposed to be IP address).

