### PR TITLE
fix: dns cache with empty response

### DIFF
--- a/app/dns/dnscommon.go
+++ b/app/dns/dnscommon.go
@@ -213,7 +213,7 @@ L:
 		case dnsmessage.TypeAAAA:
 			ans, err := parser.AAAAResource()
 			if err != nil {
-				newError("failed to parse A record for domain: ", ah.Name).Base(err).WriteToLog()
+				newError("failed to parse AAAA record for domain: ", ah.Name).Base(err).WriteToLog()
 				break L
 			}
 			ipRecord.IP = append(ipRecord.IP, net.IPAddress(ans.AAAA[:]))

--- a/app/dns/dnscommon.go
+++ b/app/dns/dnscommon.go
@@ -205,14 +205,14 @@ L:
 		switch ah.Type {
 		case dnsmessage.TypeA:
 			ans, err := parser.AResource()
-			if err != nil {
+			if err != nil || len(ans.A) == 0 {
 				newError("failed to parse A record for domain: ", ah.Name).Base(err).WriteToLog()
 				break L
 			}
 			ipRecord.IP = append(ipRecord.IP, net.IPAddress(ans.A[:]))
 		case dnsmessage.TypeAAAA:
 			ans, err := parser.AAAAResource()
-			if err != nil {
+			if err != nil || len(ans.AAAA) == 0 {
 				newError("failed to parse AAAA record for domain: ", ah.Name).Base(err).WriteToLog()
 				break L
 			}

--- a/app/dns/dnscommon.go
+++ b/app/dns/dnscommon.go
@@ -205,14 +205,14 @@ L:
 		switch ah.Type {
 		case dnsmessage.TypeA:
 			ans, err := parser.AResource()
-			if err != nil || len(ans.A) == 0 {
+			if err != nil {
 				newError("failed to parse A record for domain: ", ah.Name).Base(err).WriteToLog()
 				break L
 			}
 			ipRecord.IP = append(ipRecord.IP, net.IPAddress(ans.A[:]))
 		case dnsmessage.TypeAAAA:
 			ans, err := parser.AAAAResource()
-			if err != nil || len(ans.AAAA) == 0 {
+			if err != nil {
 				newError("failed to parse AAAA record for domain: ", ah.Name).Base(err).WriteToLog()
 				break L
 			}

--- a/app/dns/nameserver_doh.go
+++ b/app/dns/nameserver_doh.go
@@ -177,7 +177,7 @@ func (s *DoHNameServer) updateIP(req *dnsRequest, ipRec *IPRecord) {
 
 	switch req.reqType {
 	case dnsmessage.TypeA:
-		if isNewer(rec.A, ipRec) {
+		if rec.A == nil || isNewer(rec.A, ipRec) {
 			rec.A = ipRec
 			updated = true
 		}
@@ -189,7 +189,7 @@ func (s *DoHNameServer) updateIP(req *dnsRequest, ipRec *IPRecord) {
 			}
 		}
 		ipRec.IP = addr
-		if isNewer(rec.AAAA, ipRec) {
+		if rec.AAAA == nil || isNewer(rec.AAAA, ipRec) {
 			rec.AAAA = ipRec
 			updated = true
 		}

--- a/app/dns/nameserver_doh.go
+++ b/app/dns/nameserver_doh.go
@@ -177,7 +177,7 @@ func (s *DoHNameServer) updateIP(req *dnsRequest, ipRec *IPRecord) {
 
 	switch req.reqType {
 	case dnsmessage.TypeA:
-		if rec.A == nil || isNewer(rec.A, ipRec) {
+		if isNewer(rec.A, ipRec) {
 			rec.A = ipRec
 			updated = true
 		}
@@ -189,7 +189,7 @@ func (s *DoHNameServer) updateIP(req *dnsRequest, ipRec *IPRecord) {
 			}
 		}
 		ipRec.IP = addr
-		if rec.AAAA == nil || isNewer(rec.AAAA, ipRec) {
+		if isNewer(rec.AAAA, ipRec) {
 			rec.AAAA = ipRec
 			updated = true
 		}

--- a/app/dns/nameserver_doh.go
+++ b/app/dns/nameserver_doh.go
@@ -140,10 +140,10 @@ func (s *DoHNameServer) Cleanup() error {
 	}
 
 	for domain, record := range s.ips {
-		if len(record.A.IP) == 0 {
+		if record.A != nil && len(record.A.IP) == 0 {
 			record.A = nil
 		}
-		if len(record.AAAA.IP) == 0 {
+		if record.AAAA != nil && len(record.AAAA.IP) == 0 {
 			record.AAAA = nil
 		}
 

--- a/app/dns/nameserver_doh.go
+++ b/app/dns/nameserver_doh.go
@@ -140,6 +140,13 @@ func (s *DoHNameServer) Cleanup() error {
 	}
 
 	for domain, record := range s.ips {
+		if len(record.A.IP) == 0 {
+			record.A = nil
+		}
+		if len(record.AAAA.IP) == 0 {
+			record.AAAA = nil
+		}
+
 		if record.A != nil && record.A.Expire.Before(now) {
 			record.A = nil
 		}

--- a/app/dns/nameserver_doh.go
+++ b/app/dns/nameserver_doh.go
@@ -169,7 +169,10 @@ func (s *DoHNameServer) updateIP(req *dnsRequest, ipRec *IPRecord) {
 	elapsed := time.Since(req.start)
 
 	s.Lock()
-	rec := s.ips[req.domain]
+	rec, found := s.ips[req.domain]
+	if !found {
+		rec = record{}
+	}
 	updated := false
 
 	switch req.reqType {

--- a/app/dns/nameserver_doh.go
+++ b/app/dns/nameserver_doh.go
@@ -196,7 +196,7 @@ func (s *DoHNameServer) updateIP(req *dnsRequest, ipRec *IPRecord) {
 	}
 	newError(s.name, " got answer: ", req.domain, " ", req.reqType, " -> ", ipRec.IP, " ", elapsed).AtInfo().WriteToLog()
 
-	if updated {
+	if updated && len(ipRec.IP) > 0 {
 		s.ips[req.domain] = rec
 	}
 	switch req.reqType {

--- a/app/dns/nameserver_doh.go
+++ b/app/dns/nameserver_doh.go
@@ -32,7 +32,7 @@ import (
 // thus most of the DOH implementation is copied from udpns.go
 type DoHNameServer struct {
 	sync.RWMutex
-	ips        map[string]record
+	ips        map[string]*record
 	pub        *pubsub.Service
 	cleanup    *task.Periodic
 	reqID      uint32
@@ -112,7 +112,7 @@ func NewDoHLocalNameServer(url *url.URL) *DoHNameServer {
 
 func baseDOHNameServer(url *url.URL, prefix string) *DoHNameServer {
 	s := &DoHNameServer{
-		ips:    make(map[string]record),
+		ips:    make(map[string]*record),
 		pub:    pubsub.NewService(),
 		name:   prefix + "//" + url.Host,
 		dohURL: url.String(),
@@ -140,13 +140,6 @@ func (s *DoHNameServer) Cleanup() error {
 	}
 
 	for domain, record := range s.ips {
-		if record.A != nil && len(record.A.IP) == 0 {
-			record.A = nil
-		}
-		if record.AAAA != nil && len(record.AAAA.IP) == 0 {
-			record.AAAA = nil
-		}
-
 		if record.A != nil && record.A.Expire.Before(now) {
 			record.A = nil
 		}
@@ -162,6 +155,10 @@ func (s *DoHNameServer) Cleanup() error {
 		}
 	}
 
+	if len(s.ips) == 0 {
+		s.ips = make(map[string]*record)
+	}
+
 	return nil
 }
 
@@ -171,7 +168,7 @@ func (s *DoHNameServer) updateIP(req *dnsRequest, ipRec *IPRecord) {
 	s.Lock()
 	rec, found := s.ips[req.domain]
 	if !found {
-		rec = record{}
+		rec = &record{}
 	}
 	updated := false
 
@@ -182,7 +179,7 @@ func (s *DoHNameServer) updateIP(req *dnsRequest, ipRec *IPRecord) {
 			updated = true
 		}
 	case dnsmessage.TypeAAAA:
-		addr := make([]net.Address, 0)
+		addr := make([]net.Address, 0, len(ipRec.IP))
 		for _, ip := range ipRec.IP {
 			if len(ip.IP()) == net.IPv6len {
 				addr = append(addr, ip)
@@ -196,7 +193,7 @@ func (s *DoHNameServer) updateIP(req *dnsRequest, ipRec *IPRecord) {
 	}
 	newError(s.name, " got answer: ", req.domain, " ", req.reqType, " -> ", ipRec.IP, " ", elapsed).AtInfo().WriteToLog()
 
-	if updated && len(ipRec.IP) > 0 {
+	if updated {
 		s.ips[req.domain] = rec
 	}
 	switch req.reqType {
@@ -301,34 +298,30 @@ func (s *DoHNameServer) findIPsForDomain(domain string, option dns_feature.IPOpt
 		return nil, errRecordNotFound
 	}
 
+	var err4 error
+	var err6 error
 	var ips []net.Address
-	var lastErr error
-	if option.IPv6Enable && record.AAAA != nil && record.AAAA.RCode == dnsmessage.RCodeSuccess {
-		aaaa, err := record.AAAA.getIPs()
-		if err != nil {
-			lastErr = err
-		}
-		ips = append(ips, aaaa...)
-	}
+	var ip6 []net.Address
 
-	if option.IPv4Enable && record.A != nil && record.A.RCode == dnsmessage.RCodeSuccess {
-		a, err := record.A.getIPs()
-		if err != nil {
-			lastErr = err
-		}
-		ips = append(ips, a...)
+	switch {
+	case option.IPv4Enable:
+		ips, err4 = record.A.getIPs()
+		fallthrough
+	case option.IPv6Enable:
+		ip6, err6 = record.AAAA.getIPs()
+		ips = append(ips, ip6...)
 	}
 
 	if len(ips) > 0 {
 		return toNetIP(ips)
 	}
 
-	if lastErr != nil {
-		return nil, lastErr
+	if err4 != nil {
+		return nil, err4
 	}
 
-	if (option.IPv4Enable && record.A != nil) || (option.IPv6Enable && record.AAAA != nil) {
-		return nil, dns_feature.ErrEmptyResponse
+	if err6 != nil {
+		return nil, err6
 	}
 
 	return nil, errRecordNotFound

--- a/app/dns/nameserver_doh.go
+++ b/app/dns/nameserver_doh.go
@@ -162,10 +162,6 @@ func (s *DoHNameServer) Cleanup() error {
 		}
 	}
 
-	if len(s.ips) == 0 {
-		s.ips = make(map[string]record)
-	}
-
 	return nil
 }
 

--- a/app/dns/nameserver_tcp.go
+++ b/app/dns/nameserver_tcp.go
@@ -29,8 +29,8 @@ import (
 type TCPNameServer struct {
 	sync.RWMutex
 	name        string
-	destination net.Destination
-	ips         map[string]record
+	destination *net.Destination
+	ips         map[string]*record
 	pub         *pubsub.Service
 	cleanup     *task.Periodic
 	reqID       uint32
@@ -45,7 +45,7 @@ func NewTCPNameServer(url *url.URL, dispatcher routing.Dispatcher) (*TCPNameServ
 	}
 
 	s.dial = func(ctx context.Context) (net.Conn, error) {
-		link, err := dispatcher.Dispatch(ctx, s.destination)
+		link, err := dispatcher.Dispatch(ctx, *s.destination)
 		if err != nil {
 			return nil, err
 		}
@@ -67,7 +67,7 @@ func NewTCPLocalNameServer(url *url.URL) (*TCPNameServer, error) {
 	}
 
 	s.dial = func(ctx context.Context) (net.Conn, error) {
-		return internet.DialSystem(ctx, s.destination, nil)
+		return internet.DialSystem(ctx, *s.destination, nil)
 	}
 
 	return s, nil
@@ -85,8 +85,8 @@ func baseTCPNameServer(url *url.URL, prefix string) (*TCPNameServer, error) {
 	dest := net.TCPDestination(net.ParseAddress(url.Hostname()), port)
 
 	s := &TCPNameServer{
-		destination: dest,
-		ips:         make(map[string]record),
+		destination: &dest,
+		ips:         make(map[string]*record),
 		pub:         pubsub.NewService(),
 		name:        prefix + "//" + dest.NetAddr(),
 	}
@@ -114,13 +114,6 @@ func (s *TCPNameServer) Cleanup() error {
 	}
 
 	for domain, record := range s.ips {
-		if record.A != nil && len(record.A.IP) == 0 {
-			record.A = nil
-		}
-		if record.AAAA != nil && len(record.AAAA.IP) == 0 {
-			record.AAAA = nil
-		}
-
 		if record.A != nil && record.A.Expire.Before(now) {
 			record.A = nil
 		}
@@ -136,6 +129,10 @@ func (s *TCPNameServer) Cleanup() error {
 		}
 	}
 
+	if len(s.ips) == 0 {
+		s.ips = make(map[string]*record)
+	}
+
 	return nil
 }
 
@@ -145,7 +142,7 @@ func (s *TCPNameServer) updateIP(req *dnsRequest, ipRec *IPRecord) {
 	s.Lock()
 	rec, found := s.ips[req.domain]
 	if !found {
-		rec = record{}
+		rec = &record{}
 	}
 	updated := false
 
@@ -170,7 +167,7 @@ func (s *TCPNameServer) updateIP(req *dnsRequest, ipRec *IPRecord) {
 	}
 	newError(s.name, " got answer: ", req.domain, " ", req.reqType, " -> ", ipRec.IP, " ", elapsed).AtInfo().WriteToLog()
 
-	if updated && len(ipRec.IP) > 0 {
+	if updated {
 		s.ips[req.domain] = rec
 	}
 	switch req.reqType {
@@ -280,30 +277,30 @@ func (s *TCPNameServer) findIPsForDomain(domain string, option dns_feature.IPOpt
 		return nil, errRecordNotFound
 	}
 
+	var err4 error
+	var err6 error
 	var ips []net.Address
-	var lastErr error
-	if option.IPv4Enable {
-		a, err := record.A.getIPs()
-		if err != nil {
-			lastErr = err
-		}
-		ips = append(ips, a...)
-	}
+	var ip6 []net.Address
 
-	if option.IPv6Enable {
-		aaaa, err := record.AAAA.getIPs()
-		if err != nil {
-			lastErr = err
-		}
-		ips = append(ips, aaaa...)
+	switch {
+	case option.IPv4Enable:
+		ips, err4 = record.A.getIPs()
+		fallthrough
+	case option.IPv6Enable:
+		ip6, err6 = record.AAAA.getIPs()
+		ips = append(ips, ip6...)
 	}
 
 	if len(ips) > 0 {
 		return toNetIP(ips)
 	}
 
-	if lastErr != nil {
-		return nil, lastErr
+	if err4 != nil {
+		return nil, err4
+	}
+
+	if err6 != nil {
+		return nil, err6
 	}
 
 	return nil, dns_feature.ErrEmptyResponse

--- a/app/dns/nameserver_tcp.go
+++ b/app/dns/nameserver_tcp.go
@@ -170,7 +170,7 @@ func (s *TCPNameServer) updateIP(req *dnsRequest, ipRec *IPRecord) {
 	}
 	newError(s.name, " got answer: ", req.domain, " ", req.reqType, " -> ", ipRec.IP, " ", elapsed).AtInfo().WriteToLog()
 
-	if updated && len(ipRec) > 0 {
+	if updated && len(ipRec.IP) > 0 {
 		s.ips[req.domain] = rec
 	}
 	switch req.reqType {

--- a/app/dns/nameserver_udp.go
+++ b/app/dns/nameserver_udp.go
@@ -28,9 +28,9 @@ import (
 type ClassicNameServer struct {
 	sync.RWMutex
 	name      string
-	address   net.Destination
-	ips       map[string]record
-	requests  map[uint16]dnsRequest
+	address   *net.Destination
+	ips       map[string]*record
+	requests  map[uint16]*dnsRequest
 	pub       *pubsub.Service
 	udpServer *udp.Dispatcher
 	cleanup   *task.Periodic
@@ -45,9 +45,9 @@ func NewClassicNameServer(address net.Destination, dispatcher routing.Dispatcher
 	}
 
 	s := &ClassicNameServer{
-		address:  address,
-		ips:      make(map[string]record),
-		requests: make(map[uint16]dnsRequest),
+		address:  &address,
+		ips:      make(map[string]*record),
+		requests: make(map[uint16]*dnsRequest),
 		pub:      pubsub.NewService(),
 		name:     strings.ToUpper(address.String()),
 	}
@@ -76,13 +76,6 @@ func (s *ClassicNameServer) Cleanup() error {
 	}
 
 	for domain, record := range s.ips {
-		if record.A != nil && len(record.A.IP) == 0 {
-			record.A = nil
-		}
-		if record.AAAA != nil && len(record.AAAA.IP) == 0 {
-			record.AAAA = nil
-		}
-
 		if record.A != nil && record.A.Expire.Before(now) {
 			record.A = nil
 		}
@@ -91,10 +84,15 @@ func (s *ClassicNameServer) Cleanup() error {
 		}
 
 		if record.A == nil && record.AAAA == nil {
+			newError(s.name, " cleanup ", domain).AtDebug().WriteToLog()
 			delete(s.ips, domain)
 		} else {
 			s.ips[domain] = record
 		}
+	}
+
+	if len(s.ips) == 0 {
+		s.ips = make(map[string]*record)
 	}
 
 	for id, req := range s.requests {
@@ -104,7 +102,7 @@ func (s *ClassicNameServer) Cleanup() error {
 	}
 
 	if len(s.requests) == 0 {
-		s.requests = make(map[uint16]dnsRequest)
+		s.requests = make(map[uint16]*dnsRequest)
 	}
 
 	return nil
@@ -142,16 +140,16 @@ func (s *ClassicNameServer) HandleResponse(ctx context.Context, packet *udp_prot
 	elapsed := time.Since(req.start)
 	newError(s.name, " got answer: ", req.domain, " ", req.reqType, " -> ", ipRec.IP, " ", elapsed).AtInfo().WriteToLog()
 	if len(req.domain) > 0 && (rec.A != nil || rec.AAAA != nil) {
-		s.updateIP(req.domain, rec)
+		s.updateIP(req.domain, &rec)
 	}
 }
 
-func (s *ClassicNameServer) updateIP(domain string, newRec record) {
+func (s *ClassicNameServer) updateIP(domain string, newRec *record) {
 	s.Lock()
 
 	rec, found := s.ips[domain]
 	if !found {
-		rec = record{}
+		rec = &record{}
 	}
 
 	updated := false
@@ -164,7 +162,7 @@ func (s *ClassicNameServer) updateIP(domain string, newRec record) {
 		updated = true
 	}
 
-	if updated && ((newRec.A != nil && len(newRec.A.IP) > 0) || (newRec.AAAA != nil && len(newRec.AAAA.IP) > 0)) {
+	if updated {
 		newError(s.name, " updating IP records for domain:", domain).AtDebug().WriteToLog()
 		s.ips[domain] = rec
 	}
@@ -188,7 +186,7 @@ func (s *ClassicNameServer) addPendingRequest(req *dnsRequest) {
 
 	id := req.msg.ID
 	req.expire = time.Now().Add(time.Second * 8)
-	s.requests[id] = *req
+	s.requests[id] = req
 }
 
 func (s *ClassicNameServer) sendQuery(ctx context.Context, domain string, clientIP net.IP, option dns_feature.IPOption) {
@@ -206,7 +204,7 @@ func (s *ClassicNameServer) sendQuery(ctx context.Context, domain string, client
 		udpCtx = session.ContextWithContent(udpCtx, &session.Content{
 			Protocol: "dns",
 		})
-		s.udpServer.Dispatch(udpCtx, s.address, b)
+		s.udpServer.Dispatch(udpCtx, *s.address, b)
 	}
 }
 
@@ -219,30 +217,30 @@ func (s *ClassicNameServer) findIPsForDomain(domain string, option dns_feature.I
 		return nil, errRecordNotFound
 	}
 
+	var err4 error
+	var err6 error
 	var ips []net.Address
-	var lastErr error
-	if option.IPv4Enable {
-		a, err := record.A.getIPs()
-		if err != nil {
-			lastErr = err
-		}
-		ips = append(ips, a...)
-	}
+	var ip6 []net.Address
 
-	if option.IPv6Enable {
-		aaaa, err := record.AAAA.getIPs()
-		if err != nil {
-			lastErr = err
-		}
-		ips = append(ips, aaaa...)
+	switch {
+	case option.IPv4Enable:
+		ips, err4 = record.A.getIPs()
+		fallthrough
+	case option.IPv6Enable:
+		ip6, err6 = record.AAAA.getIPs()
+		ips = append(ips, ip6...)
 	}
 
 	if len(ips) > 0 {
 		return toNetIP(ips)
 	}
 
-	if lastErr != nil {
-		return nil, lastErr
+	if err4 != nil {
+		return nil, err4
+	}
+
+	if err6 != nil {
+		return nil, err6
 	}
 
 	return nil, dns_feature.ErrEmptyResponse

--- a/app/dns/nameserver_udp.go
+++ b/app/dns/nameserver_udp.go
@@ -149,7 +149,6 @@ func (s *ClassicNameServer) HandleResponse(ctx context.Context, packet *udp_prot
 func (s *ClassicNameServer) updateIP(domain string, newRec record) {
 	s.Lock()
 
-	newError(s.name, " updating IP records for domain:", domain).AtDebug().WriteToLog()
 	rec, found := s.ips[domain]
 	if !found {
 		rec = record{}
@@ -166,6 +165,7 @@ func (s *ClassicNameServer) updateIP(domain string, newRec record) {
 	}
 
 	if updated && ((newRec.A != nil && len(newRec.A.IP) > 0) || (newRec.AAAA != nil && len(newRec.AAAA.IP) > 0)) {
+		newError(s.name, " updating IP records for domain:", domain).AtDebug().WriteToLog()
 		s.ips[domain] = rec
 	}
 	if newRec.A != nil {

--- a/app/dns/nameserver_udp.go
+++ b/app/dns/nameserver_udp.go
@@ -76,6 +76,13 @@ func (s *ClassicNameServer) Cleanup() error {
 	}
 
 	for domain, record := range s.ips {
+		if record.A != nil && len(record.A.IP) == 0 {
+			record.A = nil
+		}
+		if record.AAAA != nil && len(record.AAAA.IP) == 0 {
+			record.AAAA = nil
+		}
+
 		if record.A != nil && record.A.Expire.Before(now) {
 			record.A = nil
 		}
@@ -88,10 +95,6 @@ func (s *ClassicNameServer) Cleanup() error {
 		} else {
 			s.ips[domain] = record
 		}
-	}
-
-	if len(s.ips) == 0 {
-		s.ips = make(map[string]record)
 	}
 
 	for id, req := range s.requests {
@@ -147,7 +150,10 @@ func (s *ClassicNameServer) updateIP(domain string, newRec record) {
 	s.Lock()
 
 	newError(s.name, " updating IP records for domain:", domain).AtDebug().WriteToLog()
-	rec := s.ips[domain]
+	rec, found := s.ips[domain]
+	if !found {
+		rec = record{}
+	}
 
 	updated := false
 	if isNewer(rec.A, newRec.A) {
@@ -159,7 +165,7 @@ func (s *ClassicNameServer) updateIP(domain string, newRec record) {
 		updated = true
 	}
 
-	if updated {
+	if updated && len(newRec.IP) > 0 {
 		s.ips[domain] = rec
 	}
 	if newRec.A != nil {

--- a/app/dns/nameserver_udp.go
+++ b/app/dns/nameserver_udp.go
@@ -165,7 +165,7 @@ func (s *ClassicNameServer) updateIP(domain string, newRec record) {
 		updated = true
 	}
 
-	if updated && len(newRec.IP) > 0 {
+	if updated && (len(newRec.A.IP) > 0 || len(newRec.AAAA.IP) > 0) {
 		s.ips[domain] = rec
 	}
 	if newRec.A != nil {

--- a/app/dns/nameserver_udp.go
+++ b/app/dns/nameserver_udp.go
@@ -165,7 +165,7 @@ func (s *ClassicNameServer) updateIP(domain string, newRec record) {
 		updated = true
 	}
 
-	if updated && (len(newRec.A.IP) > 0 || len(newRec.AAAA.IP) > 0) {
+	if updated && ((newRec.A != nil && len(newRec.A.IP) > 0) || (newRec.AAAA != nil && len(newRec.AAAA.IP) > 0)) {
 		s.ips[domain] = rec
 	}
 	if newRec.A != nil {


### PR DESCRIPTION
this provides a fix that the dns app won't do cache with the IPRecord with a empty address (len(rec.IP == 0)).

```
[v2ray] [Info] v2ray.com/core/app/dns: DOHL//dns.google got answer: x.xxx. TypeA -> []
[v2ray] [Info] v2ray.com/core/app/dns: DOHL//dns.google cache HIT x.xxx -> [] > empty response
```

extensive review is expected @xiaokangwang 