### PR TITLE
Add Intergrated Container Image Building

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,3 +256,68 @@ jobs:
           file_glob: true
           file: build_artifacts/v2ray-extra.zip
           tag: ${{ github.ref }}
+  buildContainer:
+    if: github.event_name == 'release'
+    needs: signature
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [std, extra]
+        arch:
+          - v2Name: 32
+            containerName: 386
+          - v2Name: 64
+            containerName: amd64
+          - v2Name: arm32-v6
+            containerName: arm/v6
+          - v2Name: arm32-v7a
+            containerName: arm/v7
+          - v2Name: arm64-v8a
+            containerName: arm64
+          - v2Name: arm64-v8a
+            containerName: arm64/v8
+
+    name: Build And Push image
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY_USER: ${{ github.actor }}
+      REGISTRY_PASSWORD: ${{ github.token }}
+      IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+      RELEASE_REPO: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Log in to ghcr.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+
+      - name: Download Assets
+        run: |
+          bash ./release/container/downloadAssets.sh ${{  github.ref_name }} ${{ matrix.arch.v2Name }} ${{ matrix.arch.containerName }} ${{ matrix.variant }}
+
+      - name: Buildah Action
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: v2ray
+          tags: ${{  github.ref_name }}-${{ matrix.arch.v2Name }}-${{ matrix.variant }}
+          containerfiles: |
+            ./release/container/Containerfile
+          build-args: |
+            TARGETPLATFORM=${{ matrix.arch.containerName }}
+            VARIANT=${{ matrix.variant }}
+          archs: ${{ matrix.arch.containerName }}
+          context: context/linux/${{ matrix.arch.containerName }}/${{ matrix.variant }}
+          extra-args: |
+            --squash
+            --timestamp 0
+
+      - name: Push To ghcr.io
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: ${{ env.IMAGE_REGISTRY }}

--- a/release/container/Containerfile
+++ b/release/container/Containerfile
@@ -1,0 +1,19 @@
+FROM docker.io/library/golang@sha256:d19ee8512191c8b8e967246d4a7d0de4f4133a30bd9ce982e9b70a0c596dbf18 AS builder
+
+FROM --platform=${TARGETPLATFORM} scratch
+
+ARG TARGETPLATFORM
+ARG VARIANT
+
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /tmp /tmp
+COPY --from=builder /dev /dev
+
+ENV v2ray.location.asset=/opt/v2ray/share
+
+COPY ./ /opt/v2ray/
+
+CMD ["/opt/v2ray/bin/v2ray"]

--- a/release/container/downloadAssets.sh
+++ b/release/container/downloadAssets.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -x -e
+
+download() {
+  curl -L "https://github.com/${RELEASE_REPO}/releases/download/$1/$2" >"$2"
+}
+
+downloadAndUnzip() {
+  download "$1" "$2"
+  unzip -n -d "${2%\.zip}" "$2"
+}
+mkdir -p assets
+
+pushd assets
+downloadAndUnzip "$1" "v2ray-linux-$2.zip"
+downloadAndUnzip "$1" "v2ray-extra.zip"
+popd
+
+placeFile() {
+  mkdir -p "context/$2"
+  cp -R "assets/$1/$3" "context/$2/$3"
+}
+
+function generateStandardVersion() {
+  placeFile "$1" "$2/bin" "v2ray"
+}
+
+function generateExtraVersion() {
+  generateStandardVersion "$1" "$2"
+  placeFile "$1" "$2/share" "geosite.dat"
+  placeFile "$1" "$2/share" "geoip.dat"
+  placeFile "$1" "$2/etc" "config.json"
+  placeFile "v2ray-extra" "$2/share" "browserforwarder"
+}
+
+if [ "$4" = "std" ]; then
+    generateStandardVersion "v2ray-linux-$2" "linux/$3/std"
+fi
+
+if [ "$4" = "extra" ]; then
+    generateExtraVersion "v2ray-linux-$2" "linux/$3/extra"
+fi
+
+


### PR DESCRIPTION
This is pull request adds automatic container building for v2ray.

The container is build after a prerelease is generated.

It comes with two favor: 
- std: Just a binary.
- extra: std with geoip, site, and extra.

Important paths:
- /opt/v2ray/bin/v2ray : the v2ray binary
- /opt/v2ray/share/ : the data files (if exists)
- /opt/v2ray/etc/config.json : the config file (if exists)

It is BTW:
- reproducible: Anyone can generate the same container image, with the same input.
- cross build ready: The builder machine does not need to execute anything.
- fully automated: No manual intervention needed to produce the build.
- distroless: image does not come with a distro, thus produce a small image.