### PR TITLE
replace same tag default outbound handler

### DIFF
--- a/app/proxyman/outbound/outbound.go
+++ b/app/proxyman/outbound/outbound.go
@@ -103,7 +103,8 @@ func (m *Manager) AddHandler(ctx context.Context, handler outbound.Handler) erro
 	m.access.Lock()
 	defer m.access.Unlock()
 
-	if m.defaultHandler == nil {
+	if m.defaultHandler == nil ||
+		(len(m.defaultHandler.Tag()) > 0 && m.defaultHandler.Tag() == handler.Tag()) {
 		m.defaultHandler = handler
 	}
 

--- a/app/proxyman/outbound/outbound.go
+++ b/app/proxyman/outbound/outbound.go
@@ -4,7 +4,6 @@ package outbound
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"sync"
 
@@ -112,7 +111,7 @@ func (m *Manager) AddHandler(ctx context.Context, handler outbound.Handler) erro
 
 	if len(tag) > 0 {
 		if oldHandler, found := m.taggedHandler[tag]; found {
-			errors.New(fmt.Sprintf("will replace the existed outbound with the tag: %s", tag)).AtWarning().WriteToLog()
+			errors.New("will replace the existed outbound with the tag: " + tag).AtWarning().WriteToLog()
 			_ = oldHandler.Close()
 		}
 		m.taggedHandler[tag] = handler


### PR DESCRIPTION
example config:
```
{
  "outbounds": [
    {
      "protocol": "vmess",
      "tag": "tagA"
    },
    {
      "protocol": "vmess",
      "tag": "tagA"
    }
  ]
}
```
first tagA outbound will be default outbound, the second outbound will replace first one in `taggedHandler `.
it looks weird.  like a orphan outbound.


