### PR TITLE
Fix some flaky tests related to pick port

### DIFF
--- a/testing/scenarios/common.go
+++ b/testing/scenarios/common.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"sync"
 	"syscall"
+	"testing"
 	"time"
 
 	"google.golang.org/protobuf/proto"
@@ -222,4 +223,21 @@ func testTCPConn2(conn net.Conn, payloadSize int, timeout time.Duration) func() 
 
 		return nil
 	}
+}
+
+func WaitConnAvailableWithTest(t *testing.T, testFunc func() error) bool {
+	for i := 1; ; i++ {
+		if i > 10 {
+			t.Log("All attempts failed to test tcp conn")
+			return false
+		}
+		time.Sleep(time.Millisecond * 10)
+		if err := testFunc(); err != nil {
+			t.Log("err ", err)
+		} else {
+			t.Log("success with", i, "attempts")
+			break
+		}
+	}
+	return true
 }

--- a/testing/scenarios/feature_test.go
+++ b/testing/scenarios/feature_test.go
@@ -235,7 +235,7 @@ func TestProxyOverKCP(t *testing.T) {
 	defer tcpServer.Close()
 
 	serverUserID := protocol.NewID(uuid.New())
-	serverPort := tcp.PickPort()
+	serverPort := udp.PickPort()
 	serverConfig := &core.Config{
 		Inbound: []*core.InboundHandlerConfig{
 			{

--- a/testing/scenarios/socks_test.go
+++ b/testing/scenarios/socks_test.go
@@ -137,7 +137,7 @@ func TestSocksBridageUDP(t *testing.T) {
 		},
 	}
 
-	clientPort := tcp.PickPort()
+	clientPort := udp.PickPort()
 	clientConfig := &core.Config{
 		Inbound: []*core.InboundHandlerConfig{
 			{
@@ -149,7 +149,7 @@ func TestSocksBridageUDP(t *testing.T) {
 					Address: net.NewIPOrDomain(dest.Address),
 					Port:    uint32(dest.Port),
 					NetworkList: &net.NetworkList{
-						Network: []net.Network{net.Network_TCP, net.Network_UDP},
+						Network: []net.Network{net.Network_UDP},
 					},
 				}),
 			},
@@ -232,7 +232,7 @@ func TestSocksBridageUDPWithRouting(t *testing.T) {
 		},
 	}
 
-	clientPort := tcp.PickPort()
+	clientPort := udp.PickPort()
 	clientConfig := &core.Config{
 		Inbound: []*core.InboundHandlerConfig{
 			{
@@ -244,7 +244,7 @@ func TestSocksBridageUDPWithRouting(t *testing.T) {
 					Address: net.NewIPOrDomain(dest.Address),
 					Port:    uint32(dest.Port),
 					NetworkList: &net.NetworkList{
-						Network: []net.Network{net.Network_TCP, net.Network_UDP},
+						Network: []net.Network{net.Network_UDP},
 					},
 				}),
 			},

--- a/testing/scenarios/vmess_test.go
+++ b/testing/scenarios/vmess_test.go
@@ -109,7 +109,7 @@ func TestVMessDynamicPort(t *testing.T) {
 		}
 
 		server, _ := InitializeServerConfig(serverConfig)
-		if server != nil && tcpConnAvailableAtPort(t, serverPort+100) {
+		if server != nil && WaitConnAvailableWithTest(t, testTCPConn(serverPort+100, 1024, time.Second*2)) {
 			defer CloseServer(server)
 			break
 		}
@@ -167,26 +167,9 @@ func TestVMessDynamicPort(t *testing.T) {
 	common.Must(err)
 	defer CloseServer(server)
 
-	if !tcpConnAvailableAtPort(t, clientPort) {
+	if !WaitConnAvailableWithTest(t, testTCPConn(clientPort, 1024, time.Second*2)) {
 		t.Fail()
 	}
-}
-
-func tcpConnAvailableAtPort(t *testing.T, port net.Port) bool {
-	for i := 1; ; i++ {
-		if i > 10 {
-			t.Log("All attempts failed to test tcp conn")
-			return false
-		}
-		time.Sleep(time.Millisecond * 10)
-		if err := testTCPConn(port, 1024, time.Second*2)(); err != nil {
-			t.Log("err ", err)
-		} else {
-			t.Log("success with", i, "attempts")
-			break
-		}
-	}
-	return true
 }
 
 func TestVMessGCM(t *testing.T) {

--- a/v2ray_test.go
+++ b/v2ray_test.go
@@ -57,7 +57,7 @@ func TestV2RayClose(t *testing.T) {
 					Address: net.NewIPOrDomain(net.LocalHostIP),
 					Port:    uint32(0),
 					NetworkList: &net.NetworkList{
-						Network: []net.Network{net.Network_TCP, net.Network_UDP},
+						Network: []net.Network{net.Network_TCP},
 					},
 				}),
 			},


### PR DESCRIPTION
For issues like:
```
--- FAIL: TestV2RayClose (0.00s)
panic: listen udp 127.0.0.1:49986: bind: An attempt was made to access a socket in a way forbidden by its access permissions. [recovered]
	panic: listen udp 127.0.0.1:49986: bind: An attempt was made to access a socket in a way forbidden by its access permissions.

goroutine 37 [running]:
testing.tRunner.func1.2({0x1ddde40, 0xc00028a280})
	C:/hostedtoolcache/windows/go/1.17.2/x64/src/testing/testing.go:1209 +0x24e
testing.tRunner.func1()
	C:/hostedtoolcache/windows/go/1.17.2/x64/src/testing/testing.go:1212 +0x218
panic({0x1ddde40, 0xc00028a280})
	C:/hostedtoolcache/windows/go/1.17.2/x64/src/runtime/panic.go:1038 +0x215
github.com/v2fly/v2ray-core/v4/common.Must(...)
	D:/a/v2ray-core/v2ray-core/common/common.go:27
github.com/v2fly/v2ray-core/v4_test.TestV2RayClose(0xc0000616c0)
	D:/a/v2ray-core/v2ray-core/v2ray_test.go:90 +0x6a9
testing.tRunner(0xc000061ba0, 0x1f38528)
	C:/hostedtoolcache/windows/go/1.17.2/x64/src/testing/testing.go:1259 +0x102
created by testing.(*T).Run
	C:/hostedtoolcache/windows/go/1.17.2/x64/src/testing/testing.go:1306 +0x35a
```