### PR TITLE
fix: net.Address type checking

### DIFF
--- a/transport/internet/tcp/hub.go
+++ b/transport/internet/tcp/hub.go
@@ -39,7 +39,7 @@ func ListenTCP(ctx context.Context, address net.Address, port net.Port, streamSe
 	}
 	var listener net.Listener
 	var err error
-	if port == net.Port(0) { // unix
+	if address.Family().IsDomain() {
 		listener, err = internet.ListenSystem(ctx, &net.UnixAddr{
 			Name: address.Domain(),
 			Net:  "unix",


### PR DESCRIPTION
Allow zero port for listening port, namely random port.