### PR TITLE
[v4] Fix: correct TCP keepalive sockopt names for darwin

### DIFF
--- a/transport/internet/sockopt_darwin.go
+++ b/transport/internet/sockopt_darwin.go
@@ -9,8 +9,6 @@ const (
 	TCP_FASTOPEN_SERVER = 0x01 // nolint: golint,stylecheck
 	// TCP_FASTOPEN_CLIENT is the value to enable TCP fast open on darwin for client connections.
 	TCP_FASTOPEN_CLIENT = 0x02 // nolint: revive,stylecheck
-	// syscall.TCP_KEEPINTVL is missing on some darwin architectures.
-	sysTCP_KEEPINTVL = 0x101 // nolint: revive,stylecheck
 )
 
 func applyOutboundSocketOptions(network string, address string, fd uintptr, config *SocketConfig) error {
@@ -27,14 +25,14 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 		}
 
 		if config.TcpKeepAliveIdle > 0 || config.TcpKeepAliveInterval > 0 {
-			if config.TcpKeepAliveIdle > 0 {
-				if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_KEEPALIVE, int(config.TcpKeepAliveInterval)); err != nil {
+			if config.TcpKeepAliveInterval > 0 {
+				if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_KEEPINTVL, int(config.TcpKeepAliveInterval)); err != nil {
 					return newError("failed to set TCP_KEEPINTVL", err)
 				}
 			}
-			if config.TcpKeepAliveInterval > 0 {
-				if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, sysTCP_KEEPINTVL, int(config.TcpKeepAliveIdle)); err != nil {
-					return newError("failed to set TCP_KEEPIDLE", err)
+			if config.TcpKeepAliveIdle > 0 {
+				if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_KEEPALIVE, int(config.TcpKeepAliveIdle)); err != nil {
+					return newError("failed to set TCP_KEEPALIVE (TCP keepalive idle time on Darwin)", err)
 				}
 			}
 			if err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_KEEPALIVE, 1); err != nil {
@@ -59,14 +57,14 @@ func applyInboundSocketOptions(network string, fd uintptr, config *SocketConfig)
 			}
 		}
 		if config.TcpKeepAliveIdle > 0 || config.TcpKeepAliveInterval > 0 {
-			if config.TcpKeepAliveIdle > 0 {
-				if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_KEEPALIVE, int(config.TcpKeepAliveInterval)); err != nil {
+			if config.TcpKeepAliveInterval > 0 {
+				if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_KEEPINTVL, int(config.TcpKeepAliveInterval)); err != nil {
 					return newError("failed to set TCP_KEEPINTVL", err)
 				}
 			}
-			if config.TcpKeepAliveInterval > 0 {
-				if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, sysTCP_KEEPINTVL, int(config.TcpKeepAliveIdle)); err != nil {
-					return newError("failed to set TCP_KEEPIDLE", err)
+			if config.TcpKeepAliveIdle > 0 {
+				if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_KEEPALIVE, int(config.TcpKeepAliveIdle)); err != nil {
+					return newError("failed to set TCP_KEEPALIVE (TCP keepalive idle time on Darwin)", err)
 				}
 			}
 			if err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_KEEPALIVE, 1); err != nil {


### PR DESCRIPTION
This backports https://github.com/v2fly/v2ray-core/pull/1777 to `dev-v4main` branch.