### PR TITLE
fix: readRequest API changed since go1.17

### DIFF
--- a/transport/internet/headers/http/http.go
+++ b/transport/internet/headers/http/http.go
@@ -90,7 +90,7 @@ func (h *HeaderReader) Read(reader io.Reader) (*buf.Buffer, error) {
 			buffer.Clear()
 			copy(buffer.Extend(lenEnding), leftover)
 
-			if _, err := readRequest(bufio.NewReader(bytes.NewReader(headerBuf.Bytes())), false); err != io.ErrUnexpectedEOF {
+			if _, err := readRequest(bufio.NewReader(bytes.NewReader(headerBuf.Bytes()))); err != io.ErrUnexpectedEOF {
 				return nil, err
 			}
 		}
@@ -110,7 +110,7 @@ func (h *HeaderReader) Read(reader io.Reader) (*buf.Buffer, error) {
 	}
 
 	// Parse the request
-	if req, err := readRequest(bufio.NewReader(bytes.NewReader(headerBuf.Bytes())), false); err != nil {
+	if req, err := readRequest(bufio.NewReader(bytes.NewReader(headerBuf.Bytes()))); err != nil {
 		return nil, err
 	} else { // nolint: golint
 		h.req = req

--- a/transport/internet/headers/http/linkedreadRequest.go
+++ b/transport/internet/headers/http/linkedreadRequest.go
@@ -9,4 +9,4 @@ import (
 )
 
 //go:linkname readRequest net/http.readRequest
-func readRequest(b *bufio.Reader, deleteHostHeader bool) (req *http.Request, err error)
+func readRequest(b *bufio.Reader) (req *http.Request, err error)


### PR DESCRIPTION
Private function `readRequest`  has changed since 1.17. 

```diff
-func readRequest(b *bufio.Reader, deleteHostHeader bool) (req *Request, err error) {
+func readRequest(b *bufio.Reader) (req *Request, err error) {
```

Golang related commit : https://github.com/golang/go/commit/acb189ea59d7f47e5db075e502dcce5eac6571dc#diff-58d1202218e4b5db623ceb4abddb3c166adc4c34a327c1c9df106191edc370d2R1022


fixed: #1265