### PR TITLE
Fix sockopt.TcpKeepAliveInterval

### DIFF
--- a/transport/internet/system_dialer.go
+++ b/transport/internet/system_dialer.go
@@ -64,7 +64,7 @@ func (d *DefaultSystemDialer) Dial(ctx context.Context, src net.Address, dest ne
 		}, nil
 	}
 	goStdKeepAlive := time.Duration(0)
-	if sockopt != nil && sockopt.TcpKeepAliveIdle != 0 {
+	if sockopt != nil && (sockopt.TcpKeepAliveInterval != 0 || sockopt.TcpKeepAliveIdle != 0) {
 		goStdKeepAlive = time.Duration(-1)
 	}
 	dialer := &net.Dialer{

--- a/transport/internet/system_listener.go
+++ b/transport/internet/system_listener.go
@@ -50,7 +50,7 @@ func (dl *DefaultListener) Listen(ctx context.Context, addr net.Addr, sockopt *S
 		network = addr.Network()
 		address = addr.String()
 		lc.Control = getControlFunc(ctx, sockopt, dl.controllers)
-		if sockopt != nil && sockopt.TcpKeepAliveIdle != 0 {
+		if sockopt != nil && (sockopt.TcpKeepAliveInterval != 0 || sockopt.TcpKeepAliveIdle != 0) {
 			lc.KeepAlive = time.Duration(-1)
 		}
 	case *net.UnixAddr:


### PR DESCRIPTION
The Keep-Alive configs may be overridden with golang default settings when `tcpKeepAliveInterval` is set without `tcpKeepAliveIdle`.
Adopt: https://github.com/XTLS/Xray-core/pull/1328