### PR TITLE
Chore: add trimmed geoip-only-cn-private.dat to package

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Download geo files
         run: |
           wget -O release/config/geoip.dat "https://raw.githubusercontent.com/v2fly/geoip/release/geoip.dat"
+          wget -O release/config/geoip-only-cn-private.dat "https://raw.githubusercontent.com/v2fly/geoip/release/geoip-only-cn-private.dat"
           wget -O release/config/geosite.dat "https://raw.githubusercontent.com/v2fly/domain-list-community/release/dlc.dat"
 
       - name: Install build dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,7 @@ jobs:
       - name: Download geo files
         run: |
           wget -O release/config/geoip.dat "https://raw.githubusercontent.com/v2fly/geoip/release/geoip.dat"
+          wget -O release/config/geoip-only-cn-private.dat "https://raw.githubusercontent.com/v2fly/geoip/release/geoip-only-cn-private.dat"
           wget -O release/config/geosite.dat "https://raw.githubusercontent.com/v2fly/domain-list-community/release/dlc.dat"
 
       - name: Prepare package


### PR DESCRIPTION
This size-reduced dat file `geoip-only-cn-private.dat` only includes `geoip:cn` and `geoip:private` list, which is suitable for ROM/RAM insufficient devices.

Use it in V2Ray like this:

- `ext:geoip-only-cn-private.dat:cn`
- `ext:geoip-only-cn-private.dat:private`