### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/app/dns/nameserver_doh.go
+++ b/app/dns/nameserver_doh.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"sync"
@@ -283,11 +282,11 @@ func (s *DoHNameServer) dohHTTPSContext(ctx context.Context, b []byte) ([]byte, 
 
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		io.Copy(ioutil.Discard, resp.Body) // flush resp.Body so that the conn is reusable
+		io.Copy(io.Discard, resp.Body) // flush resp.Body so that the conn is reusable
 		return nil, fmt.Errorf("DOH server returned code %d", resp.StatusCode)
 	}
 
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func (s *DoHNameServer) findIPsForDomain(domain string, option dns_feature.IPOption) ([]net.IP, error) {

--- a/common/buf/multi_buffer_test.go
+++ b/common/buf/multi_buffer_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/rand"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -120,7 +119,7 @@ func TestMultiBufferReadAllToByte(t *testing.T) {
 		common.Must(err)
 		f.Close()
 
-		cnt, err := ioutil.ReadFile(dat)
+		cnt, err := os.ReadFile(dat)
 		common.Must(err)
 
 		if d := cmp.Diff(buf2, cnt); d != "" {

--- a/common/common.go
+++ b/common/common.go
@@ -5,7 +5,7 @@ package common
 import (
 	"fmt"
 	"go/build"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -70,7 +70,7 @@ func GetRuntimeEnv(key string) (string, error) {
 	}
 	var data []byte
 	var runtimeEnv string
-	data, readErr := ioutil.ReadFile(file)
+	data, readErr := os.ReadFile(file)
 	if readErr != nil {
 		return "", readErr
 	}
@@ -153,7 +153,7 @@ func FetchHTTPContent(target string) ([]byte, error) {
 		return nil, newError("unexpected HTTP status code: ", resp.StatusCode)
 	}
 
-	content, err := ioutil.ReadAll(resp.Body)
+	content, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, newError("failed to read HTTP response").Base(err)
 	}

--- a/common/drain/drainer.go
+++ b/common/drain/drainer.go
@@ -2,7 +2,6 @@ package drain
 
 import (
 	"io"
-	"io/ioutil"
 
 	"github.com/v2fly/v2ray-core/v4/common/dice"
 )
@@ -36,7 +35,7 @@ func (d *BehaviorSeedLimitedDrainer) Drain(reader io.Reader) error {
 }
 
 func drainReadN(reader io.Reader, n int) error {
-	_, err := io.CopyN(ioutil.Discard, reader, int64(n))
+	_, err := io.CopyN(io.Discard, reader, int64(n))
 	return err
 }
 

--- a/common/log/logger_test.go
+++ b/common/log/logger_test.go
@@ -1,7 +1,6 @@
 package log_test
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -13,7 +12,7 @@ import (
 )
 
 func TestFileLogger(t *testing.T) {
-	f, err := ioutil.TempFile("", "vtest")
+	f, err := os.CreateTemp("", "vtest")
 	common.Must(err)
 	path := f.Name()
 	common.Must(f.Close())

--- a/infra/conf/geodata/memconservative/cache.go
+++ b/infra/conf/geodata/memconservative/cache.go
@@ -1,7 +1,7 @@
 package memconservative
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"google.golang.org/protobuf/proto"
@@ -53,7 +53,7 @@ func (g GeoIPCache) Unmarshal(filename, code string) (*router.GeoIP, error) {
 	case errFailedToReadBytes, errFailedToReadExpectedLenBytes,
 		errInvalidGeodataFile, errInvalidGeodataVarintLength:
 		newError("failed to decode geoip file: ", filename, ", fallback to the original ReadFile method")
-		geoipBytes, err = ioutil.ReadFile(asset)
+		geoipBytes, err = os.ReadFile(asset)
 		if err != nil {
 			return nil, err
 		}
@@ -118,7 +118,7 @@ func (g GeoSiteCache) Unmarshal(filename, code string) (*router.GeoSite, error) 
 	case errFailedToReadBytes, errFailedToReadExpectedLenBytes,
 		errInvalidGeodataFile, errInvalidGeodataVarintLength:
 		newError("failed to decode geoip file: ", filename, ", fallback to the original ReadFile method")
-		geositeBytes, err = ioutil.ReadFile(asset)
+		geositeBytes, err = os.ReadFile(asset)
 		if err != nil {
 			return nil, err
 		}

--- a/infra/control/certchainhash.go
+++ b/infra/control/certchainhash.go
@@ -3,7 +3,7 @@ package control
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	v2tls "github.com/v2fly/v2ray-core/v4/transport/internet/tls"
 )
@@ -30,7 +30,7 @@ func (c CertificateChainHashCommand) Execute(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	certContent, err := ioutil.ReadFile(*cert)
+	certContent, err := os.ReadFile(*cert)
 	if err != nil {
 		return err
 	}

--- a/infra/control/config.go
+++ b/infra/control/config.go
@@ -3,7 +3,6 @@ package control
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -73,10 +72,10 @@ func (c *ConfigCommand) LoadArg(arg string) (out io.Reader, err error) {
 		data, err = FetchHTTPContent(arg)
 
 	case arg == "stdin:":
-		data, err = ioutil.ReadAll(os.Stdin)
+		data, err = io.ReadAll(os.Stdin)
 
 	default:
-		data, err = ioutil.ReadFile(arg)
+		data, err = os.ReadFile(arg)
 	}
 
 	if err != nil {

--- a/infra/vprotogen/main.go
+++ b/infra/vprotogen/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"go/build"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -46,7 +45,7 @@ func GetRuntimeEnv(key string) (string, error) {
 	}
 	var data []byte
 	var runtimeEnv string
-	data, readErr := ioutil.ReadFile(file)
+	data, readErr := os.ReadFile(file)
 	if readErr != nil {
 		return "", readErr
 	}

--- a/main/confloader/external/external.go
+++ b/main/confloader/external/external.go
@@ -5,7 +5,6 @@ package external
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -24,10 +23,10 @@ func ConfigLoader(arg string) (out io.Reader, err error) {
 		data, err = FetchHTTPContent(arg)
 
 	case arg == "stdin:":
-		data, err = ioutil.ReadAll(os.Stdin)
+		data, err = io.ReadAll(os.Stdin)
 
 	default:
-		data, err = ioutil.ReadFile(arg)
+		data, err = os.ReadFile(arg)
 	}
 
 	if err != nil {

--- a/main/main.go
+++ b/main/main.go
@@ -5,7 +5,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
@@ -54,7 +53,7 @@ func dirExists(file string) bool {
 }
 
 func readConfDir(dirPath string) {
-	confs, err := ioutil.ReadDir(dirPath)
+	confs, err := os.ReadDir(dirPath)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/testing/scenarios/common.go
+++ b/testing/scenarios/common.go
@@ -5,7 +5,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -102,7 +102,7 @@ func genTestBinaryPath() {
 	testBinaryPathGen.Do(func() {
 		var tempDir string
 		common.Must(retry.Timed(5, 100).On(func() error {
-			dir, err := ioutil.TempDir("", "v2ray")
+			dir, err := os.MkdirTemp("", "v2ray")
 			if err != nil {
 				return err
 			}

--- a/testing/scenarios/feature_test.go
+++ b/testing/scenarios/feature_test.go
@@ -2,7 +2,7 @@ package scenarios
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -643,7 +643,7 @@ func TestDomainSniffing(t *testing.T) {
 		if resp.StatusCode != 200 {
 			t.Error("unexpected status code: ", resp.StatusCode)
 		}
-		common.Must(resp.Write(ioutil.Discard))
+		common.Must(resp.Write(io.Discard))
 	}
 }
 

--- a/testing/scenarios/http_test.go
+++ b/testing/scenarios/http_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/rand"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"testing"
@@ -75,7 +74,7 @@ func TestHttpConformance(t *testing.T) {
 			t.Fatal("status: ", resp.StatusCode)
 		}
 
-		content, err := ioutil.ReadAll(resp.Body)
+		content, err := io.ReadAll(resp.Body)
 		common.Must(err)
 		if string(content) != "Home" {
 			t.Fatal("body: ", string(content))
@@ -271,7 +270,7 @@ func TestHttpPost(t *testing.T) {
 			t.Fatal("status: ", resp.StatusCode)
 		}
 
-		content, err := ioutil.ReadAll(resp.Body)
+		content, err := io.ReadAll(resp.Body)
 		common.Must(err)
 		if r := cmp.Diff(content, xor(payload)); r != "" {
 			t.Fatal(r)
@@ -368,7 +367,7 @@ func TestHttpBasicAuth(t *testing.T) {
 				t.Fatal("status: ", resp.StatusCode)
 			}
 
-			content, err := ioutil.ReadAll(resp.Body)
+			content, err := io.ReadAll(resp.Body)
 			common.Must(err)
 			if string(content) != "Home" {
 				t.Fatal("body: ", string(content))


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.