### PR TITLE
Fix failure of cache expired DNS record querying over DOH (v2fly#1556)

### DIFF
--- a/app/dns/nameserver_doh.go
+++ b/app/dns/nameserver_doh.go
@@ -297,7 +297,7 @@ func (s *DoHNameServer) findIPsForDomain(domain string, option dns_feature.IPOpt
 
 	var ips []net.Address
 	var lastErr error
-	if option.IPv6Enable && record.AAAA != nil && record.AAAA.RCode == dnsmessage.RCodeSuccess {
+	if option.IPv6Enable {
 		aaaa, err := record.AAAA.getIPs()
 		if err != nil {
 			lastErr = err
@@ -305,7 +305,7 @@ func (s *DoHNameServer) findIPsForDomain(domain string, option dns_feature.IPOpt
 		ips = append(ips, aaaa...)
 	}
 
-	if option.IPv4Enable && record.A != nil && record.A.RCode == dnsmessage.RCodeSuccess {
+	if option.IPv4Enable {
 		a, err := record.A.getIPs()
 		if err != nil {
 			lastErr = err


### PR DESCRIPTION
I might have found out why issue #1556 happened. I have tested this issue and found it would only recurrent when a domain name has only A record. But it works well if has both A and AAAA.

https://github.com/v2fly/v2ray-core/blob/0bf1f2bae6d305a612d159b7ec9211c7db46632d/app/dns/nameserver_doh.go#L300-L329

`if` statements at line 300 and 308 do check `record.AAAA != nil && record.AAAA.RCode == dnsmessage.RCodeSuccess` they shouldn't, which should be done by method `getIPs()`. This causes error `errRecordNotFound` should returned by `getIPs()` can't be captured to `lastErr`, and finally the function returns at line 325 with error `ErrEmptyResponse`. This will let its caller `QueryIP()` returns directly, and skip "domain name re-querying" step we really need.

I did delete job at line 300 and 308. It works fine for me. I hope this can help you!