### PR TITLE
Remove v2ctl from debian/rules

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -21,7 +21,7 @@ jobs:
   package:
     if: github.repository == 'v2fly/v2ray-core'
     runs-on: ubuntu-latest
-    container: golang:1.17-bullseye
+    container: golang:1.19-bullseye
 
     steps:
       - name: Update & install dependencies

--- a/release/debian/rules
+++ b/release/debian/rules
@@ -14,8 +14,6 @@ execute_after_dh_auto_configure:
 override_dh_auto_build:
 	DH_GOPKG="github.com/v2fly/v2ray-core/v5/main" dh_auto_build -- -ldflags "-s -w"
 	cd $(BUILDDIR); mv bin/main bin/v2ray
-	DH_GOPKG="github.com/v2fly/v2ray-core/v5/infra/control/main" dh_auto_build -- -ldflags "-s -w" -tags confonly
-	cd $(BUILDDIR); mv bin/main bin/v2ctl
 
 override_dh_auto_install:
 	dh_auto_install -- --no-source


### PR DESCRIPTION
It seems to be left over from https://github.com/v2fly/v2ray-core/pull/488