### PR TITLE
Fix erroneous prefix checking

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -182,7 +182,7 @@ func shouldOverride(result SniffResult, domainOverride []string) bool {
 		protocolString = resComp.ProtocolForDomainResult()
 	}
 	for _, p := range domainOverride {
-		if strings.HasPrefix(protocolString, p) {
+		if strings.HasPrefix(p, protocolString) {
 			return true
 		}
 		if resultSubset, ok := result.(SnifferIsProtoSubsetOf); ok {


### PR DESCRIPTION
`fakedns+others` won't work due to this bug.