### PR TITLE
fix: dnscommon cache expired within ttl preferred

### DIFF
--- a/app/dns/dnscommon.go
+++ b/app/dns/dnscommon.go
@@ -193,13 +193,9 @@ L:
 			break
 		}
 
-		ttl := ah.TTL
-		if ttl == 0 {
-			ttl = 600
-		}
-		expire := now.Add(time.Duration(ttl) * time.Second)
-		if ipRecord.Expire.After(expire) {
-			ipRecord.Expire = expire
+		// keeps ttl preferred
+		if ttl := ah.TTL; ttl > 0 {
+			ipRecord.Expire = now.Add(time.Duration(ttl) * time.Second)
 		}
 
 		switch ah.Type {


### PR DESCRIPTION
this provides a behavior that ipRecord made by app/dns/dnscommon.parseResponse follows the expired time within ah.TTL always.

the current behavior: within const 600 seconds except  ah.TTL < 600 seconds.