### PR TITLE
Observatory probe interval的问题

### DIFF
--- a/app/observatory/observer.go
+++ b/app/observatory/observer.go
@@ -79,12 +79,13 @@ func (o *Observer) background() {
 			if o.finished.Done() {
 				return
 			}
-			sleepTime := time.Second * 10
-			if o.config.ProbeInterval != 0 {
-				sleepTime = time.Duration(o.config.ProbeInterval)
-			}
-			time.Sleep(sleepTime)
 		}
+
+		sleepTime := time.Second * 10
+		if o.config.ProbeInterval != 0 {
+			sleepTime = time.Duration(o.config.ProbeInterval)
+		}
+		time.Sleep(sleepTime)
 	}
 }
 


### PR DESCRIPTION
程序原来观测模式下的实现，是第一个周期，测试第一个outbound，第二个周期，测试第二个outbound。也就是，如果有10个outbound要测，周期是10s的话，那要等100秒，才能测完这10个。
现在也不清楚原来写这个机制的，是不是的确有需要，所以才这样实现。但目前以我看来，这样测试延迟并没有太大的实用价值，因此，这里修改为，测试完一个outbound，要测试下一个时，不间隔一个probeInterval。等所有都测试完，再等待一个probeInterval。