### PR TITLE
search for assets in xdg data directories on non-windows platforms

### DIFF
--- a/common/platform/others.go
+++ b/common/platform/others.go
@@ -4,10 +4,9 @@
 package platform
 
 import (
-	"errors"
-	"io/fs"
-	"os"
 	"path/filepath"
+
+	"github.com/adrg/xdg"
 )
 
 func LineSeparator() string {
@@ -19,20 +18,10 @@ func GetAssetLocation(file string) string {
 	const name = "v2ray.location.asset"
 	assetPath := NewEnvFlag(name).GetValue(getExecutableDir)
 	defPath := filepath.Join(assetPath, file)
-	for _, p := range []string{
-		defPath,
-		filepath.Join("/usr/local/share/v2ray/", file),
-		filepath.Join("/usr/share/v2ray/", file),
-		filepath.Join("/opt/share/v2ray/", file),
-	} {
-		if _, err := os.Stat(p); err != nil && errors.Is(err, fs.ErrNotExist) {
-			continue
-		}
-
-		// asset found
-		return p
+	relPath := filepath.Join("v2ray", file)
+	fullPath, err := xdg.SearchDataFile(relPath)
+	if err != nil {
+		return defPath
 	}
-
-	// asset not found, let the caller throw out the error
-	return defPath
+	return fullPath
 }

--- a/common/platform/others.go
+++ b/common/platform/others.go
@@ -10,18 +10,8 @@ import (
 	"path/filepath"
 )
 
-func ExpandEnv(s string) string {
-	return os.ExpandEnv(s)
-}
-
 func LineSeparator() string {
 	return "\n"
-}
-
-func GetToolLocation(file string) string {
-	const name = "v2ray.location.tool"
-	toolPath := EnvFlag{Name: name, AltName: NormalizeEnvName(name)}.GetValue(getExecutableDir)
-	return filepath.Join(toolPath, file)
 }
 
 // GetAssetLocation search for `file` in certain locations

--- a/common/platform/windows.go
+++ b/common/platform/windows.go
@@ -5,19 +5,8 @@ package platform
 
 import "path/filepath"
 
-func ExpandEnv(s string) string {
-	// TODO
-	return s
-}
-
 func LineSeparator() string {
 	return "\r\n"
-}
-
-func GetToolLocation(file string) string {
-	const name = "v2ray.location.tool"
-	toolPath := EnvFlag{Name: name, AltName: NormalizeEnvName(name)}.GetValue(getExecutableDir)
-	return filepath.Join(toolPath, file+".exe")
 }
 
 // GetAssetLocation search for `file` in the excutable dir

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/v2fly/v2ray-core/v5
 go 1.17
 
 require (
+	github.com/adrg/xdg v0.4.0
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/go-chi/render v1.0.1
 	github.com/go-playground/validator/v10 v10.10.0

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGy
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
+github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
@@ -503,6 +505,7 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d h1:FjkYO/PPp4Wi0EAUOVLxePm7qVW4r4ctbWpURyuOD0E=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=


### PR DESCRIPTION
ref: https://github.com/v2rayA/v2rayA/pull/393

search paths before the change:
- `/usr/local/share/v2ray`
- `/usr/share/v2ray`
- `/opt/share/v2ray`
- `$V2RAY_LOCATION_ASSET or executable dir`

search paths after the change:
- `$XDG_DATA_HOME/v2ray` or `~/.local/share/v2ray`
- `for dir in $XDG_DATA_DIRS; $dir/v2ray` or `/usr/local/share/v2ray` and `/usr/share/v2ray`
- `$V2RAY_LOCATION_ASSET or executable dir`

the only breaking change is that `/opt/share/v2ray` is no longer searched