### PR TITLE
Refactor strmatcher.MphMatcherGroup

### DIFF
--- a/common/strmatcher/matchergroup_mph_test.go
+++ b/common/strmatcher/matchergroup_mph_test.go
@@ -267,3 +267,12 @@ func TestMphMatcherGroupAsIndexMatcher(t *testing.T) {
 		}
 	}
 }
+
+func TestEmptyMphMatcherGroup(t *testing.T) {
+	g := NewMphMatcherGroup()
+	g.Build()
+	r := g.Match("v2fly.org")
+	if len(r) != 0 {
+		t.Error("Expect [], but ", r)
+	}
+}

--- a/common/strmatcher/matchergroup_mph_test.go
+++ b/common/strmatcher/matchergroup_mph_test.go
@@ -1,6 +1,7 @@
 package strmatcher_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/v2fly/v2ray-core/v4/common"
@@ -169,6 +170,100 @@ func TestMphMatcherGroup(t *testing.T) {
 			if m := mph.MatchAny(test.pattern); m != test.res {
 				t.Error("unexpected output: ", m, " for test case ", test)
 			}
+		}
+	}
+}
+
+// See https://github.com/v2fly/v2ray-core/issues/92#issuecomment-673238489
+func TestMphMatcherGroupAsIndexMatcher(t *testing.T) {
+	rules := []struct {
+		Type   Type
+		Domain string
+	}{
+		// Regex not supported by MphMatcherGroup
+		// {
+		// 	Type:   Regex,
+		// 	Domain: "apis\\.us$",
+		// },
+		// Substr not supported by MphMatcherGroup
+		// {
+		// 	Type:   Substr,
+		// 	Domain: "apis",
+		// },
+		{
+			Type:   Domain,
+			Domain: "googleapis.com",
+		},
+		{
+			Type:   Domain,
+			Domain: "com",
+		},
+		{
+			Type:   Full,
+			Domain: "www.baidu.com",
+		},
+		// Substr not supported by MphMatcherGroup, We add another matcher to preserve index
+		{
+			Type:   Domain,        // Substr,
+			Domain: "example.com", // "apis",
+		},
+		{
+			Type:   Domain,
+			Domain: "googleapis.com",
+		},
+		{
+			Type:   Full,
+			Domain: "fonts.googleapis.com",
+		},
+		{
+			Type:   Full,
+			Domain: "www.baidu.com",
+		},
+		{ // This matcher (index 10) is swapped with matcher (index 6) to test that full matcher takes high priority.
+			Type:   Full,
+			Domain: "example.com",
+		},
+		{
+			Type:   Domain,
+			Domain: "example.com",
+		},
+	}
+	cases := []struct {
+		Input  string
+		Output []uint32
+	}{
+		{
+			Input:  "www.baidu.com",
+			Output: []uint32{5, 9, 4},
+		},
+		{
+			Input:  "fonts.googleapis.com",
+			Output: []uint32{8, 3, 7, 4 /*2, 6*/},
+		},
+		{
+			Input:  "example.googleapis.com",
+			Output: []uint32{3, 7, 4 /*2, 6*/},
+		},
+		{
+			Input: "testapis.us",
+			// Output: []uint32{ /*2, 6*/ /*1,*/ },
+			Output: nil,
+		},
+		{
+			Input:  "example.com",
+			Output: []uint32{10, 6, 11, 4},
+		},
+	}
+	matcherGroup := NewMphMatcherGroup()
+	for i, rule := range rules {
+		matcher, err := rule.Type.New(rule.Domain)
+		common.Must(err)
+		common.Must(AddMatcherToGroup(matcherGroup, matcher, uint32(i+3)))
+	}
+	matcherGroup.Build()
+	for _, test := range cases {
+		if m := matcherGroup.Match(test.Input); !reflect.DeepEqual(m, test.Output) {
+			t.Error("unexpected output: ", m, " for test case ", test)
 		}
 	}
 }


### PR DESCRIPTION
As per description in https://github.com/v2fly/v2ray-core/discussions/1275#discussioncomment-1559883:

> `MphMatcherGroup` uses an algorithm [Hash, displace, and compress](http://cmph.sourceforge.net/papers/esa09.pdf) to construct a minimal perfect hash table. It involves `1. a normal hash function`, and `2. a series of hash functions independent to each others`.
> 
> This is how this `MphMatcherGroup` works:
> 
> #### First level hash: RollingHash
> Rolling hash is chosen here because we can easily calculate the hash of a full domain and all its subdomains.
> 
> We obtain a seed from the result of first level hash.
> 
> #### Second level hash: MemHash
> One of second level functions is selected according to the seed obtained from first level hash.
> 
> This is done by choosing golang runtime's `memhash`, because `memhash` requires a seed as argument, and with different seeds, `memhash` behaves exactly like distinct hash functions independent to each other.
> 
> To use `memhash`, current implementation of `MphMatcherGroup` copies source code (unoptimized version) from golang runtime. However, we could directly reference the runtime 'simplementation using compiler directive `go:linkname`:
> 
> ```
> //go:noescape
> //go:linkname memhash runtime.memhash
> func memhash(p unsafe.Pointer, h, s uintptr) uintptr
> ```
> 
> While avoiding duplicate code, the runtime's memhash implementation could also benefit from hardware optimizations like AES if supported. Current `MphMatcherGroup` unconditionally uses the unoptimized fallback version.

