### PR TITLE
feat: Replace default Health Ping URL to HTTPS

### DIFF
--- a/app/observatory/burst/config.pb.go
+++ b/app/observatory/burst/config.pb.go
@@ -77,7 +77,7 @@ type HealthPingConfig struct {
 	unknownFields protoimpl.UnknownFields
 
 	// destination url, need 204 for success return
-	// default http://www.google.com/gen_204
+	// default https://connectivitycheck.gstatic.com/generate_204
 	Destination string `protobuf:"bytes,1,opt,name=destination,proto3" json:"destination,omitempty"`
 	// connectivity check url
 	Connectivity string `protobuf:"bytes,2,opt,name=connectivity,proto3" json:"connectivity,omitempty"`

--- a/app/observatory/burst/config.proto
+++ b/app/observatory/burst/config.proto
@@ -21,7 +21,7 @@ message Config {
 
 message HealthPingConfig {
   // destination url, need 204 for success return
-  // default http://www.google.com/gen_204
+  // default https://connectivitycheck.gstatic.com/generate_204
   string destination = 1;
   // connectivity check url
   string connectivity = 2;

--- a/app/observatory/burst/healthping.go
+++ b/app/observatory/burst/healthping.go
@@ -43,7 +43,10 @@ func NewHealthPing(ctx context.Context, config *HealthPingConfig) *HealthPing {
 		}
 	}
 	if settings.Destination == "" {
-		settings.Destination = "http://www.google.com/gen_204"
+		// Destination URL, need 204 for success return default to chromium
+		// https://github.com/chromium/chromium/blob/main/components/safety_check/url_constants.cc#L10
+		// https://chromium.googlesource.com/chromium/src/+/refs/heads/main/components/safety_check/url_constants.cc#10
+		settings.Destination = "https://connectivitycheck.gstatic.com/generate_204"
 	}
 	if settings.Interval == 0 {
 		settings.Interval = time.Duration(1) * time.Minute


### PR DESCRIPTION
Destination URL, need 204 for success, return default to chromium browser URL 

This is by default used by chromium based browsers and by all android >6 devices