### PR TITLE
Feat: refine the logic of security type AUTO

### DIFF
--- a/common/protocol/headers.go
+++ b/common/protocol/headers.go
@@ -1,8 +1,9 @@
 package protocol
 
 import (
-	"golang.org/x/sys/cpu"
 	"runtime"
+
+	"golang.org/x/sys/cpu"
 
 	"github.com/v2fly/v2ray-core/v5/common/bitmask"
 	"github.com/v2fly/v2ray-core/v5/common/net"

--- a/common/protocol/headers.go
+++ b/common/protocol/headers.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"golang.org/x/sys/cpu"
 	"runtime"
 
 	"github.com/v2fly/v2ray-core/v5/common/bitmask"
@@ -79,9 +80,21 @@ type CommandSwitchAccount struct {
 	ValidMin byte
 }
 
+var (
+	hasGCMAsmAMD64 = cpu.X86.HasAES && cpu.X86.HasPCLMULQDQ
+	hasGCMAsmARM64 = cpu.ARM64.HasAES && cpu.ARM64.HasPMULL
+	// Keep in sync with crypto/aes/cipher_s390x.go.
+	hasGCMAsmS390X = cpu.S390X.HasAES && cpu.S390X.HasAESCBC && cpu.S390X.HasAESCTR &&
+		(cpu.S390X.HasGHASH || cpu.S390X.HasAESGCM)
+
+	hasAESGCMHardwareSupport = runtime.GOARCH == "amd64" && hasGCMAsmAMD64 ||
+		runtime.GOARCH == "arm64" && hasGCMAsmARM64 ||
+		runtime.GOARCH == "s390x" && hasGCMAsmS390X
+)
+
 func (sc *SecurityConfig) GetSecurityType() SecurityType {
 	if sc == nil || sc.Type == SecurityType_AUTO {
-		if runtime.GOARCH == "amd64" || runtime.GOARCH == "s390x" || runtime.GOARCH == "arm64" {
+		if hasAESGCMHardwareSupport {
 			return SecurityType_AES128_GCM
 		}
 		return SecurityType_CHACHA20_POLY1305


### PR DESCRIPTION
Dear V2Fly Maintainers,

This patch will change the logic of cipher selection for security type "auto", which based on codes migrated from go standard library `crypto/tls`.  
In the previous, this took mistakes on devices which does not support AES-GCM hardware acceleration but have installed a 64-bit system, such as J1900 mini-PC with x86_64 system and Raspberry with aarch64 kernel. It influenced me and my friends so we used to specify `chacha20-poly1305` manually. And this might solve the problem.  
I will keep following on this, thank you!  
  
Best regards,  
Hellojack  
  
Refer: 
https://cs.opensource.google/go/go/+/master:src/crypto/tls/cipher_suites.go;drc=9e6cd3985dbcdcfe0ed2075be6dbe8c5d6de59cb;l=364