### PR TITLE
Fix TCP Keep-Alive (initial) interval.

### DIFF
--- a/transport/internet/sockopt_darwin.go
+++ b/transport/internet/sockopt_darwin.go
@@ -25,6 +25,10 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 				return err
 			}
 		}
+
+		if err := enableKeepAlive(fd, config.GetTcpKeepAliveInterval()); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -42,6 +46,10 @@ func applyInboundSocketOptions(network string, fd uintptr, config *SocketConfig)
 				return err
 			}
 		}
+
+		if err := enableKeepAlive(fd, config.GetTcpKeepAliveInterval()); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -56,5 +64,22 @@ func setReuseAddr(fd uintptr) error {
 }
 
 func setReusePort(fd uintptr) error {
+	return nil
+}
+
+func enableKeepAlive(fd uintptr, TcpKeepAliveInterval int32) error {
+	if TcpKeepAliveInterval >= 0 {
+		if TcpKeepAliveInterval == 0 {
+			// Default timeout is 10 minutes.
+			TcpKeepAliveInterval = 600
+		}
+		if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_KEEPALIVE, 1); err != nil {
+			return newError("failed to set SO_KEEPALIVE", err)
+		}
+		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPALIVE, int(TcpKeepAliveInterval)); err != nil {
+			return newError("failed to set TCP_KEEPALIVE", err)
+		}
+	}
+
 	return nil
 }

--- a/transport/internet/sockopt_darwin.go
+++ b/transport/internet/sockopt_darwin.go
@@ -67,16 +67,16 @@ func setReusePort(fd uintptr) error {
 	return nil
 }
 
-func enableKeepAlive(fd uintptr, TcpKeepAliveInterval int32) error {
-	if TcpKeepAliveInterval >= 0 {
-		if TcpKeepAliveInterval == 0 {
+func enableKeepAlive(fd uintptr, tcpKeepAliveInterval int32) error {
+	if tcpKeepAliveInterval >= 0 {
+		if tcpKeepAliveInterval == 0 {
 			// Default timeout is 10 minutes.
-			TcpKeepAliveInterval = 600
+			tcpKeepAliveInterval = 600
 		}
 		if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_KEEPALIVE, 1); err != nil {
 			return newError("failed to set SO_KEEPALIVE", err)
 		}
-		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPALIVE, int(TcpKeepAliveInterval)); err != nil {
+		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPALIVE, int(tcpKeepAliveInterval)); err != nil {
 			return newError("failed to set TCP_KEEPALIVE", err)
 		}
 	}

--- a/transport/internet/sockopt_freebsd.go
+++ b/transport/internet/sockopt_freebsd.go
@@ -238,16 +238,16 @@ func setReusePort(fd uintptr) error {
 	return nil
 }
 
-func enableKeepAlive(fd uintptr, TcpKeepAliveInterval int32) error {
-	if TcpKeepAliveInterval >= 0 {
-		if TcpKeepAliveInterval == 0 {
+func enableKeepAlive(fd uintptr, tcpKeepAliveInterval int32) error {
+	if tcpKeepAliveInterval >= 0 {
+		if tcpKeepAliveInterval == 0 {
 			// Default timeout is 10 minutes.
-			TcpKeepAliveInterval = 600
+			tcpKeepAliveInterval = 600
 		}
 		if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_KEEPALIVE, 1); err != nil {
 			return newError("failed to set SO_KEEPALIVE", err)
 		}
-		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPIDLE, int(TcpKeepAliveInterval)); err != nil {
+		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPIDLE, int(tcpKeepAliveInterval)); err != nil {
 			return newError("failed to set TCP_KEEPIDLE", err)
 		}
 	}

--- a/transport/internet/sockopt_linux.go
+++ b/transport/internet/sockopt_linux.go
@@ -127,16 +127,16 @@ func setReusePort(fd uintptr) error {
 	return nil
 }
 
-func enableKeepAlive(fd uintptr, TcpKeepAliveInterval int32) error {
-	if TcpKeepAliveInterval >= 0 {
-		if TcpKeepAliveInterval == 0 {
+func enableKeepAlive(fd uintptr, tcpKeepAliveInterval int32) error {
+	if tcpKeepAliveInterval >= 0 {
+		if tcpKeepAliveInterval == 0 {
 			// Default timeout is 10 minutes.
-			TcpKeepAliveInterval = 600
+			tcpKeepAliveInterval = 600
 		}
 		if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_KEEPALIVE, 1); err != nil {
 			return newError("failed to set SO_KEEPALIVE", err)
 		}
-		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPIDLE, int(TcpKeepAliveInterval)); err != nil {
+		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPIDLE, int(tcpKeepAliveInterval)); err != nil {
 			return newError("failed to set TCP_KEEPIDLE", err)
 		}
 	}

--- a/transport/internet/sockopt_linux.go
+++ b/transport/internet/sockopt_linux.go
@@ -60,8 +60,8 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 		}
 
 		if config.TcpKeepAliveInterval != 0 {
-			if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPINTVL, int(config.TcpKeepAliveInterval)); err != nil {
-				return newError("failed to set TCP_KEEPINTVL", err)
+			if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPIDLE, int(config.TcpKeepAliveInterval)); err != nil {
+				return newError("failed to set TCP_KEEPIDLE", err)
 			}
 		}
 	}
@@ -94,8 +94,8 @@ func applyInboundSocketOptions(network string, fd uintptr, config *SocketConfig)
 		}
 
 		if config.TcpKeepAliveInterval != 0 {
-			if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPINTVL, int(config.TcpKeepAliveInterval)); err != nil {
-				return newError("failed to set TCP_KEEPINTVL", err)
+			if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPIDLE, int(config.TcpKeepAliveInterval)); err != nil {
+				return newError("failed to set TCP_KEEPIDLE", err)
 			}
 		}
 	}

