### PR TITLE
Fix: build routing condition for geo domain

### DIFF
--- a/app/router/config.go
+++ b/app/router/config.go
@@ -46,6 +46,18 @@ func (rr *RoutingRule) BuildCondition() (Condition, error) {
 		conds.Add(cond)
 	}
 
+	var geoDomains []*routercommon.Domain
+	for _, geo := range rr.GeoDomain {
+		geoDomains = append(geoDomains, geo.Domain...)
+	}
+	if len(geoDomains) > 0 {
+		cond, err := NewDomainMatcher(rr.DomainMatcher, geoDomains)
+		if err != nil {
+			return nil, newError("failed to build geo domain condition").Base(err)
+		}
+		conds.Add(cond)
+	}
+
 	if len(rr.UserEmail) > 0 {
 		conds.Add(NewUserMatcher(rr.UserEmail))
 	}

--- a/app/router/router.go
+++ b/app/router/router.go
@@ -220,7 +220,6 @@ func init() {
 					if err != nil {
 						return nil, newError("unable to load geodomain").Base(err)
 					}
-					rule.Domain = append(rule.Domain, geo.Domain...)
 				}
 			}
 			if v.PortList != "" {
@@ -240,6 +239,7 @@ func init() {
 				rule.SourcePortList = portList.Build()
 			}
 			rule.Domain = v.Domain
+			rule.GeoDomain = v.GeoDomain
 			if v.Networks != "" {
 				rule.Networks = net.ParseNetworks(v.Networks)
 			}


### PR DESCRIPTION
This fix routing condition not build for geoDomain in router rule with jsonv5 config.

---

Another simpler fix would be 
```diff
--- a/app/router/router.go
+++ b/app/router/router.go
@@ -239,7 +239,7 @@ func init() {
                                }
                                rule.SourcePortList = portList.Build()
                        }
-                       rule.Domain = v.Domain
+                       rule.Domain = append(rule.Domain, v.Domain...)
                        if v.Networks != "" {
                                rule.Networks = net.ParseNetworks(v.Networks)
                        }
```
which makes routing condition a union of both "geoDomain" and "domain", which might not be desired. Hence this fix.