### PR TITLE
Fix TestUserValidator

### DIFF
--- a/proxy/vmess/validator.go
+++ b/proxy/vmess/validator.go
@@ -71,6 +71,11 @@ func NewTimedUserValidator(hasher protocol.IDHash) *TimedUserValidator {
 	return tuv
 }
 
+// visible for testing
+func (v *TimedUserValidator) GetBaseTime() protocol.Timestamp {
+	return v.baseTime
+}
+
 func (v *TimedUserValidator) generateNewHashes(nowSec protocol.Timestamp, user *user) {
 	var hashValue [16]byte
 	genEndSec := nowSec + cacheDurationSec

--- a/proxy/vmess/validator_test.go
+++ b/proxy/vmess/validator_test.go
@@ -2,7 +2,6 @@ package vmess_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/v2fly/v2ray-core/v4/common"
 	"github.com/v2fly/v2ray-core/v4/common/protocol"
@@ -33,8 +32,8 @@ func TestUserValidator(t *testing.T) {
 	common.Must(v.Add(user))
 
 	{
-		testSmallLag := func(lag time.Duration) {
-			ts := protocol.Timestamp(time.Now().Add(time.Second * lag).Unix())
+		testSmallLag := func(lag int64) {
+			ts := int64(v.GetBaseTime()) + lag + 240
 			idHash := hasher(id.Bytes())
 			common.Must2(serial.WriteUint64(idHash, uint64(ts)))
 			userHash := idHash.Sum(nil)
@@ -46,7 +45,7 @@ func TestUserValidator(t *testing.T) {
 			if euser.Email != user.Email {
 				t.Error("unexpected user email: ", euser.Email, " want ", user.Email)
 			}
-			if ets != ts {
+			if int64(ets) != ts {
 				t.Error("unexpected timestamp: ", ets, " want ", ts)
 			}
 		}
@@ -61,8 +60,8 @@ func TestUserValidator(t *testing.T) {
 	}
 
 	{
-		testBigLag := func(lag time.Duration) {
-			ts := protocol.Timestamp(time.Now().Add(time.Second * lag).Unix())
+		testBigLag := func(lag int64) {
+			ts := int64(v.GetBaseTime()) + lag + 240
 			idHash := hasher(id.Bytes())
 			common.Must2(serial.WriteUint64(idHash, uint64(ts)))
 			userHash := idHash.Sum(nil)


### PR DESCRIPTION
https://github.com/XTLS/Xray-core/runs/4017048502?check_suite_focus=true

TestUserValidator randomly fail because the time.Now() in test is slightly later than the base time in validator. If it happened to land on another second, the verification on the edge of 120 seconds will fail.
Fix it by referencing the base time in validator.