### PR TITLE
Fix: compatible with reverse portal of legacy V2Ray

### DIFF
--- a/app/reverse/reverse.go
+++ b/app/reverse/reverse.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	internalDomain = "reverse.internal.v2fly.org"
+	internalDomain         = "reverse.internal.v2fly.org"
+	internalDomainProjectV = "reverse.internal.v2ray.com"
 )
 
 func isDomain(dest net.Destination, domain string) bool {
@@ -22,7 +23,7 @@ func isDomain(dest net.Destination, domain string) bool {
 }
 
 func isInternalDomain(dest net.Destination) bool {
-	return isDomain(dest, internalDomain)
+	return isDomain(dest, internalDomain) || isDomain(dest, internalDomainProjectV)
 }
 
 func init() {


### PR DESCRIPTION
It fixed that `bridge` does not properly dispatch connections from `portal` of legacy V2Ray.
It seems like an unexpected and breaking change caused by #677.

