### PR TITLE
Use go-proxyproto in fallbacks

### DIFF
--- a/proxy/vless/inbound/inbound.go
+++ b/proxy/vless/inbound/inbound.go
@@ -5,8 +5,9 @@ package inbound
 import (
 	"context"
 	"io"
-	"strconv"
 	"time"
+
+	"github.com/pires/go-proxyproto"
 
 	core "github.com/v2fly/v2ray-core/v4"
 	"github.com/v2fly/v2ray-core/v4/common"
@@ -278,46 +279,13 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection i
 			postRequest := func() error {
 				defer timer.SetTimeout(sessionPolicy.Timeouts.DownlinkOnly)
 				if fb.Xver != 0 {
-					remoteAddr, remotePort, err := net.SplitHostPort(connection.RemoteAddr().String())
-					if err != nil {
-						return err
-					}
-					localAddr, localPort, err := net.SplitHostPort(connection.LocalAddr().String())
-					if err != nil {
-						return err
-					}
-					ipv4 := true
-					for i := 0; i < len(remoteAddr); i++ {
-						if remoteAddr[i] == ':' {
-							ipv4 = false
-							break
-						}
-					}
 					pro := buf.New()
 					defer pro.Release()
-					switch fb.Xver {
-					case 1:
-						if ipv4 {
-							pro.Write([]byte("PROXY TCP4 " + remoteAddr + " " + localAddr + " " + remotePort + " " + localPort + "\r\n"))
-						} else {
-							pro.Write([]byte("PROXY TCP6 " + remoteAddr + " " + localAddr + " " + remotePort + " " + localPort + "\r\n"))
-						}
 
-					case 2:
-						pro.Write([]byte("\x0D\x0A\x0D\x0A\x00\x0D\x0A\x51\x55\x49\x54\x0A\x21")) // signature + v2 + PROXY
-						if ipv4 {
-							pro.Write([]byte("\x11\x00\x0C")) // AF_INET + STREAM + 12 bytes
-							pro.Write(net.ParseIP(remoteAddr).To4())
-							pro.Write(net.ParseIP(localAddr).To4())
-						} else {
-							pro.Write([]byte("\x21\x00\x24")) // AF_INET6 + STREAM + 36 bytes
-							pro.Write(net.ParseIP(remoteAddr).To16())
-							pro.Write(net.ParseIP(localAddr).To16())
-						}
-						p1, _ := strconv.ParseUint(remotePort, 10, 16)
-						p2, _ := strconv.ParseUint(localPort, 10, 16)
-						pro.Write([]byte{byte(p1 >> 8), byte(p1), byte(p2 >> 8), byte(p2)})
+					if _, err := proxyproto.HeaderProxyFromAddrs(byte(fb.Xver), connection.RemoteAddr(), connection.LocalAddr()).WriteTo(pro); err != nil {
+						return newError("failed to format PROXY protocol v", fb.Xver).Base(err).AtWarning()
 					}
+
 					if err := serverWriter.WriteMultiBuffer(buf.MultiBuffer{pro}); err != nil {
 						return newError("failed to set PROXY protocol v", fb.Xver).Base(err).AtWarning()
 					}


### PR DESCRIPTION
Use `go-proxyproto` to format Proxy Protocol in VLESS and Trojan fallbacks. After changing to `go-proxyproto`, the Proxy Protocol in the fallbacks will support more protocols, such as Unix Socket.