### PR TITLE
Fix servername not supplied to security engine (Fix #2243)

### DIFF
--- a/app/proxyman/outbound/handler.go
+++ b/app/proxyman/outbound/handler.go
@@ -188,7 +188,7 @@ func (h *Handler) Dial(ctx context.Context, dest net.Destination) (internet.Conn
 				}
 
 				if securityEngine != nil {
-					conn, err = securityEngine.Client(conn)
+					conn, err = securityEngine.Client(conn, security.OptionWithDestination{Dest: dest})
 					if err != nil {
 						return nil, newError("unable to create security protocol client from security engine").Base(err)
 					}

--- a/transport/internet/tcp/dialer.go
+++ b/transport/internet/tcp/dialer.go
@@ -25,7 +25,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 	}
 
 	if securityEngine != nil {
-		conn, err = securityEngine.Client(conn)
+		conn, err = securityEngine.Client(conn, security.OptionWithDestination{Dest: dest})
 		if err != nil {
 			return nil, newError("unable to create security protocol client from security engine").Base(err)
 		}


### PR DESCRIPTION
This is a merge request fixes a bug introduced in security engine, in which server name information is not supplied to security engine when TCP transport is used.

(Fix #2243)