### PR TITLE
fix selectLeastLoad() returns wrong number of nodes

### DIFF
--- a/app/router/strategy_leastload.go
+++ b/app/router/strategy_leastload.go
@@ -118,8 +118,8 @@ func (l *LeastLoadStrategy) selectLeastLoad(nodes []*node) []*node {
 	// go through all base line until find expected selects
 	for _, b := range l.settings.Baselines {
 		baseline := time.Duration(b)
-		for i := 0; i < availableCount; i++ {
-			if nodes[i].RTTDeviationCost > baseline {
+		for i := count; i < availableCount; i++ {
+			if nodes[i].RTTDeviationCost >= baseline {
 				break
 			}
 			count = i + 1


### PR DESCRIPTION
the PR fixes `selectLeastLoad()` returns wrong number of nodes