### PR TITLE
Draft : Endpoint independent mapping support

### DIFF
--- a/app/commander/outbound.go
+++ b/app/commander/outbound.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/v2fly/v2ray-core/v4/common"
+	"github.com/v2fly/v2ray-core/v4/common/buf"
 	"github.com/v2fly/v2ray-core/v4/common/net"
 	"github.com/v2fly/v2ray-core/v4/common/signal/done"
 	"github.com/v2fly/v2ray-core/v4/transport"
@@ -82,7 +83,7 @@ func (co *Outbound) Dispatch(ctx context.Context, link *transport.Link) {
 	}
 
 	closeSignal := done.New()
-	c := net.NewConnection(net.ConnectionInputMulti(link.Writer), net.ConnectionOutputMulti(link.Reader), net.ConnectionOnClose(closeSignal))
+	c := buf.NewConnection(buf.ConnectionInputMulti(link.Writer), buf.ConnectionOutputMulti(link.Reader), buf.ConnectionOnClose(closeSignal))
 	co.listener.add(c)
 	co.access.RUnlock()
 	<-closeSignal.Wait()

--- a/app/dns/nameserver_doh.go
+++ b/app/dns/nameserver_doh.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/net/dns/dnsmessage"
 
 	"github.com/v2fly/v2ray-core/v4/common"
+	"github.com/v2fly/v2ray-core/v4/common/buf"
 	"github.com/v2fly/v2ray-core/v4/common/net"
 	"github.com/v2fly/v2ray-core/v4/common/protocol/dns"
 	"github.com/v2fly/v2ray-core/v4/common/session"
@@ -68,9 +69,9 @@ func NewDoHNameServer(url *url.URL, dispatcher routing.Dispatcher) (*DoHNameServ
 			if err != nil {
 				return nil, err
 			}
-			return net.NewConnection(
-				net.ConnectionInputMulti(link.Writer),
-				net.ConnectionOutputMulti(link.Reader),
+			return buf.NewConnection(
+				buf.ConnectionInputMulti(link.Writer),
+				buf.ConnectionOutputMulti(link.Reader),
 			), nil
 		},
 	}

--- a/app/dns/nameserver_tcp.go
+++ b/app/dns/nameserver_tcp.go
@@ -51,9 +51,9 @@ func NewTCPNameServer(url *url.URL, dispatcher routing.Dispatcher) (*TCPNameServ
 			return nil, err
 		}
 
-		return net.NewConnection(
-			net.ConnectionInputMulti(link.Writer),
-			net.ConnectionOutputMulti(link.Reader),
+		return buf.NewConnection(
+			buf.ConnectionInputMulti(link.Writer),
+			buf.ConnectionOutputMulti(link.Reader),
 		), nil
 	}
 

