### PR TITLE
Update testing/scenarios/common.go

### DIFF
--- a/testing/scenarios/common.go
+++ b/testing/scenarios/common.go
@@ -69,8 +69,6 @@ func InitializeServerConfigs(configs ...*core.Config) ([]*exec.Cmd, error) {
 		servers = append(servers, server)
 	}
 
-	time.Sleep(time.Second * 2)
-
 	return servers, nil
 }
 
@@ -90,6 +88,8 @@ func InitializeServerConfig(config *core.Config) (*exec.Cmd, error) {
 	if err := proc.Start(); err != nil {
 		return nil, err
 	}
+
+	time.Sleep(time.Second * 2)
 
 	return proc, nil
 }


### PR DESCRIPTION
On low-performance machines, some tests fail.

For example, the test `TestVMessDynamicPort` in `testing/scenarios/vmess_test.go`:
https://github.com/v2fly/v2ray-core/blob/4e247840821f3dd326722d4db02ee3c237074fc2/testing/scenarios/vmess_test.go#L111-L119
will fail, because no matter how many times it is retried, the port `serverPort+100` will not be available immediately after the server process has started.

By moving the `time.Sleep(time.Second * 2)` from `InitializeServerConfigs` to `InitializeServerConfig`, every v2ray process created will have sufficient time to begin working. 