### PR TITLE
Fix: correct TCP keepalive sockopt names for darwin

### DIFF
--- a/transport/internet/sockopt_darwin.go
+++ b/transport/internet/sockopt_darwin.go
@@ -24,18 +24,18 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 			}
 		}
 
-		if config.TcpKeepAliveIdle > 0 {
-			if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_KEEPALIVE, int(config.TcpKeepAliveInterval)); err != nil {
+		if config.TcpKeepAliveInterval > 0 {
+			if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_KEEPINTVL, int(config.TcpKeepAliveInterval)); err != nil {
 				return newError("failed to set TCP_KEEPINTVL").Base(err)
 			}
 		}
-		if config.TcpKeepAliveInterval > 0 {
-			if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_KEEPINTVL, int(config.TcpKeepAliveIdle)); err != nil {
-				return newError("failed to set TCP_KEEPIDLE").Base(err)
+		if config.TcpKeepAliveIdle > 0 {
+			if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_KEEPALIVE, int(config.TcpKeepAliveIdle)); err != nil {
+				return newError("failed to set TCP_KEEPALIVE (TCP keepalive idle time on Darwin)").Base(err)
 			}
 		}
 
-		if config.TcpKeepAliveIdle > 0 || config.TcpKeepAliveInterval > 0 {
+		if config.TcpKeepAliveInterval > 0 || config.TcpKeepAliveIdle > 0 {
 			if err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_KEEPALIVE, 1); err != nil {
 				return newError("failed to set SO_KEEPALIVE").Base(err)
 			}
@@ -69,17 +69,17 @@ func applyInboundSocketOptions(network string, fd uintptr, config *SocketConfig)
 				return err
 			}
 		}
-		if config.TcpKeepAliveIdle > 0 {
-			if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_KEEPALIVE, int(config.TcpKeepAliveInterval)); err != nil {
+		if config.TcpKeepAliveInterval > 0 {
+			if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_KEEPINTVL, int(config.TcpKeepAliveInterval)); err != nil {
 				return newError("failed to set TCP_KEEPINTVL").Base(err)
 			}
 		}
-		if config.TcpKeepAliveInterval > 0 {
-			if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.SO_KEEPALIVE, int(config.TcpKeepAliveIdle)); err != nil {
-				return newError("failed to set TCP_KEEPIDLE").Base(err)
+		if config.TcpKeepAliveIdle > 0 {
+			if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_KEEPALIVE, int(config.TcpKeepAliveIdle)); err != nil {
+				return newError("failed to set TCP_KEEPALIVE (TCP keepalive idle time on Darwin)").Base(err)
 			}
 		}
-		if config.TcpKeepAliveIdle > 0 || config.TcpKeepAliveInterval > 0 {
+		if config.TcpKeepAliveInterval > 0 || config.TcpKeepAliveIdle > 0 {
 			if err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_KEEPALIVE, 1); err != nil {
 				return newError("failed to set SO_KEEPALIVE").Base(err)
 			}


### PR DESCRIPTION
I have no darwin devices to test these changes, but the original code doesn't seem to be correct.

/cc @ValdikSS 