### PR TITLE
Fix: routing cannot route DNS over QUIC with IP

### DIFF
--- a/app/dns/nameserver_quic.go
+++ b/app/dns/nameserver_quic.go
@@ -55,7 +55,7 @@ func NewQUICNameServer(url *url.URL) (*QUICNameServer, error) {
 			return nil, err
 		}
 	}
-	dest := net.UDPDestination(net.DomainAddress(url.Hostname()), port)
+	dest := net.UDPDestination(net.ParseAddress(url.Hostname()), port)
 
 	s := &QUICNameServer{
 		ips:         make(map[string]*record),


### PR DESCRIPTION
This Pull Request is inspired by #1144.
I think routing may cannot route DNS over QUIC with IP Address.
Because AdGuard DNS is the only Public DNS that supported DNS over QUIC, and it not supported SNI with IP Address, so I didn't test it.