### PR TITLE
[app/dns] Add tests for idn support

### DIFF
--- a/common/strmatcher/matchers.go
+++ b/common/strmatcher/matchers.go
@@ -176,7 +176,7 @@ func ToDomain(pattern string) (string, error) {
 		}
 		if !isASCII {
 			var err error
-			pattern, err = idna.New().ToASCII(pattern)
+			pattern, err = idna.Punycode.ToASCII(pattern)
 			if err != nil {
 				return "", err
 			}


### PR DESCRIPTION
https://github.com/v2fly/v2ray-core/issues/2022 requests IDN support for DNS, and https://github.com/v2fly/v2ray-core/pull/2053 resolves it. 

In fact, the merged PR https://github.com/v2fly/v2ray-core/pull/2188 already resolves aforementioned issue. The tests from https://github.com/v2fly/v2ray-core/pull/2053 are good so added in this PR and thus closes #2022.