### PR TITLE
Increase some tls test timeout

### DIFF
--- a/testing/scenarios/tls_test.go
+++ b/testing/scenarios/tls_test.go
@@ -125,7 +125,7 @@ func TestSimpleTLSConnection(t *testing.T) {
 	common.Must(err)
 	defer CloseAllServers(servers)
 
-	if err := testTCPConn(clientPort, 1024, time.Second*2)(); err != nil {
+	if err := testTCPConn(clientPort, 1024, time.Second*20)(); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -247,7 +247,7 @@ func TestAutoIssuingCertificate(t *testing.T) {
 	defer CloseAllServers(servers)
 
 	for i := 0; i < 10; i++ {
-		if err := testTCPConn(clientPort, 1024, time.Second*2)(); err != nil {
+		if err := testTCPConn(clientPort, 1024, time.Second*20)(); err != nil {
 			t.Error(err)
 		}
 	}
@@ -350,7 +350,7 @@ func TestTLSOverKCP(t *testing.T) {
 	common.Must(err)
 	defer CloseAllServers(servers)
 
-	if err := testTCPConn(clientPort, 1024, time.Second*2)(); err != nil {
+	if err := testTCPConn(clientPort, 1024, time.Second*20)(); err != nil {
 		t.Error(err)
 	}
 }
@@ -689,7 +689,7 @@ func TestSimpleTLSConnectionPinned(t *testing.T) {
 	common.Must(err)
 	defer CloseAllServers(servers)
 
-	if err := testTCPConn(clientPort, 1024, time.Second*2)(); err != nil {
+	if err := testTCPConn(clientPort, 1024, time.Second*20)(); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
This issue is tricky but I think it is the right fix:
- The log show no other error but a simple timeout
- The timeout happen at the first attempt
- Configuration has tls.Certificate{)
- The other tests in the same file file has 20 or 40 seconds timeout, while these tests only have 2 seconds

Examples of error logs:

> === RUN   TestTLSOverKCP
> 2021/10/16 01:24:44 [Info] All server closed.
> Xray 1.4.5 (Xray, Penetrates Everything.) Custom (go1.17.2 darwin/amd64)
> A unified platform for anti-censorship.
> Xray 1.4.5 (Xray, Penetrates Everything.) Custom (go1.17.2 darwin/amd64)
> A unified platform for anti-censorship.
> 2021/10/16 01:24:44 [Debug] app/proxyman/inbound: creating stream worker on 127.0.0.1:60064
> 2021/10/16 01:24:44 [Debug] app/proxyman/inbound: creating stream worker on 127.0.0.1:57919
> 2021/10/16 01:24:44 [Info] transport/internet/tcp: listening TCP on 127.0.0.1:57919
> Warning: 6 01:24:44 [Warning] core: Xray 1.4.5 started
> 2021/10/16 01:24:44 [Info] transport/internet/udp: listening UDP on 127.0.0.1:60064
> 2021/10/16 01:24:44 [Info] transport/internet/kcp: listening on 127.0.0.1:60064
> Warning: 6 01:24:44 [Warning] core: Xray 1.4.5 started
> 2021/10/16 01:24:46 [Debug] [3692665765] proxy/dokodemo: processing connection from: 127.0.0.1:57920
> 2021/10/16 01:24:46 [Info] [3692665765] proxy/dokodemo: received request for 127.0.0.1:57920
> 2021/10/16 01:24:46 [Info] [3692665765] app/dispatcher: default route for tcp:127.0.0.1:57918
> 2021/10/16 01:24:46 127.0.0.1:57920 accepted tcp:127.0.0.1:57918
> 2021/10/16 01:24:46 [Info] transport/internet/kcp: dialing mKCP to udp:127.0.0.1:60064
> 2021/10/16 01:24:46 [Debug] transport/internet: dialing to udp:127.0.0.1:60064
> 2021/10/16 01:24:46 [Info] transport/internet/kcp: #43629 creating connection to 127.0.0.1:60064
> 2021/10/16 01:24:48 [Info] [3692665765] proxy/vmess/outbound: tunneling request to tcp:127.0.0.1:57918 via tcp:127.0.0.1:60064
> 2021/10/16 01:24:48 [Info] transport/internet/kcp: #43629 creating connection to 127.0.0.1:60065
> 2021/10/16 01:24:48 [Info] [663379056] proxy/vmess/inbound: received request for tcp:127.0.0.1:57918
> 2021/10/16 01:24:48 [Info] [663379056] app/dispatcher: default route for tcp:127.0.0.1:57918
> 2021/10/16 01:24:48 127.0.0.1:60065 accepted tcp:127.0.0.1:57918
> 2021/10/16 01:24:48 [Info] [663379056] proxy/freedom: opening connection to tcp:127.0.0.1:57918
> 2021/10/16 01:24:48 [Info] [663379056] transport/internet/tcp: dialing TCP to tcp:127.0.0.1:57918
> 2021/10/16 01:24:48 [Debug] transport/internet: dialing to tcp:127.0.0.1:57918
>     tls_test.go:354: read tcp 127.0.0.1:57920->127.0.0.1:57919: i/o timeout
> 2021/10/16 01:24:48 [Info] Closing all servers.
> 2021/10/16 01:24:48 [Info] All server closed.
> Failed accept TCP connection: accept tcp 127.0.0.1:57918: use of closed network connection
> --- FAIL: TestTLSOverKCP (4.02s)

> === RUN   TestAutoIssuingCertificate
> Xray 1.5.0 (Xray, Penetrates Everything.) Custom (go1.17.2 darwin/amd64)
> A unified platform for anti-censorship.
> Xray 1.5.0 (Xray, Penetrates Everything.) Custom (go1.17.2 darwin/amd64)
> A unified platform for anti-censorship.
> 2021/10/26 05:04:00 [Debug] app/proxyman/inbound: creating stream worker on 127.0.0.1:57913
> 2021/10/26 05:04:00 [Info] transport/internet/tcp: listening TCP on 127.0.0.1:57913
> 2021/10/26 05:04:00 [Debug] app/proxyman/inbound: creating stream worker on 127.0.0.1:57914
> 2021/10/26 05:04:00 [Info] transport/internet/tcp: listening TCP on 127.0.0.1:57914
> Warning: 6 05:04:00 [Warning] core: Xray 1.5.0 started
> Warning: 6 05:04:00 [Warning] core: Xray 1.5.0 started
> 2021/10/26 05:04:02 [Debug] [2108095845] proxy/dokodemo: processing connection from: 127.0.0.1:57916
> 2021/10/26 05:04:02 [Info] [2108095845] proxy/dokodemo: received request for 127.0.0.1:57916
> 2021/10/26 05:04:02 [Info] [2108095845] app/dispatcher: default route for tcp:127.0.0.1:57912
> 2021/10/26 05:04:02 127.0.0.1:57916 accepted tcp:127.0.0.1:57912
> 2021/10/26 05:04:02 [Info] [2108095845] transport/internet/tcp: dialing TCP to tcp:127.0.0.1:57913
> 2021/10/26 05:04:02 [Debug] transport/internet: dialing to tcp:127.0.0.1:57913
>     tls_test.go:251: read tcp 127.0.0.1:57916->127.0.0.1:57914: i/o timeout
> 2021/10/26 05:04:04 [Debug] [276061090] proxy/dokodemo: processing connection from: 127.0.0.1:57918
> 2021/10/26 05:04:04 [Info] [276061090] proxy/dokodemo: received request for 127.0.0.1:57918
> 2021/10/26 05:04:04 [Info] [276061090] app/dispatcher: default route for tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 127.0.0.1:57918 accepted tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [276061090] transport/internet/tcp: dialing TCP to tcp:127.0.0.1:57913
> 2021/10/26 05:04:04 [Debug] transport/internet: dialing to tcp:127.0.0.1:57913
> 2021/10/26 05:04:04 [Info] [2108095845] proxy/vmess/outbound: tunneling request to tcp:127.0.0.1:57912 via tcp:127.0.0.1:57913
> 2021/10/26 05:04:04 [Info] [276061090] proxy/vmess/outbound: tunneling request to tcp:127.0.0.1:57912 via tcp:127.0.0.1:57913
> 2021/10/26 05:04:04 [Info] transport/internet/tls: new certificate for example.com (expire on 2021-10-26T06:04:04Z) issued
> 2021/10/26 05:04:04 [Info] transport/internet/tls: new certificate for example.com (expire on 2021-10-26T06:04:04Z) issued
> 2021/10/26 05:04:04 [Info] [2251492753] proxy/vmess/inbound: received request for tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [2985197607] proxy/vmess/inbound: received request for tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [2251492753] app/dispatcher: default route for tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 127.0.0.1:57917 accepted tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [2251492753] proxy/freedom: opening connection to tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [2251492753] transport/internet/tcp: dialing TCP to tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Debug] transport/internet: dialing to tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [2985197607] app/dispatcher: default route for tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [2773020914] proxy/vmess/inbound: received request for tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [2773020914] app/dispatcher: default route for tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 127.0.0.1:57932 accepted tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [2773020914] proxy/freedom: opening connection to tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [2773020914] transport/internet/tcp: dialing TCP to tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Debug] transport/internet: dialing to tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Debug] [2861773689] proxy/dokodemo: processing connection from: 127.0.0.1:57934
> 2021/10/26 05:04:04 [Info] [2861773689] proxy/dokodemo: received request for 127.0.0.1:57934
> 2021/10/26 05:04:04 [Info] [2861773689] app/dispatcher: default route for tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 127.0.0.1:57934 accepted tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [2861773689] transport/internet/tcp: dialing TCP to tcp:127.0.0.1:57913
> 2021/10/26 05:04:04 [Debug] transport/internet: dialing to tcp:127.0.0.1:57913
> 2021/10/26 05:04:04 [Info] [2861773689] proxy/vmess/outbound: tunneling request to tcp:127.0.0.1:57912 via tcp:127.0.0.1:57913
> 2021/10/26 05:04:04 [Info] [4009836136] proxy/vmess/inbound: received request for tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [4009836136] app/dispatcher: default route for tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 127.0.0.1:57935 accepted tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [4009836136] proxy/freedom: opening connection to tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [4009836136] transport/internet/tcp: dialing TCP to tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Debug] transport/internet: dialing to tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Debug] [683629327] proxy/dokodemo: processing connection from: 127.0.0.1:57937
> 2021/10/26 05:04:04 [Info] [683629327] proxy/dokodemo: received request for 127.0.0.1:57937
> 2021/10/26 05:04:04 [Info] [683629327] app/dispatcher: default route for tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 127.0.0.1:57937 accepted tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [683629327] transport/internet/tcp: dialing TCP to tcp:127.0.0.1:57913
> 2021/10/26 05:04:04 [Debug] transport/internet: dialing to tcp:127.0.0.1:57913
> 2021/10/26 05:04:04 [Info] [683629327] proxy/vmess/outbound: tunneling request to tcp:127.0.0.1:57912 via tcp:127.0.0.1:57913
> 2021/10/26 05:04:04 [Info] [171006827] proxy/vmess/inbound: received request for tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [171006827] app/dispatcher: default route for tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 127.0.0.1:57938 accepted tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [171006827] proxy/freedom: opening connection to tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [171006827] transport/internet/tcp: dialing TCP to tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Debug] transport/internet: dialing to tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Debug] [1650106380] proxy/dokodemo: processing connection from: 127.0.0.1:57940
> 2021/10/26 05:04:04 [Info] [1650106380] proxy/dokodemo: received request for 127.0.0.1:57940
> 2021/10/26 05:04:04 [Info] [1650106380] app/dispatcher: default route for tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 127.0.0.1:57940 accepted tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [1650106380] transport/internet/tcp: dialing TCP to tcp:127.0.0.1:57913
> 2021/10/26 05:04:04 [Debug] transport/internet: dialing to tcp:127.0.0.1:57913
> 2021/10/26 05:04:04 [Info] [1650106380] proxy/vmess/outbound: tunneling request to tcp:127.0.0.1:57912 via tcp:127.0.0.1:57913
> 2021/10/26 05:04:04 [Info] [3329904998] proxy/vmess/inbound: received request for tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [3329904998] app/dispatcher: default route for tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 127.0.0.1:57941 accepted tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [3329904998] proxy/freedom: opening connection to tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [3329904998] transport/internet/tcp: dialing TCP to tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Debug] transport/internet: dialing to tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Debug] [134014321] proxy/dokodemo: processing connection from: 127.0.0.1:57943
> 2021/10/26 05:04:04 [Info] [134014321] proxy/dokodemo: received request for 127.0.0.1:57943
> 2021/10/26 05:04:04 [Info] [134014321] app/dispatcher: default route for tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 127.0.0.1:57943 accepted tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [134014321] transport/internet/tcp: dialing TCP to tcp:127.0.0.1:57913
> 2021/10/26 05:04:04 [Debug] transport/internet: dialing to tcp:127.0.0.1:57913
> 2021/10/26 05:04:04 [Info] [134014321] proxy/vmess/outbound: tunneling request to tcp:127.0.0.1:57912 via tcp:127.0.0.1:57913
> 2021/10/26 05:04:04 [Info] [2579723939] proxy/vmess/inbound: received request for tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [2579723939] app/dispatcher: default route for tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 127.0.0.1:57944 accepted tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [2579723939] proxy/freedom: opening connection to tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] [2579723939] transport/internet/tcp: dialing TCP to tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Debug] transport/internet: dialing to tcp:127.0.0.1:57912
> 2021/10/26 05:04:04 [Info] Closing all servers.
> Failed accept TCP connection: accept tcp 127.0.0.1:57912: use of closed network connection
> 2021/10/26 05:04:04 [Info] All server closed.
> --- FAIL: TestAutoIssuingCertificate (4.10s)