--- a/transport/internet/sockopt_other.go
+++ b/transport/internet/sockopt_other.go
@@ -22,3 +22,7 @@ func setReuseAddr(fd uintptr) error {
 func setReusePort(fd uintptr) error {
 	return nil
 }
+
+func enableKeepAlive(fd uintptr, TcpKeepAliveInterval int32) error {
+	return nil
+}

--- a/transport/internet/sockopt_other.go
+++ b/transport/internet/sockopt_other.go
@@ -3,26 +3,26 @@
 
 package internet
 
-func applyOutboundSocketOptions(network string, address string, fd uintptr, config *SocketConfig) error {
+func applyOutboundSocketOptions(_ string, _ string, _ uintptr, _ *SocketConfig) error {
 	return nil
 }
 
-func applyInboundSocketOptions(network string, fd uintptr, config *SocketConfig) error {
+func applyInboundSocketOptions(_ string, _ uintptr, _ *SocketConfig) error {
 	return nil
 }
 
-func bindAddr(fd uintptr, ip []byte, port uint32) error {
+func bindAddr(_ uintptr, _ []byte, _ uint32) error {
 	return nil
 }
 
-func setReuseAddr(fd uintptr) error {
+func setReuseAddr(_ uintptr) error {
 	return nil
 }
 
-func setReusePort(fd uintptr) error {
+func setReusePort(_ uintptr) error {
 	return nil
 }
 
-func enableKeepAlive(fd uintptr, TcpKeepAliveInterval int32) error {
+func enableKeepAlive(_ uintptr, _ int32) error {
 	return nil
 }

--- a/transport/internet/sockopt_windows.go
+++ b/transport/internet/sockopt_windows.go
@@ -60,9 +60,9 @@ func setReusePort(fd uintptr) error {
 	return nil
 }
 
-func enableKeepAlive(fd uintptr, TcpKeepAliveInterval int32) error {
-	if TcpKeepAliveInterval >= 0 {
-        // On Windows, we only enable Keep-Alive.
+func enableKeepAlive(fd uintptr, tcpKeepAliveInterval int32) error {
+	if tcpKeepAliveInterval >= 0 {
+		// On Windows, we only enable Keep-Alive.
 		if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.SOL_SOCKET, syscall.SO_KEEPALIVE, 1); err != nil {
 			return newError("failed to set SO_KEEPALIVE", err)
 		}

--- a/transport/internet/system_dialer.go
+++ b/transport/internet/system_dialer.go
@@ -67,6 +67,7 @@ func (d *DefaultSystemDialer) Dial(ctx context.Context, src net.Address, dest ne
 	dialer := &net.Dialer{
 		Timeout:   time.Second * 16,
 		LocalAddr: resolveSrcAddr(dest.Network, src),
+		KeepAlive: time.Second * time.Duration(sockopt.TcpKeepAliveInterval),
 	}
 
 	if sockopt != nil || len(d.controllers) > 0 {

--- a/transport/internet/system_listener.go
+++ b/transport/internet/system_listener.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"runtime"
 	"syscall"
+	"time"
 
 	"github.com/pires/go-proxyproto"
 
@@ -49,6 +50,7 @@ func (dl *DefaultListener) Listen(ctx context.Context, addr net.Addr, sockopt *S
 		network = addr.Network()
 		address = addr.String()
 		lc.Control = getControlFunc(ctx, sockopt, dl.controllers)
+		lc.KeepAlive = time.Second * time.Duration(sockopt.TcpKeepAliveInterval)
 	case *net.UnixAddr:
 		lc.Control = nil
 		network = addr.Network()


### PR DESCRIPTION
The previous commit ab6480ef729509bc269e804a4f3de073fd33c657 changed incorrect parameter.
It applied keep-alive interval to TCP_KEEPINTVL, but it should be applied to TCP_KEEPIDLE instead.

>TCP_KEEPIDLE (since Linux 2.4)
>        The  time  (in  seconds)  the  connection needs to remain idle before TCP starts sending keepalive probes, if the socket option SO_KEEPALIVE has been set on this socket.  This option should not be used in code intended to be portable.
>
>TCP_KEEPINTVL (since Linux 2.4)
>        The time (in seconds) between individual keepalive probes.  This option should not be used in code intended to be portable.


This pull-request disables golang keep-alive handling and set up everything manually properly.

Fixes https://github.com/v2ray/v2ray-core/issues/2564