### PR TITLE
Skip validating on empty http host config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,3 +256,68 @@ jobs:
           file_glob: true
           file: build_artifacts/v2ray-extra.zip
           tag: ${{ github.ref }}
+  buildContainer:
+    if: github.event_name == 'release'
+    needs: signature
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [std, extra]
+        arch:
+          - v2Name: 32
+            containerName: 386
+          - v2Name: 64
+            containerName: amd64
+          - v2Name: arm32-v6
+            containerName: arm/v6
+          - v2Name: arm32-v7a
+            containerName: arm/v7
+          - v2Name: arm64-v8a
+            containerName: arm64
+          - v2Name: arm64-v8a
+            containerName: arm64/v8
+
+    name: Build And Push image
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY_USER: ${{ github.actor }}
+      REGISTRY_PASSWORD: ${{ github.token }}
+      IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+      RELEASE_REPO: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Log in to ghcr.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+
+      - name: Download Assets
+        run: |
+          bash ./release/container/downloadAssets.sh ${{  github.ref_name }} ${{ matrix.arch.v2Name }} ${{ matrix.arch.containerName }} ${{ matrix.variant }}
+
+      - name: Buildah Action
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: v2ray
+          tags: ${{  github.ref_name }}-${{ matrix.arch.v2Name }}-${{ matrix.variant }}
+          containerfiles: |
+            ./release/container/Containerfile
+          build-args: |
+            TARGETPLATFORM=${{ matrix.arch.containerName }}
+            VARIANT=${{ matrix.variant }}
+          archs: ${{ matrix.arch.containerName }}
+          context: context/linux/${{ matrix.arch.containerName }}/${{ matrix.variant }}
+          extra-args: |
+            --squash
+            --timestamp 0
+
+      - name: Push To ghcr.io
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: ${{ env.IMAGE_REGISTRY }}

--- a/common/protocol/quic/qtls_go118.go
+++ b/common/protocol/quic/qtls_go118.go
@@ -1,0 +1,18 @@
+//go:build go1.18 && !go1.19
+
+package quic
+
+import (
+	"crypto/cipher"
+
+	"github.com/quic-go/qtls-go1-18"
+)
+
+type (
+	// A CipherSuiteTLS13 is a cipher suite for TLS 1.3
+	CipherSuiteTLS13 = qtls.CipherSuiteTLS13
+)
+
+func AEADAESGCMTLS13(key, fixedNonce []byte) cipher.AEAD {
+	return qtls.AEADAESGCMTLS13(key, fixedNonce)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/v2fly/v2ray-core/v5
 
-go 1.19
+go 1.18
 
 require (
 	github.com/adrg/xdg v0.4.0
@@ -16,6 +16,7 @@ require (
 	github.com/mustafaturan/bus v1.0.2
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pires/go-proxyproto v0.6.2
+	github.com/quic-go/qtls-go1-18 v0.2.0
 	github.com/quic-go/qtls-go1-19 v0.2.1
 	github.com/quic-go/qtls-go1-20 v0.1.1
 	github.com/quic-go/quic-go v0.32.0
@@ -65,7 +66,6 @@ require (
 	github.com/pion/udp v0.1.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/quic-go/qtls-go1-18 v0.2.0 // indirect
 	github.com/riobard/go-bloom v0.0.0-20200614022211-cdc8013cb5b3 // indirect
 	github.com/secure-io/siv-go v0.0.0-20180922214919-5ff40651e2c4 // indirect
 	github.com/xtaci/smux v1.5.15 // indirect

--- a/release/container/Containerfile
+++ b/release/container/Containerfile
@@ -1,0 +1,19 @@
+FROM docker.io/library/golang@sha256:d19ee8512191c8b8e967246d4a7d0de4f4133a30bd9ce982e9b70a0c596dbf18 AS builder
+
+FROM --platform=${TARGETPLATFORM} scratch
+
+ARG TARGETPLATFORM
+ARG VARIANT
+
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /tmp /tmp
+COPY --from=builder /dev /dev
+
+ENV v2ray.location.asset=/opt/v2ray/share
+
+COPY ./ /opt/v2ray/
+
+CMD ["/opt/v2ray/bin/v2ray"]

--- a/release/container/downloadAssets.sh
+++ b/release/container/downloadAssets.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -x -e
+
+download() {
+  curl -L "https://github.com/${RELEASE_REPO}/releases/download/$1/$2" >"$2"
+}
+
+downloadAndUnzip() {
+  download "$1" "$2"
+  unzip -n -d "${2%\.zip}" "$2"
+}
+mkdir -p assets
+
+pushd assets
+downloadAndUnzip "$1" "v2ray-linux-$2.zip"
+downloadAndUnzip "$1" "v2ray-extra.zip"
+popd
+
+placeFile() {
+  mkdir -p "context/$2"
+  cp -R "assets/$1/$3" "context/$2/$3"
+}
+
+function generateStandardVersion() {
+  placeFile "$1" "$2/bin" "v2ray"
+}
+
+function generateExtraVersion() {
+  generateStandardVersion "$1" "$2"
+  placeFile "$1" "$2/share" "geosite.dat"
+  placeFile "$1" "$2/share" "geoip.dat"
+  placeFile "$1" "$2/etc" "config.json"
+  placeFile "v2ray-extra" "$2/share" "browserforwarder"
+}
+
+if [ "$4" = "std" ]; then
+    generateStandardVersion "v2ray-linux-$2" "linux/$3/std"
+fi
+
+if [ "$4" = "extra" ]; then
+    generateExtraVersion "v2ray-linux-$2" "linux/$3/extra"
+fi
+
+

--- a/transport/internet/http/hub.go
+++ b/transport/internet/http/hub.go
@@ -58,7 +58,7 @@ func (fw flushWriter) Write(p []byte) (n int, err error) {
 
 func (l *Listener) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	host := request.Host
-	if !l.config.isValidHost(host) {
+	if len(l.config.Host) != 0 && !l.config.isValidHost(host) {
 		writer.WriteHeader(404)
 		return
 	}


### PR DESCRIPTION
A common use case is to put v2ray behind an http server. The http server verifies the host name then reverse proxy the traffic to v2ray.

So v2ray don't need to verify host again, just leave `httpSettings.host` empty.