### PR TITLE
Feat: [app/proxyman] [proxy/dokodemo, socks] More accurate inbound gateway detection and behaviors

### DIFF
--- a/app/proxyman/inbound/always.go
+++ b/app/proxyman/inbound/always.go
@@ -78,15 +78,6 @@ func NewAlwaysOnInboundHandler(ctx context.Context, tag string, receiverConfig *
 		return nil, newError("failed to parse stream config").Base(err).AtWarning()
 	}
 
-	if receiverConfig.ReceiveOriginalDestination {
-		if mss.SocketSettings == nil {
-			mss.SocketSettings = &internet.SocketConfig{}
-		}
-		if mss.SocketSettings.Tproxy == internet.SocketConfig_Off {
-			mss.SocketSettings.Tproxy = internet.SocketConfig_Redirect
-		}
-		mss.SocketSettings.ReceiveOriginalDestAddress = true
-	}
 	if pr == nil {
 		if net.HasNetwork(nl, net.Network_UNIX) {
 			newError("creating unix domain socket worker on ", address).AtDebug().WriteToLog()

--- a/app/proxyman/inbound/dynamic.go
+++ b/app/proxyman/inbound/dynamic.go
@@ -48,15 +48,6 @@ func NewDynamicInboundHandler(ctx context.Context, tag string, receiverConfig *p
 	if err != nil {
 		return nil, newError("failed to parse stream settings").Base(err).AtWarning()
 	}
-	if receiverConfig.ReceiveOriginalDestination {
-		if mss.SocketSettings == nil {
-			mss.SocketSettings = &internet.SocketConfig{}
-		}
-		if mss.SocketSettings.Tproxy == internet.SocketConfig_Off {
-			mss.SocketSettings.Tproxy = internet.SocketConfig_Redirect
-		}
-		mss.SocketSettings.ReceiveOriginalDestAddress = true
-	}
 
 	h.streamSettings = mss
 

--- a/common/net/system.go
+++ b/common/net/system.go
@@ -14,6 +14,7 @@ var (
 	DialUDP         = net.DialUDP
 	DialUnix        = net.DialUnix
 	FileConn        = net.FileConn
+	InterfaceAddrs  = net.InterfaceAddrs
 	Listen          = net.Listen
 	ListenTCP       = net.ListenTCP
 	ListenUDP       = net.ListenUDP

--- a/infra/conf/v4/v2ray.go
+++ b/infra/conf/v4/v2ray.go
@@ -10,6 +10,7 @@ import (
 	"github.com/v2fly/v2ray-core/v5/app/dispatcher"
 	"github.com/v2fly/v2ray-core/v5/app/proxyman"
 	"github.com/v2fly/v2ray-core/v5/app/stats"
+	"github.com/v2fly/v2ray-core/v5/common/net"
 	"github.com/v2fly/v2ray-core/v5/common/serial"
 	"github.com/v2fly/v2ray-core/v5/infra/conf/cfgcommon"
 	"github.com/v2fly/v2ray-core/v5/infra/conf/cfgcommon/loader"
@@ -199,6 +200,17 @@ func (c *InboundDetourConfig) Build() (*core.InboundHandlerConfig, error) {
 		if receiverSettings.StreamSettings.SocketSettings.Tproxy == internet.SocketConfig_Off {
 			receiverSettings.StreamSettings.SocketSettings.Tproxy = internet.SocketConfig_Redirect
 		}
+	}
+	if content, ok := rawConfig.(*SocksServerConfig); ok && content.UDP &&
+		(receiverSettings.Listen.AsAddress() == net.AnyIP || receiverSettings.Listen.AsAddress() == net.AnyIPv6) {
+		receiverSettings.ReceiveOriginalDestination = true
+		if receiverSettings.StreamSettings == nil {
+			receiverSettings.StreamSettings = &internet.StreamConfig{}
+		}
+		if receiverSettings.StreamSettings.SocketSettings == nil {
+			receiverSettings.StreamSettings.SocketSettings = &internet.SocketConfig{}
+		}
+		receiverSettings.StreamSettings.SocketSettings.ReceiveOriginalDestAddress = true
 	}
 	ts, err := rawConfig.(cfgcommon.Buildable).Build()
 	if err != nil {

--- a/infra/conf/v5cfg/inbound.go
+++ b/infra/conf/v5cfg/inbound.go
@@ -69,11 +69,31 @@ func (c InboundConfig) BuildV5(ctx context.Context) (proto.Message, error) {
 		return nil, newError("unable to load inbound protocol config").Base(err)
 	}
 
-	if content, ok := inboundConfigPack.(*dokodemo.SimplifiedConfig); ok {
-		receiverSettings.ReceiveOriginalDestination = content.FollowRedirect
+	if content, ok := inboundConfigPack.(*dokodemo.SimplifiedConfig); ok && content.FollowRedirect {
+		receiverSettings.ReceiveOriginalDestination = true
+		if receiverSettings.StreamSettings == nil {
+			receiverSettings.StreamSettings = &internet.StreamConfig{}
+		}
+		if receiverSettings.StreamSettings.SocketSettings == nil {
+			receiverSettings.StreamSettings.SocketSettings = &internet.SocketConfig{}
+		}
+		receiverSettings.StreamSettings.SocketSettings.ReceiveOriginalDestAddress = true
+		if receiverSettings.StreamSettings.SocketSettings.Tproxy == internet.SocketConfig_Off {
+			receiverSettings.StreamSettings.SocketSettings.Tproxy = internet.SocketConfig_Redirect
+		}
 	}
-	if content, ok := inboundConfigPack.(*dokodemo.Config); ok {
-		receiverSettings.ReceiveOriginalDestination = content.FollowRedirect
+	if content, ok := inboundConfigPack.(*dokodemo.Config); ok && content.FollowRedirect {
+		receiverSettings.ReceiveOriginalDestination = true
+		if receiverSettings.StreamSettings == nil {
+			receiverSettings.StreamSettings = &internet.StreamConfig{}
+		}
+		if receiverSettings.StreamSettings.SocketSettings == nil {
+			receiverSettings.StreamSettings.SocketSettings = &internet.SocketConfig{}
+		}
+		receiverSettings.StreamSettings.SocketSettings.ReceiveOriginalDestAddress = true
+		if receiverSettings.StreamSettings.SocketSettings.Tproxy == internet.SocketConfig_Off {
+			receiverSettings.StreamSettings.SocketSettings.Tproxy = internet.SocketConfig_Redirect
+		}
 	}
 
 	return &core.InboundHandlerConfig{

--- a/infra/conf/v5cfg/inbound.go
+++ b/infra/conf/v5cfg/inbound.go
@@ -7,8 +7,10 @@ import (
 
 	core "github.com/v2fly/v2ray-core/v5"
 	"github.com/v2fly/v2ray-core/v5/app/proxyman"
+	"github.com/v2fly/v2ray-core/v5/common/net"
 	"github.com/v2fly/v2ray-core/v5/common/serial"
 	"github.com/v2fly/v2ray-core/v5/proxy/dokodemo"
+	"github.com/v2fly/v2ray-core/v5/proxy/socks"
 	"github.com/v2fly/v2ray-core/v5/transport/internet"
 )
 
@@ -94,6 +96,17 @@ func (c InboundConfig) BuildV5(ctx context.Context) (proto.Message, error) {
 		if receiverSettings.StreamSettings.SocketSettings.Tproxy == internet.SocketConfig_Off {
 			receiverSettings.StreamSettings.SocketSettings.Tproxy = internet.SocketConfig_Redirect
 		}
+	}
+	if content, ok := inboundConfigPack.(*socks.ServerConfig); ok && content.UdpEnabled &&
+		(receiverSettings.Listen.AsAddress() == net.AnyIP || receiverSettings.Listen.AsAddress() == net.AnyIPv6) {
+		receiverSettings.ReceiveOriginalDestination = true
+		if receiverSettings.StreamSettings == nil {
+			receiverSettings.StreamSettings = &internet.StreamConfig{}
+		}
+		if receiverSettings.StreamSettings.SocketSettings == nil {
+			receiverSettings.StreamSettings.SocketSettings = &internet.SocketConfig{}
+		}
+		receiverSettings.StreamSettings.SocketSettings.ReceiveOriginalDestAddress = true
 	}
 
 	return &core.InboundHandlerConfig{

--- a/proxy/dokodemo/dokodemo.go
+++ b/proxy/dokodemo/dokodemo.go
@@ -99,11 +99,12 @@ func (d *Door) Process(ctx context.Context, network net.Network, conn internet.C
 	destinationOverridden := false
 	if d.config.FollowRedirect {
 		if outbound := session.OutboundFromContext(ctx); outbound != nil && outbound.Target.IsValid() {
-			dest = outbound.Target
-			destinationOverridden = true
+			if inbound := session.InboundFromContext(ctx); inbound == nil || outbound.Target != inbound.Gateway {
+				dest = outbound.Target
+				destinationOverridden = true
+			}
 		} else if handshake, ok := conn.(hasHandshakeAddress); ok {
-			addr := handshake.HandshakeAddress()
-			if addr != nil {
+			if addr := handshake.HandshakeAddress(); addr != nil {
 				dest.Address = addr
 				destinationOverridden = true
 			}


### PR DESCRIPTION
In a session context's inbound information we have a `Gateway` field indicating which inbound listener the connection is from. 

Currently, the `Gateway` field is always set to the tcp/udp worker's configured address and ports, which can be vague and unhelpful when the address is a wildcard `0.0.0.0`.

This PR improves the detection of the actual packet destination address when the configured address is `0.0.0.0` or `::`, and utilize the accurate gateway address to improve following inbound proxy's behavior:

#### SOCKS
When `UdpAssociate` address is unspecified, it returns inbound's gateway address. However if returned address is `0.0.0.0`, the client would not send udp packets back to the server.

https://github.com/v2fly/v2ray-core/pull/522 described this issue and solved it by specially handling the wildcard address in the client side. By obtaining the accurate gateway address, we could solve this issue in the server side, to make compatible a wider range of SOCKS clients.

#### Dokodemo Door
When in transparent proxy mode, the destination will always be rewritten and the forward address in dokodemo's config is not used. However one may expect a following use case: 

When setting up v2ray as the main DNS server, the main dokodemo inbound (port 53) could work in both forward mode and transparent proxy mode:
* If the packet target is v2ray instance itself, serve as a normal DNS server, and forward any non A and AAAA requests (e.g. PTR) to the configured forward address (e.g. 127.0.0.11 in docker container).
* If the packet target is not v2ray itself (gets redirected by transparent proxy), serve as transparent proxying DNS server, and forward any non A and AAAA requests to its original destination.

Therefore, by utilizing the accurate gateway address, the dokodemo inbound may not overwrite the destination if the packet target is dokodemo itself, therefore reusing the default forward address and working as a non-tproxy server.