### PR TITLE
systemd: Replace User=nobody with DynamicUser=yes

### DIFF
--- a/release/config/systemd/system/v2ray.service
+++ b/release/config/systemd/system/v2ray.service
@@ -4,7 +4,7 @@ Documentation=https://www.v2fly.org/
 After=network.target nss-lookup.target
 
 [Service]
-User=nobody
+DynamicUser=yes
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
 NoNewPrivileges=true

--- a/release/config/systemd/system/v2ray@.service
+++ b/release/config/systemd/system/v2ray@.service
@@ -4,7 +4,7 @@ Documentation=https://www.v2fly.org/
 After=network.target nss-lookup.target
 
 [Service]
-User=nobody
+DynamicUser=yes
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
 NoNewPrivileges=true

--- a/release/debian/v2ray.service
+++ b/release/debian/v2ray.service
@@ -4,7 +4,7 @@ Documentation=https://www.v2fly.org/
 After=network.target nss-lookup.target
 
 [Service]
-User=nobody
+DynamicUser=yes
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
 NoNewPrivileges=true

--- a/release/debian/v2ray@.service
+++ b/release/debian/v2ray@.service
@@ -4,7 +4,7 @@ Documentation=https://www.v2fly.org/
 After=network.target nss-lookup.target
 
 [Service]
-User=nobody
+DynamicUser=yes
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
 NoNewPrivileges=true


### PR DESCRIPTION
systemd warning:

> Special user nobody configured, this is not safe!

DynamicUser [1] seems to be the recommended approach now. See also [2].

[1] https://www.freedesktop.org/software/systemd/man/systemd.exec.html#DynamicUser=
[2] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=976858
