### PR TITLE
Feat: add bind to device to Windows and Darwin

### DIFF
--- a/transport/internet/sockopt_darwin.go
+++ b/transport/internet/sockopt_darwin.go
@@ -1,6 +1,8 @@
 package internet
 
 import (
+	"net"
+
 	"golang.org/x/sys/unix"
 )
 
@@ -39,6 +41,19 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 			if err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_KEEPALIVE, 1); err != nil {
 				return newError("failed to set SO_KEEPALIVE").Base(err)
 			}
+		}
+	}
+
+	if config.BindToDevice != "" {
+		iface, err := net.InterfaceByName(config.BindToDevice)
+		if err != nil {
+			return newError("failed to get interface ", config.BindToDevice).Base(err)
+		}
+		if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_IP, unix.IP_BOUND_IF, iface.Index); err != nil {
+			return newError("failed to set IP_BOUND_IF", err)
+		}
+		if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_IPV6, unix.IPV6_BOUND_IF, iface.Index); err != nil {
+			return newError("failed to set IPV6_BOUND_IF", err)
 		}
 	}
 
@@ -83,6 +98,19 @@ func applyInboundSocketOptions(network string, fd uintptr, config *SocketConfig)
 			if err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_KEEPALIVE, 1); err != nil {
 				return newError("failed to set SO_KEEPALIVE").Base(err)
 			}
+		}
+	}
+
+	if config.BindToDevice != "" {
+		iface, err := net.InterfaceByName(config.BindToDevice)
+		if err != nil {
+			return newError("failed to get interface ", config.BindToDevice).Base(err)
+		}
+		if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_IP, unix.IP_BOUND_IF, iface.Index); err != nil {
+			return newError("failed to set IP_BOUND_IF", err)
+		}
+		if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_IPV6, unix.IPV6_BOUND_IF, iface.Index); err != nil {
+			return newError("failed to set IPV6_BOUND_IF", err)
 		}
 	}
 

--- a/transport/internet/sockopt_windows.go
+++ b/transport/internet/sockopt_windows.go
@@ -1,13 +1,16 @@
 package internet
 
 import (
+	"net"
 	"syscall"
 
 	"golang.org/x/sys/windows"
 )
 
 const (
-	TCP_FASTOPEN = 15 // nolint: revive,stylecheck
+	TCP_FASTOPEN    = 15 // nolint: revive,stylecheck
+	IP_UNICAST_IF   = 31 // nolint: revive,stylecheck
+	IPV6_UNICAST_IF = 31 // nolint: revive,stylecheck
 )
 
 func setTFO(fd syscall.Handle, settings SocketConfig_TCPFastOpenState) error {
@@ -33,6 +36,19 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.SOL_SOCKET, syscall.SO_KEEPALIVE, 1); err != nil {
 				return newError("failed to set SO_KEEPALIVE", err)
 			}
+		}
+	}
+
+	if config.BindToDevice != "" {
+		iface, err := net.InterfaceByName(config.BindToDevice)
+		if err != nil {
+			return newError("failed to get interface ", config.BindToDevice).Base(err)
+		}
+		if err := windows.SetsockoptInt(windows.Handle(fd), windows.IPPROTO_IP, IP_UNICAST_IF, iface.Index); err != nil {
+			return newError("failed to set IP_UNICAST_IF", err)
+		}
+		if err := windows.SetsockoptInt(windows.Handle(fd), windows.IPPROTO_IPV6, IPV6_UNICAST_IF, iface.Index); err != nil {
+			return newError("failed to set IPV6_UNICAST_IF", err)
 		}
 	}
 


### PR DESCRIPTION
I don't have any device to test if it works on Mac OS.

> Windows IP_UNICAST_IF
> Gets or sets the outgoing interface for sending IPv4 traffic. This option does not change the default interface for receiving IPv4 traffic. This option is important for multihomed computers. The input value for setting this option is a 4-byte IPv4 address in network byte order. This DWORD parameter must be an interface index in network byte order. Any IP address in the 0.x.x.x block (first octet of 0) except IPv4 address 0.0.0.0 is treated as an interface index. An interface index is a 24-bit number, and the 0.0.0.0/8 IPv4 address block is not used (this range is reserved). The interface index can be used to specify the default interface for sending traffic for IPv4. The [GetAdaptersAddresses](https://docs.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-getadaptersaddresses) function can be used to obtain the interface index information. If optval is zero , the default interface for sending traffic is set to unspecified. When getting this option, the optval returns the current default interface index for sending IPv4 traffic in host byte order.

<https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options>