--- a/app/proxyman/outbound/handler.go
+++ b/app/proxyman/outbound/handler.go
@@ -6,6 +6,7 @@ import (
 	core "github.com/v2fly/v2ray-core/v4"
 	"github.com/v2fly/v2ray-core/v4/app/proxyman"
 	"github.com/v2fly/v2ray-core/v4/common"
+	"github.com/v2fly/v2ray-core/v4/common/buf"
 	"github.com/v2fly/v2ray-core/v4/common/mux"
 	"github.com/v2fly/v2ray-core/v4/common/net"
 	"github.com/v2fly/v2ray-core/v4/common/session"
@@ -178,7 +179,7 @@ func (h *Handler) Dial(ctx context.Context, dest net.Destination) (internet.Conn
 				downlinkReader, downlinkWriter := pipe.New(opts...)
 
 				go handler.Dispatch(ctx, &transport.Link{Reader: uplinkReader, Writer: downlinkWriter})
-				conn := net.NewConnection(net.ConnectionInputMulti(uplinkWriter), net.ConnectionOutputMulti(downlinkReader))
+				conn := buf.NewConnection(buf.ConnectionInputMulti(uplinkWriter), buf.ConnectionOutputMulti(downlinkReader))
 
 				if config := tls.ConfigFromStreamSettings(h.streamSettings); config != nil {
 					tlsConfig := config.GetTLSConfig(tls.WithDestination(dest))

--- a/common/buf/buffer.go
+++ b/common/buf/buffer.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/v2fly/v2ray-core/v4/common/bytespool"
+	"github.com/v2fly/v2ray-core/v4/common/net"
 )
 
 const (
@@ -17,9 +18,10 @@ var pool = bytespool.GetPool(Size)
 // the buffer into an internal buffer pool, in order to recreate a buffer more
 // quickly.
 type Buffer struct {
-	v     []byte
-	start int32
-	end   int32
+	v        []byte
+	start    int32
+	end      int32
+	Endpoint *net.Destination
 }
 
 // New creates a Buffer with 0 length and 2K capacity.

--- a/functions.go
+++ b/functions.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/v2fly/v2ray-core/v4/common"
+	"github.com/v2fly/v2ray-core/v4/common/buf"
 	"github.com/v2fly/v2ray-core/v4/common/net"
 	"github.com/v2fly/v2ray-core/v4/features/routing"
 	"github.com/v2fly/v2ray-core/v4/transport/internet/udp"
@@ -59,13 +60,13 @@ func Dial(ctx context.Context, v *Instance, dest net.Destination) (net.Conn, err
 	if err != nil {
 		return nil, err
 	}
-	var readerOpt net.ConnectionOption
+	var readerOpt buf.ConnectionOption
 	if dest.Network == net.Network_TCP {
-		readerOpt = net.ConnectionOutputMulti(r.Reader)
+		readerOpt = buf.ConnectionOutputMulti(r.Reader)
 	} else {
-		readerOpt = net.ConnectionOutputMultiUDP(r.Reader)
+		readerOpt = buf.ConnectionOutputMultiUDP(r.Reader)
 	}
-	return net.NewConnection(net.ConnectionInputMulti(r.Writer), readerOpt), nil
+	return buf.NewConnection(buf.ConnectionInputMulti(r.Writer), readerOpt), nil
 }
 
 // DialUDP provides a way to exchange UDP packets through V2Ray instance to remote servers.

--- a/proxy/loopback/loopback.go
+++ b/proxy/loopback/loopback.go
@@ -55,14 +55,14 @@ func (l *Loopback) Process(ctx context.Context, link *transport.Link, _ internet
 			return err
 		}
 
-		var readerOpt net.ConnectionOption
+		var readerOpt buf.ConnectionOption
 		if dialDest.Network == net.Network_TCP {
-			readerOpt = net.ConnectionOutputMulti(rawConn.Reader)
+			readerOpt = buf.ConnectionOutputMulti(rawConn.Reader)
 		} else {
-			readerOpt = net.ConnectionOutputMultiUDP(rawConn.Reader)
+			readerOpt = buf.ConnectionOutputMultiUDP(rawConn.Reader)
 		}
 
-		conn = net.NewConnection(net.ConnectionInputMulti(rawConn.Writer), readerOpt)
+		conn = buf.NewConnection(buf.ConnectionInputMulti(rawConn.Writer), readerOpt)
 		return nil
 	})
 	if err != nil {

--- a/proxy/shadowsocks/client.go
+++ b/proxy/shadowsocks/client.go
@@ -137,10 +137,10 @@ func (c *Client) Process(ctx context.Context, link *transport.Link, dialer inter
 	}
 
 	if request.Command == protocol.RequestCommandUDP {
-		writer := &buf.SequentialWriter{Writer: &UDPWriter{
+		writer := &UDPWriter{
 			Writer:  conn,
 			Request: request,
-		}}
+		}
 
 		requestDone := func() error {
 			defer timer.SetTimeout(sessionPolicy.Timeouts.DownlinkOnly)

--- a/proxy/socks/client.go
+++ b/proxy/socks/client.go
@@ -141,7 +141,7 @@ func (c *Client) Process(ctx context.Context, link *transport.Link, dialer inter
 		defer udpConn.Close()
 		requestFunc = func() error {
 			defer timer.SetTimeout(p.Timeouts.DownlinkOnly)
-			return buf.Copy(link.Reader, &buf.SequentialWriter{Writer: NewUDPWriter(request, udpConn)}, buf.UpdateActivity(timer))
+			return buf.Copy(link.Reader, NewUDPWriter(request, udpConn), buf.UpdateActivity(timer))
 		}
 		responseFunc = func() error {
 			defer timer.SetTimeout(p.Timeouts.UplinkOnly)

--- a/proxy/socks/protocol_test.go
+++ b/proxy/socks/protocol_test.go
@@ -20,7 +20,7 @@ func TestUDPEncoding(t *testing.T) {
 		Address: net.IPAddress([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6}),
 		Port:    1024,
 	}
-	writer := &buf.SequentialWriter{Writer: NewUDPWriter(request, b)}
+	writer := NewUDPWriter(request, b)
 
 	content := []byte{'a'}
 	payload := buf.New()

--- a/proxy/trojan/protocol.go
+++ b/proxy/trojan/protocol.go
@@ -100,31 +100,29 @@ type PacketWriter struct {
 
 // WriteMultiBuffer implements buf.Writer
 func (w *PacketWriter) WriteMultiBuffer(mb buf.MultiBuffer) error {
-	b := make([]byte, maxLength)
-	for !mb.IsEmpty() {
-		var length int
-		mb, length = buf.SplitBytes(mb, b)
-		if _, err := w.writePacket(b[:length], w.Target); err != nil {
+	for _, buffer := range mb {
+		var target net.Destination
+		if buffer.Endpoint != nil {
+			target = *buffer.Endpoint
+		} else {
+			target = w.Target
+		}
+		if _, err := w.writePacket(buffer.Bytes(), target); err != nil {
 			buf.ReleaseMulti(mb)
 			return err
 		}
 	}
-
 	return nil
 }
 
 // WriteMultiBufferWithMetadata writes udp packet with destination specified
 func (w *PacketWriter) WriteMultiBufferWithMetadata(mb buf.MultiBuffer, dest net.Destination) error {
-	b := make([]byte, maxLength)
-	for !mb.IsEmpty() {
-		var length int
-		mb, length = buf.SplitBytes(mb, b)
-		if _, err := w.writePacket(b[:length], dest); err != nil {
+	for _, buffer := range mb {
+		if _, err := w.writePacket(buffer.Bytes(), dest); err != nil {
 			buf.ReleaseMulti(mb)
 			return err
 		}
 	}
-
 	return nil
 }
 
@@ -267,6 +265,7 @@ func (r *PacketReader) ReadMultiBufferWithMetadata() (*PacketPayload, error) {
 		}
 
 		b := buf.New()
+		b.Endpoint = &dest
 		mb = append(mb, b)
 		n, err := b.ReadFullFrom(r, int32(length))
 		if err != nil {

--- a/transport/internet/http/dialer.go
+++ b/transport/internet/http/dialer.go
@@ -147,10 +147,10 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 
 	bwriter := buf.NewBufferedWriter(pwriter)
 	common.Must(bwriter.SetBuffered(false))
-	return net.NewConnection(
-		net.ConnectionOutput(response.Body),
-		net.ConnectionInput(bwriter),
-		net.ConnectionOnClose(common.ChainedClosable{breader, bwriter, response.Body}),
+	return buf.NewConnection(
+		buf.ConnectionOutput(response.Body),
+		buf.ConnectionInput(bwriter),
+		buf.ConnectionOnClose(common.ChainedClosable{breader, bwriter, response.Body}),
 	), nil
 }
 

--- a/transport/internet/http/hub.go
+++ b/transport/internet/http/hub.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/net/http2/h2c"
 
 	"github.com/v2fly/v2ray-core/v4/common"
+	"github.com/v2fly/v2ray-core/v4/common/buf"
 	"github.com/v2fly/v2ray-core/v4/common/net"
 	http_proto "github.com/v2fly/v2ray-core/v4/common/protocol/http"
 	"github.com/v2fly/v2ray-core/v4/common/serial"
@@ -104,12 +105,12 @@ func (l *Listener) ServeHTTP(writer http.ResponseWriter, request *http.Request) 
 	}
 
 	done := done.New()
-	conn := net.NewConnection(
-		net.ConnectionOutput(request.Body),
-		net.ConnectionInput(flushWriter{w: writer, d: done}),
-		net.ConnectionOnClose(common.ChainedClosable{done, request.Body}),
-		net.ConnectionLocalAddr(l.Addr()),
-		net.ConnectionRemoteAddr(remoteAddr),
+	conn := buf.NewConnection(
+		buf.ConnectionOutput(request.Body),
+		buf.ConnectionInput(flushWriter{w: writer, d: done}),
+		buf.ConnectionOnClose(common.ChainedClosable{done, request.Body}),
+		buf.ConnectionLocalAddr(l.Addr()),
+		buf.ConnectionRemoteAddr(remoteAddr),
 	)
 	l.handler(conn)
 	<-done.Wait()

--- a/transport/internet/system_dialer.go
+++ b/transport/internet/system_dialer.go
@@ -58,9 +58,9 @@ func (d *DefaultSystemDialer) Dial(ctx context.Context, src net.Address, dest ne
 		if err != nil {
 			return nil, err
 		}
-		return &packetConnWrapper{
-			conn: packetConn,
-			dest: destAddr,
+		return &PacketConnWrapper{
+			Conn: packetConn,
+			Dest: destAddr,
 		}, nil
 	}
 
@@ -95,42 +95,50 @@ func (d *DefaultSystemDialer) Dial(ctx context.Context, src net.Address, dest ne
 	return dialer.DialContext(ctx, dest.Network.SystemString(), dest.NetAddr())
 }
 
-type packetConnWrapper struct {
-	conn net.PacketConn
-	dest net.Addr
+type PacketConnWrapper struct {
+	Conn net.PacketConn
+	Dest net.Addr
 }
 
-func (c *packetConnWrapper) Close() error {
-	return c.conn.Close()
+func (c *PacketConnWrapper) Close() error {
+	return c.Conn.Close()
 }
 
-func (c *packetConnWrapper) LocalAddr() net.Addr {
-	return c.conn.LocalAddr()
+func (c *PacketConnWrapper) LocalAddr() net.Addr {
+	return c.Conn.LocalAddr()
 }
 
-func (c *packetConnWrapper) RemoteAddr() net.Addr {
-	return c.dest
+func (c *PacketConnWrapper) RemoteAddr() net.Addr {
+	return c.Dest
 }
 
-func (c *packetConnWrapper) Write(p []byte) (int, error) {
-	return c.conn.WriteTo(p, c.dest)
+func (c *PacketConnWrapper) Write(p []byte) (int, error) {
+	return c.Conn.WriteTo(p, c.Dest)
 }
 
-func (c *packetConnWrapper) Read(p []byte) (int, error) {
-	n, _, err := c.conn.ReadFrom(p)
+func (c *PacketConnWrapper) Read(p []byte) (int, error) {
+	n, _, err := c.Conn.ReadFrom(p)
 	return n, err
 }
 
-func (c *packetConnWrapper) SetDeadline(t time.Time) error {
-	return c.conn.SetDeadline(t)
+func (c *PacketConnWrapper) WriteTo(p []byte, d net.Addr) (int, error) {
+	return c.Conn.WriteTo(p, d)
 }
 
-func (c *packetConnWrapper) SetReadDeadline(t time.Time) error {
-	return c.conn.SetReadDeadline(t)
+func (c *PacketConnWrapper) ReadFrom(p []byte) (int, net.Addr, error) {
+	return c.Conn.ReadFrom(p)
 }
 
-func (c *packetConnWrapper) SetWriteDeadline(t time.Time) error {
-	return c.conn.SetWriteDeadline(t)
+func (c *PacketConnWrapper) SetDeadline(t time.Time) error {
+	return c.Conn.SetDeadline(t)
+}
+
+func (c *PacketConnWrapper) SetReadDeadline(t time.Time) error {
+	return c.Conn.SetReadDeadline(t)
+}
+
+func (c *PacketConnWrapper) SetWriteDeadline(t time.Time) error {
+	return c.Conn.SetWriteDeadline(t)
 }
 
 type SystemDialerAdapter interface {

--- a/transport/internet/tagged/taggedimpl/impl.go
+++ b/transport/internet/tagged/taggedimpl/impl.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	core "github.com/v2fly/v2ray-core/v4"
+	"github.com/v2fly/v2ray-core/v4/common/buf"
 	"github.com/v2fly/v2ray-core/v4/common/net"
 	"github.com/v2fly/v2ray-core/v4/common/session"
 	"github.com/v2fly/v2ray-core/v4/features/routing"
@@ -34,13 +35,13 @@ func DialTaggedOutbound(ctx context.Context, dest net.Destination, tag string) (
 	if err != nil {
 		return nil, err
 	}
-	var readerOpt net.ConnectionOption
+	var readerOpt buf.ConnectionOption
 	if dest.Network == net.Network_TCP {
-		readerOpt = net.ConnectionOutputMulti(r.Reader)
+		readerOpt = buf.ConnectionOutputMulti(r.Reader)
 	} else {
-		readerOpt = net.ConnectionOutputMultiUDP(r.Reader)
+		readerOpt = buf.ConnectionOutputMultiUDP(r.Reader)
 	}
-	return net.NewConnection(net.ConnectionInputMulti(r.Writer), readerOpt), nil
+	return buf.NewConnection(buf.ConnectionInputMulti(r.Writer), readerOpt), nil
 }
 
 func init() {

--- a/transport/internet/udp/dispatcher.go
+++ b/transport/internet/udp/dispatcher.go
@@ -6,12 +6,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/v2fly/v2ray-core/v4/common"
 	"github.com/v2fly/v2ray-core/v4/common/buf"
 	"github.com/v2fly/v2ray-core/v4/common/net"
 	"github.com/v2fly/v2ray-core/v4/common/protocol/udp"
 	"github.com/v2fly/v2ray-core/v4/common/session"
-	"github.com/v2fly/v2ray-core/v4/common/signal"
 	"github.com/v2fly/v2ray-core/v4/common/signal/done"
 	"github.com/v2fly/v2ray-core/v4/features/routing"
 	"github.com/v2fly/v2ray-core/v4/transport"
@@ -21,32 +19,21 @@ type ResponseCallback func(ctx context.Context, packet *udp.Packet)
 
 type connEntry struct {
 	link   *transport.Link
-	timer  signal.ActivityUpdater
+	ctx    context.Context
 	cancel context.CancelFunc
 }
 
 type Dispatcher struct {
 	sync.RWMutex
-	conns      map[net.Destination]*connEntry
+	conn       *connEntry
 	dispatcher routing.Dispatcher
 	callback   ResponseCallback
 }
 
 func NewDispatcher(dispatcher routing.Dispatcher, callback ResponseCallback) *Dispatcher {
 	return &Dispatcher{
-		conns:      make(map[net.Destination]*connEntry),
 		dispatcher: dispatcher,
 		callback:   callback,
-	}
-}
-
-func (v *Dispatcher) RemoveRay(dest net.Destination) {
-	v.Lock()
-	defer v.Unlock()
-	if conn, found := v.conns[dest]; found {
-		common.Close(conn.link.Reader)
-		common.Close(conn.link.Writer)
-		delete(v.conns, dest)
 	}
 }
 
@@ -54,38 +41,35 @@ func (v *Dispatcher) getInboundRay(ctx context.Context, dest net.Destination) *c
 	v.Lock()
 	defer v.Unlock()
 
-	if entry, found := v.conns[dest]; found {
-		return entry
+	if v.conn != nil {
+		select {
+		case <-v.conn.ctx.Done():
+			v.conn = nil
+		default:
+			return v.conn
+		}
 	}
 
 	newError("establishing new connection for ", dest).WriteToLog()
 
 	ctx, cancel := context.WithCancel(ctx)
-	removeRay := func() {
-		cancel()
-		v.RemoveRay(dest)
-	}
-	timer := signal.CancelAfterInactivity(ctx, removeRay, time.Second*4)
 	link, _ := v.dispatcher.Dispatch(ctx, dest)
 	entry := &connEntry{
 		link:   link,
-		timer:  timer,
-		cancel: removeRay,
+		ctx:    ctx,
+		cancel: cancel,
 	}
-	v.conns[dest] = entry
+	v.conn = entry
 	go handleInput(ctx, entry, dest, v.callback)
 	return entry
 }
 
 func (v *Dispatcher) Dispatch(ctx context.Context, destination net.Destination, payload *buf.Buffer) {
-	// TODO: Add user to destString
-	newError("dispatch request to: ", destination).AtDebug().WriteToLog(session.ExportIDToError(ctx))
-
 	conn := v.getInboundRay(ctx, destination)
 	outputStream := conn.link.Writer
 	if outputStream != nil {
 		if err := outputStream.WriteMultiBuffer(buf.MultiBuffer{payload}); err != nil {
-			newError("failed to write first UDP payload").Base(err).WriteToLog(session.ExportIDToError(ctx))
+			newError("write udp failed").Base(err).WriteToLog(session.ExportIDToError(ctx))
 			conn.cancel()
 			return
 		}
@@ -94,9 +78,7 @@ func (v *Dispatcher) Dispatch(ctx context.Context, destination net.Destination, 
 
 func handleInput(ctx context.Context, conn *connEntry, dest net.Destination, callback ResponseCallback) {
 	defer conn.cancel()
-
 	input := conn.link.Reader
-	timer := conn.timer
 
 	for {
 		select {
@@ -107,20 +89,27 @@ func handleInput(ctx context.Context, conn *connEntry, dest net.Destination, cal
 
 		mb, err := input.ReadMultiBuffer()
 		if err != nil {
-			newError("failed to handle UDP input").Base(err).WriteToLog(session.ExportIDToError(ctx))
+			buf.ReleaseMulti(mb)
+			newError("udp connection closed").Base(err).WriteToLog(session.ExportIDToError(ctx))
 			return
 		}
-		timer.Update()
 		for _, b := range mb {
-			callback(ctx, &udp.Packet{
+			packet := udp.Packet{
 				Payload: b,
 				Source:  dest,
-			})
+			}
+			if b.Endpoint == nil {
+				packet.Source = dest
+			} else {
+				packet.Source = *b.Endpoint
+			}
+			callback(ctx, &packet)
 		}
 	}
 }
 
 type dispatcherConn struct {
+	ctx        context.Context
 	dispatcher *Dispatcher
 	cache      chan *udp.Packet
 	done       *done.Instance
@@ -128,6 +117,7 @@ type dispatcherConn struct {
 
 func DialDispatcher(ctx context.Context, dispatcher routing.Dispatcher) (net.PacketConn, error) {
 	c := &dispatcherConn{
+		ctx:   ctx,
 		cache: make(chan *udp.Packet, 16),
 		done:  done.New(),
 	}
@@ -168,8 +158,9 @@ func (c *dispatcherConn) WriteTo(p []byte, addr net.Addr) (int, error) {
 	n := copy(raw, p)
 	buffer.Resize(0, int32(n))
 
-	ctx := context.Background()
-	c.dispatcher.Dispatch(ctx, net.DestinationFromAddr(addr), buffer)
+	endpoint := net.DestinationFromAddr(addr)
+	buffer.Endpoint = &endpoint
+	c.dispatcher.Dispatch(c.ctx, endpoint, buffer)
 	return n, nil
 }
 


### PR DESCRIPTION
Problem: v2ray-core does not return the UDP Packet source correctly, and causes broken mapping behavior.

This is a simple fix, shadowsocks and socks have been tested, and v*ess and mux.cool are not supported.

Other changes:
Fixed behavior of core.DialUDP
Package modified for the file connections.go due the circular package import
Exported `packetConnWrapper` so that custom system dialer can handle UDP connections correctly