### PR TITLE
Change all tests to VMessAEAD

### DIFF
--- a/infra/conf/cfgcommon/common_test.go
+++ b/infra/conf/cfgcommon/common_test.go
@@ -209,8 +209,7 @@ func TestUserParsing(t *testing.T) {
 	common.Must(json.Unmarshal([]byte(`{
     "id": "96edb838-6d68-42ef-a933-25f7ac3a9d09",
     "email": "love@v2fly.org",
-    "level": 1,
-    "alterId": 100
+    "level": 1
   }`), user))
 
 	nUser := user.Build()

--- a/infra/conf/v4/v2ray_test.go
+++ b/infra/conf/v4/v2ray_test.go
@@ -79,7 +79,6 @@ func TestV2RayConfig(t *testing.T) {
 					"settings": {
 						"clients": [
 							{
-								"alterId": 100,
 								"security": "aes-128-gcm",
 								"id": "0cdf8a45-303d-4fed-9780-29aa7f54175e"
 							}
@@ -109,7 +108,6 @@ func TestV2RayConfig(t *testing.T) {
 					"settings": {
 						"clients": [
 							{
-								"alterId": 100,
 								"security": "aes-128-gcm",
 								"id": "0cdf8a45-303d-4fed-9780-29aa7f54175e"
 							}
@@ -280,8 +278,7 @@ func TestV2RayConfig(t *testing.T) {
 								{
 									Level: 0,
 									Account: serial.ToTypedMessage(&vmess.Account{
-										Id:      "0cdf8a45-303d-4fed-9780-29aa7f54175e",
-										AlterId: 100,
+										Id: "0cdf8a45-303d-4fed-9780-29aa7f54175e",
 										SecuritySettings: &protocol.SecurityConfig{
 											Type: protocol.SecurityType_AES128_GCM,
 										},
@@ -336,8 +333,7 @@ func TestV2RayConfig(t *testing.T) {
 								{
 									Level: 0,
 									Account: serial.ToTypedMessage(&vmess.Account{
-										Id:      "0cdf8a45-303d-4fed-9780-29aa7f54175e",
-										AlterId: 100,
+										Id: "0cdf8a45-303d-4fed-9780-29aa7f54175e",
 										SecuritySettings: &protocol.SecurityConfig{
 											Type: protocol.SecurityType_AES128_GCM,
 										},

--- a/infra/conf/v4/vmess_test.go
+++ b/infra/conf/v4/vmess_test.go
@@ -49,8 +49,7 @@ func TestVMessOutbound(t *testing.T) {
 								Email: "love@v2fly.org",
 								Level: 255,
 								Account: serial.ToTypedMessage(&vmess.Account{
-									Id:      "e641f5ad-9397-41e3-bf1a-e8740dfed019",
-									AlterId: 0,
+									Id: "e641f5ad-9397-41e3-bf1a-e8740dfed019",
 									SecuritySettings: &protocol.SecurityConfig{
 										Type: protocol.SecurityType_AUTO,
 									},
@@ -76,14 +75,12 @@ func TestVMessInbound(t *testing.T) {
 					{
 						"id": "27848739-7e62-4138-9fd3-098a63964b6b",
 						"level": 0,
-						"alterId": 16,
 						"email": "love@v2fly.org",
 						"security": "aes-128-gcm"
 					}
 				],
 				"default": {
-					"level": 0,
-					"alterId": 32
+					"level": 0
 				},
 				"detour": {
 					"to": "tag_to_detour"
@@ -97,8 +94,7 @@ func TestVMessInbound(t *testing.T) {
 						Level: 0,
 						Email: "love@v2fly.org",
 						Account: serial.ToTypedMessage(&vmess.Account{
-							Id:      "27848739-7e62-4138-9fd3-098a63964b6b",
-							AlterId: 16,
+							Id: "27848739-7e62-4138-9fd3-098a63964b6b",
 							SecuritySettings: &protocol.SecurityConfig{
 								Type: protocol.SecurityType_AES128_GCM,
 							},
@@ -106,8 +102,7 @@ func TestVMessInbound(t *testing.T) {
 					},
 				},
 				Default: &inbound.DefaultConfig{
-					Level:   0,
-					AlterId: 32,
+					Level: 0,
 				},
 				Detour: &inbound.DetourConfig{
 					To: "tag_to_detour",

--- a/proxy/vmess/encoding/encoding_test.go
+++ b/proxy/vmess/encoding/encoding_test.go
@@ -28,8 +28,7 @@ func TestRequestSerialization(t *testing.T) {
 	}
 	id := uuid.New()
 	account := &vmess.Account{
-		Id:      id.String(),
-		AlterId: 0,
+		Id: id.String(),
 	}
 	user.Account = toAccount(account)
 
@@ -78,8 +77,7 @@ func TestInvalidRequest(t *testing.T) {
 	}
 	id := uuid.New()
 	account := &vmess.Account{
-		Id:      id.String(),
-		AlterId: 0,
+		Id: id.String(),
 	}
 	user.Account = toAccount(account)
 
@@ -120,8 +118,7 @@ func TestMuxRequest(t *testing.T) {
 	}
 	id := uuid.New()
 	account := &vmess.Account{
-		Id:      id.String(),
-		AlterId: 0,
+		Id: id.String(),
 	}
 	user.Account = toAccount(account)
 

--- a/proxy/vmess/validator_test.go
+++ b/proxy/vmess/validator_test.go
@@ -26,8 +26,7 @@ func TestUserValidator(t *testing.T) {
 	user := &protocol.MemoryUser{
 		Email: "test",
 		Account: toAccount(&Account{
-			Id:      id.String(),
-			AlterId: 8,
+			Id: id.String(),
 		}),
 	}
 	common.Must(v.Add(user))
@@ -99,8 +98,7 @@ func BenchmarkUserValidator(b *testing.B) {
 			v.Add(&protocol.MemoryUser{
 				Email: "test",
 				Account: toAccount(&Account{
-					Id:      id.String(),
-					AlterId: 16,
+					Id: id.String(),
 				}),
 			})
 		}

--- a/release/config/vpoint_vmess_freedom.json
+++ b/release/config/vpoint_vmess_freedom.json
@@ -6,8 +6,7 @@
       "clients": [
         {
           "id": "23ad6b10-8d1a-40f7-8ad0-e3e35cd38297",
-          "level": 1,
-          "alterId": 64
+          "level": 1
         }
       ]
     }

--- a/testing/scenarios/command_test.go
+++ b/testing/scenarios/command_test.go
@@ -182,8 +182,7 @@ func TestCommanderAddRemoveUser(t *testing.T) {
 					User: []*protocol.User{
 						{
 							Account: serial.ToTypedMessage(&vmess.Account{
-								Id:      u1.String(),
-								AlterId: 64,
+								Id: u1.String(),
 							}),
 						},
 					},
@@ -249,8 +248,7 @@ func TestCommanderAddRemoveUser(t *testing.T) {
 							User: []*protocol.User{
 								{
 									Account: serial.ToTypedMessage(&vmess.Account{
-										Id:      u2.String(),
-										AlterId: 64,
+										Id: u2.String(),
 										SecuritySettings: &protocol.SecurityConfig{
 											Type: protocol.SecurityType_AES128_GCM,
 										},
@@ -286,8 +284,7 @@ func TestCommanderAddRemoveUser(t *testing.T) {
 				User: &protocol.User{
 					Email: "test@v2fly.org",
 					Account: serial.ToTypedMessage(&vmess.Account{
-						Id:      u2.String(),
-						AlterId: 64,
+						Id: u2.String(),
 					}),
 				},
 			}),
@@ -377,8 +374,7 @@ func TestCommanderStats(t *testing.T) {
 							Level: 1,
 							Email: "test",
 							Account: serial.ToTypedMessage(&vmess.Account{
-								Id:      userID.String(),
-								AlterId: 64,
+								Id: userID.String(),
 							}),
 						},
 					},
@@ -433,8 +429,7 @@ func TestCommanderStats(t *testing.T) {
 							User: []*protocol.User{
 								{
 									Account: serial.ToTypedMessage(&vmess.Account{
-										Id:      userID.String(),
-										AlterId: 64,
+										Id: userID.String(),
 										SecuritySettings: &protocol.SecurityConfig{
 											Type: protocol.SecurityType_AES128_GCM,
 										},

--- a/testing/scenarios/feature_test.go
+++ b/testing/scenarios/feature_test.go
@@ -673,8 +673,7 @@ func TestDialV2Ray(t *testing.T) {
 					User: []*protocol.User{
 						{
 							Account: serial.ToTypedMessage(&vmess.Account{
-								Id:      userID.String(),
-								AlterId: 64,
+								Id: userID.String(),
 							}),
 						},
 					},
@@ -705,8 +704,7 @@ func TestDialV2Ray(t *testing.T) {
 							User: []*protocol.User{
 								{
 									Account: serial.ToTypedMessage(&vmess.Account{
-										Id:      userID.String(),
-										AlterId: 64,
+										Id: userID.String(),
 										SecuritySettings: &protocol.SecurityConfig{
 											Type: protocol.SecurityType_AES128_GCM,
 										},

--- a/testing/scenarios/policy_test.go
+++ b/testing/scenarios/policy_test.go
@@ -77,8 +77,7 @@ func TestVMessClosing(t *testing.T) {
 					User: []*protocol.User{
 						{
 							Account: serial.ToTypedMessage(&vmess.Account{
-								Id:      userID.String(),
-								AlterId: 64,
+								Id: userID.String(),
 							}),
 						},
 					},
@@ -131,8 +130,7 @@ func TestVMessClosing(t *testing.T) {
 							User: []*protocol.User{
 								{
 									Account: serial.ToTypedMessage(&vmess.Account{
-										Id:      userID.String(),
-										AlterId: 64,
+										Id: userID.String(),
 										SecuritySettings: &protocol.SecurityConfig{
 											Type: protocol.SecurityType_AES128_GCM,
 										},
@@ -191,8 +189,7 @@ func TestZeroBuffer(t *testing.T) {
 					User: []*protocol.User{
 						{
 							Account: serial.ToTypedMessage(&vmess.Account{
-								Id:      userID.String(),
-								AlterId: 64,
+								Id: userID.String(),
 							}),
 						},
 					},
@@ -238,8 +235,7 @@ func TestZeroBuffer(t *testing.T) {
 							User: []*protocol.User{
 								{
 									Account: serial.ToTypedMessage(&vmess.Account{
-										Id:      userID.String(),
-										AlterId: 64,
+										Id: userID.String(),
 										SecuritySettings: &protocol.SecurityConfig{
 											Type: protocol.SecurityType_AES128_GCM,
 										},

--- a/testing/scenarios/reverse_test.go
+++ b/testing/scenarios/reverse_test.go
@@ -95,8 +95,7 @@ func TestReverseProxy(t *testing.T) {
 					User: []*protocol.User{
 						{
 							Account: serial.ToTypedMessage(&vmess.Account{
-								Id:      userID.String(),
-								AlterId: 64,
+								Id: userID.String(),
 							}),
 						},
 					},
@@ -170,8 +169,7 @@ func TestReverseProxy(t *testing.T) {
 							User: []*protocol.User{
 								{
 									Account: serial.ToTypedMessage(&vmess.Account{
-										Id:      userID.String(),
-										AlterId: 64,
+										Id: userID.String(),
 										SecuritySettings: &protocol.SecurityConfig{
 											Type: protocol.SecurityType_AES128_GCM,
 										},
@@ -279,8 +277,7 @@ func TestReverseProxyLongRunning(t *testing.T) {
 					User: []*protocol.User{
 						{
 							Account: serial.ToTypedMessage(&vmess.Account{
-								Id:      userID.String(),
-								AlterId: 64,
+								Id: userID.String(),
 							}),
 						},
 					},
@@ -367,8 +364,7 @@ func TestReverseProxyLongRunning(t *testing.T) {
 							User: []*protocol.User{
 								{
 									Account: serial.ToTypedMessage(&vmess.Account{
-										Id:      userID.String(),
-										AlterId: 64,
+										Id: userID.String(),
 										SecuritySettings: &protocol.SecurityConfig{
 											Type: protocol.SecurityType_AES128_GCM,
 										},

--- a/testing/scenarios/transport_test.go
+++ b/testing/scenarios/transport_test.go
@@ -290,8 +290,7 @@ func TestVMessQuic(t *testing.T) {
 					User: []*protocol.User{
 						{
 							Account: serial.ToTypedMessage(&vmess.Account{
-								Id:      userID.String(),
-								AlterId: 64,
+								Id: userID.String(),
 							}),
 						},
 					},
@@ -353,8 +352,7 @@ func TestVMessQuic(t *testing.T) {
 							User: []*protocol.User{
 								{
 									Account: serial.ToTypedMessage(&vmess.Account{
-										Id:      userID.String(),
-										AlterId: 64,
+										Id: userID.String(),
 										SecuritySettings: &protocol.SecurityConfig{
 											Type: protocol.SecurityType_AES128_GCM,
 										},

--- a/testing/scenarios/vmess_test.go
+++ b/testing/scenarios/vmess_test.go
@@ -215,8 +215,7 @@ func TestVMessGCM(t *testing.T) {
 					User: []*protocol.User{
 						{
 							Account: serial.ToTypedMessage(&vmess.Account{
-								Id:      userID.String(),
-								AlterId: 64,
+								Id: userID.String(),
 							}),
 						},
 					},
@@ -262,8 +261,7 @@ func TestVMessGCM(t *testing.T) {
 							User: []*protocol.User{
 								{
 									Account: serial.ToTypedMessage(&vmess.Account{
-										Id:      userID.String(),
-										AlterId: 64,
+										Id: userID.String(),
 										SecuritySettings: &protocol.SecurityConfig{
 											Type: protocol.SecurityType_AES128_GCM,
 										},
@@ -319,8 +317,7 @@ func TestVMessGCMReadv(t *testing.T) {
 					User: []*protocol.User{
 						{
 							Account: serial.ToTypedMessage(&vmess.Account{
-								Id:      userID.String(),
-								AlterId: 64,
+								Id: userID.String(),
 							}),
 						},
 					},
@@ -366,8 +363,7 @@ func TestVMessGCMReadv(t *testing.T) {
 							User: []*protocol.User{
 								{
 									Account: serial.ToTypedMessage(&vmess.Account{
-										Id:      userID.String(),
-										AlterId: 64,
+										Id: userID.String(),
 										SecuritySettings: &protocol.SecurityConfig{
 											Type: protocol.SecurityType_AES128_GCM,
 										},
@@ -426,8 +422,7 @@ func TestVMessGCMUDP(t *testing.T) {
 					User: []*protocol.User{
 						{
 							Account: serial.ToTypedMessage(&vmess.Account{
-								Id:      userID.String(),
-								AlterId: 64,
+								Id: userID.String(),
 							}),
 						},
 					},
@@ -473,8 +468,7 @@ func TestVMessGCMUDP(t *testing.T) {
 							User: []*protocol.User{
 								{
 									Account: serial.ToTypedMessage(&vmess.Account{
-										Id:      userID.String(),
-										AlterId: 64,
+										Id: userID.String(),
 										SecuritySettings: &protocol.SecurityConfig{
 											Type: protocol.SecurityType_AES128_GCM,
 										},
@@ -527,8 +521,7 @@ func TestVMessChacha20(t *testing.T) {
 					User: []*protocol.User{
 						{
 							Account: serial.ToTypedMessage(&vmess.Account{
-								Id:      userID.String(),
-								AlterId: 64,
+								Id: userID.String(),
 							}),
 						},
 					},
@@ -574,8 +567,7 @@ func TestVMessChacha20(t *testing.T) {
 							User: []*protocol.User{
 								{
 									Account: serial.ToTypedMessage(&vmess.Account{
-										Id:      userID.String(),
-										AlterId: 64,
+										Id: userID.String(),
 										SecuritySettings: &protocol.SecurityConfig{
 											Type: protocol.SecurityType_CHACHA20_POLY1305,
 										},
@@ -629,8 +621,7 @@ func TestVMessNone(t *testing.T) {
 					User: []*protocol.User{
 						{
 							Account: serial.ToTypedMessage(&vmess.Account{
-								Id:      userID.String(),
-								AlterId: 64,
+								Id: userID.String(),
 							}),
 						},
 					},
@@ -676,8 +667,7 @@ func TestVMessNone(t *testing.T) {
 							User: []*protocol.User{
 								{
 									Account: serial.ToTypedMessage(&vmess.Account{
-										Id:      userID.String(),
-										AlterId: 64,
+										Id: userID.String(),
 										SecuritySettings: &protocol.SecurityConfig{
 											Type: protocol.SecurityType_NONE,
 										},
@@ -733,8 +723,7 @@ func TestVMessKCP(t *testing.T) {
 					User: []*protocol.User{
 						{
 							Account: serial.ToTypedMessage(&vmess.Account{
-								Id:      userID.String(),
-								AlterId: 64,
+								Id: userID.String(),
 							}),
 						},
 					},
@@ -780,8 +769,7 @@ func TestVMessKCP(t *testing.T) {
 							User: []*protocol.User{
 								{
 									Account: serial.ToTypedMessage(&vmess.Account{
-										Id:      userID.String(),
-										AlterId: 64,
+										Id: userID.String(),
 										SecuritySettings: &protocol.SecurityConfig{
 											Type: protocol.SecurityType_AES128_GCM,
 										},
@@ -861,8 +849,7 @@ func TestVMessKCPLarge(t *testing.T) {
 					User: []*protocol.User{
 						{
 							Account: serial.ToTypedMessage(&vmess.Account{
-								Id:      userID.String(),
-								AlterId: 64,
+								Id: userID.String(),
 							}),
 						},
 					},
@@ -908,8 +895,7 @@ func TestVMessKCPLarge(t *testing.T) {
 							User: []*protocol.User{
 								{
 									Account: serial.ToTypedMessage(&vmess.Account{
-										Id:      userID.String(),
-										AlterId: 64,
+										Id: userID.String(),
 										SecuritySettings: &protocol.SecurityConfig{
 											Type: protocol.SecurityType_AES128_GCM,
 										},
@@ -990,8 +976,7 @@ func TestVMessGCMMux(t *testing.T) {
 					User: []*protocol.User{
 						{
 							Account: serial.ToTypedMessage(&vmess.Account{
-								Id:      userID.String(),
-								AlterId: 64,
+								Id: userID.String(),
 							}),
 						},
 					},
@@ -1043,8 +1028,7 @@ func TestVMessGCMMux(t *testing.T) {
 							User: []*protocol.User{
 								{
 									Account: serial.ToTypedMessage(&vmess.Account{
-										Id:      userID.String(),
-										AlterId: 64,
+										Id: userID.String(),
 										SecuritySettings: &protocol.SecurityConfig{
 											Type: protocol.SecurityType_AES128_GCM,
 										},
@@ -1107,8 +1091,7 @@ func TestVMessGCMMuxUDP(t *testing.T) {
 					User: []*protocol.User{
 						{
 							Account: serial.ToTypedMessage(&vmess.Account{
-								Id:      userID.String(),
-								AlterId: 64,
+								Id: userID.String(),
 							}),
 						},
 					},
@@ -1174,8 +1157,7 @@ func TestVMessGCMMuxUDP(t *testing.T) {
 							User: []*protocol.User{
 								{
 									Account: serial.ToTypedMessage(&vmess.Account{
-										Id:      userID.String(),
-										AlterId: 64,
+										Id: userID.String(),
 										SecuritySettings: &protocol.SecurityConfig{
 											Type: protocol.SecurityType_AES128_GCM,
 										},
@@ -1236,8 +1218,7 @@ func TestVMessZero(t *testing.T) {
 					User: []*protocol.User{
 						{
 							Account: serial.ToTypedMessage(&vmess.Account{
-								Id:      userID.String(),
-								AlterId: 64,
+								Id: userID.String(),
 							}),
 						},
 					},
@@ -1283,8 +1264,7 @@ func TestVMessZero(t *testing.T) {
 							User: []*protocol.User{
 								{
 									Account: serial.ToTypedMessage(&vmess.Account{
-										Id:      userID.String(),
-										AlterId: 64,
+										Id: userID.String(),
 										SecuritySettings: &protocol.SecurityConfig{
 											Type: protocol.SecurityType_ZERO,
 										},
@@ -1337,8 +1317,7 @@ func TestVMessGCMLengthAuth(t *testing.T) {
 					User: []*protocol.User{
 						{
 							Account: serial.ToTypedMessage(&vmess.Account{
-								Id:      userID.String(),
-								AlterId: 64,
+								Id: userID.String(),
 							}),
 						},
 					},
@@ -1384,8 +1363,7 @@ func TestVMessGCMLengthAuth(t *testing.T) {
 							User: []*protocol.User{
 								{
 									Account: serial.ToTypedMessage(&vmess.Account{
-										Id:      userID.String(),
-										AlterId: 64,
+										Id: userID.String(),
 										SecuritySettings: &protocol.SecurityConfig{
 											Type: protocol.SecurityType_AES128_GCM,
 										},
@@ -1443,7 +1421,6 @@ func TestVMessGCMLengthAuthPlusNoTerminationSignal(t *testing.T) {
 						{
 							Account: serial.ToTypedMessage(&vmess.Account{
 								Id:           userID.String(),
-								AlterId:      64,
 								TestsEnabled: "AuthenticatedLength|NoTerminationSignal",
 							}),
 						},
@@ -1490,8 +1467,7 @@ func TestVMessGCMLengthAuthPlusNoTerminationSignal(t *testing.T) {
 							User: []*protocol.User{
 								{
 									Account: serial.ToTypedMessage(&vmess.Account{
-										Id:      userID.String(),
-										AlterId: 64,
+										Id: userID.String(),
 										SecuritySettings: &protocol.SecurityConfig{
 											Type: protocol.SecurityType_AES128_GCM,
 										},


### PR DESCRIPTION
Old VMess MD5 tests will be rejected and fail in 2022:

common/drain: drained connection > proxy/vmess/encoding: invalid user: VMessAEAD is enforced and a non VMessAEAD connection is received.