### PR TITLE
[app/dispatcher] [proxy/dns] Support domain string validation

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -15,6 +15,7 @@ import (
 	"github.com/v2fly/v2ray-core/v5/common/net"
 	"github.com/v2fly/v2ray-core/v5/common/protocol"
 	"github.com/v2fly/v2ray-core/v5/common/session"
+	"github.com/v2fly/v2ray-core/v5/common/strmatcher"
 	"github.com/v2fly/v2ray-core/v5/features/outbound"
 	"github.com/v2fly/v2ray-core/v5/features/policy"
 	"github.com/v2fly/v2ray-core/v5/features/routing"
@@ -224,10 +225,11 @@ func (d *DefaultDispatcher) Dispatch(ctx context.Context, destination net.Destin
 				content.Protocol = result.Protocol()
 			}
 			if err == nil && shouldOverride(result, sniffingRequest.OverrideDestinationForProtocol) {
-				domain := result.Domain()
-				newError("sniffed domain: ", domain).WriteToLog(session.ExportIDToError(ctx))
-				destination.Address = net.ParseAddress(domain)
-				ob.Target = destination
+				if domain, err := strmatcher.ToDomain(result.Domain()); err == nil {
+					newError("sniffed domain: ", domain, " for ", destination).WriteToLog(session.ExportIDToError(ctx))
+					destination.Address = net.ParseAddress(domain)
+					ob.Target = destination
+				}
 			}
 			d.routedDispatch(ctx, outbound, destination)
 		}()

--- a/common/strmatcher/matchers_test.go
+++ b/common/strmatcher/matchers_test.go
@@ -1,7 +1,9 @@
 package strmatcher_test
 
 import (
+	"reflect"
 	"testing"
+	"unsafe"
 
 	"github.com/v2fly/v2ray-core/v5/common"
 	. "github.com/v2fly/v2ray-core/v5/common/strmatcher"
@@ -68,6 +70,80 @@ func TestMatcher(t *testing.T) {
 		common.Must(err)
 		if m := matcher.Match(test.input); m != test.output {
 			t.Error("unexpected output: ", m, " for test case ", test)
+		}
+	}
+}
+
+func TestToDomain(t *testing.T) {
+	{ // Test normal ASCII domain, which should not trigger new string data allocation
+		input := "v2fly.org"
+		domain, err := ToDomain(input)
+		if err != nil {
+			t.Error("unexpected error: ", err)
+		}
+		if domain != input {
+			t.Error("unexpected output: ", domain, " for test case ", input)
+		}
+		if (*reflect.StringHeader)(unsafe.Pointer(&input)).Data != (*reflect.StringHeader)(unsafe.Pointer(&domain)).Data {
+			t.Error("different string data of output: ", domain, " and test case ", input)
+		}
+	}
+	{ // Test ASCII domain containing upper case letter, which should be converted to lower case
+		input := "v2FLY.oRg"
+		domain, err := ToDomain(input)
+		if err != nil {
+			t.Error("unexpected error: ", err)
+		}
+		if domain != "v2fly.org" {
+			t.Error("unexpected output: ", domain, " for test case ", input)
+		}
+	}
+	{ // Test internationalized domain, which should be translated to ASCII punycode
+		input := "v2fly.公益"
+		domain, err := ToDomain(input)
+		if err != nil {
+			t.Error("unexpected error: ", err)
+		}
+		if domain != "v2fly.xn--55qw42g" {
+			t.Error("unexpected output: ", domain, " for test case ", input)
+		}
+	}
+	{ // Test internationalized domain containing upper case letter
+		input := "v2FLY.公益"
+		domain, err := ToDomain(input)
+		if err != nil {
+			t.Error("unexpected error: ", err)
+		}
+		if domain != "v2fly.xn--55qw42g" {
+			t.Error("unexpected output: ", domain, " for test case ", input)
+		}
+	}
+	{ // Test domain name of invalid character, which should return with error
+		input := "{"
+		_, err := ToDomain(input)
+		if err == nil {
+			t.Error("unexpected non error for test case ", input)
+		}
+	}
+	{ // Test domain name containing a space, which should return with error
+		input := "Mijia Cloud"
+		_, err := ToDomain(input)
+		if err == nil {
+			t.Error("unexpected non error for test case ", input)
+		}
+	}
+	{ // Test domain name containing an underscore, which should return with error
+		input := "Mijia_Cloud.com"
+		_, err := ToDomain(input)
+		if err == nil {
+			t.Error("unexpected non error for test case ", input)
+		}
+	}
+	{ // Test internationalized domain containing invalid character
+		input := "Mijia Cloud.公司"
+		_, err := ToDomain(input)
+		if err == nil {
+			t.Error("unexpected non error for test case ", input)
 		}
 	}
 }

--- a/proxy/dns/dns.go
+++ b/proxy/dns/dns.go
@@ -15,6 +15,7 @@ import (
 	dns_proto "github.com/v2fly/v2ray-core/v5/common/protocol/dns"
 	"github.com/v2fly/v2ray-core/v5/common/session"
 	"github.com/v2fly/v2ray-core/v5/common/signal"
+	"github.com/v2fly/v2ray-core/v5/common/strmatcher"
 	"github.com/v2fly/v2ray-core/v5/common/task"
 	"github.com/v2fly/v2ray-core/v5/features/dns"
 	"github.com/v2fly/v2ray-core/v5/features/policy"
@@ -190,8 +191,10 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, d internet.
 			if !h.isOwnLink(ctx) {
 				isIPQuery, domain, id, qType := parseIPQuery(b.Bytes())
 				if isIPQuery {
-					go h.handleIPQuery(id, qType, domain, writer)
-					continue
+					if domain, err := strmatcher.ToDomain(domain); err == nil {
+						go h.handleIPQuery(id, qType, domain, writer)
+						continue
+					}
 				}
 			}
 


### PR DESCRIPTION
There were two related bugs:
1. Domain `Mijia Cloud` overrides the destination, but cannot be resolved by any DNS server, thus failed to dial. See https://github.com/v2ray/v2ray-core/issues/2615.
2. Doing `nslookup { <v2ray-dns>` caused v2ray dns app using mph domain matcher to crash. Fixed by https://github.com/v2fly/v2ray-core/pull/1988.

They are all related to usage of an invalid domain. https://github.com/v2fly/v2ray-core/pull/806 tried to prevent the invalid domain from overriding the destination, but closed due to definition of `invalid` is not correct. But preventing invalid domain from being used (as destination, or by DNS app) is meaningful, so this PR uses a more formal validation method `ToDomain` from `common/strmatcher` module to resolve this issue.

`ToDomain` will convert a string to a valid string in domain charset (the LDH subset), and return error if the input string cannot be converted to a domain string (e.g. containing a space). It also will:
1. Convert domain string to lower case, for better matching in domain matcher module.
2. Convert internationalized domain (containing non-ASCII char) to puny code form, which is implemented in this PR.

Therefore, an invalid domain will:
1. Invalid domain string will not override the destination. This will prevent `Mijia Cloud` from replacing the original IP destination.
2. DNS outbound will not use DNS app for invalid domain string, and just forward it to original destination as-is (normally, the forward address specified in dokodemo-door).