### PR TITLE
[proxy/vmess] Fix UDP over TCP fragmentation in VMESS + zero security

### DIFF
--- a/common/net/packetstream/packetstream.go
+++ b/common/net/packetstream/packetstream.go
@@ -1,0 +1,62 @@
+package packetstream
+
+import (
+	"encoding/binary"
+	"io"
+
+	"github.com/v2fly/v2ray-core/v5/common/buf"
+)
+
+// PacketStreamWriter is a Writer that writes one packet with length info as header into a byte stream.
+type PacketStreamWriter struct {
+	io.Writer
+}
+
+// WriteMultiBuffer implements buf.Writer
+func (w *PacketStreamWriter) WriteMultiBuffer(multiBuffer buf.MultiBuffer) error {
+	defer buf.ReleaseMulti(multiBuffer)
+	for mb := multiBuffer; mb.Len() > 0; {
+		var payload *buf.Buffer
+		mb, payload = buf.SplitFirst(mb)
+		if payload.IsEmpty() {
+			continue
+		}
+
+		var lengthBuf [2]byte
+		binary.BigEndian.PutUint16(lengthBuf[:], uint16(payload.Len()))
+
+		buffer := buf.NewWithSize(2 + payload.Len())
+		defer buffer.Release()
+		if _, err := buffer.Write(lengthBuf[:]); err != nil {
+			return err
+		}
+		if _, err := buffer.Write(payload.Bytes()); err != nil {
+			return err
+		}
+		if _, err := w.Writer.Write(buffer.Bytes()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// PacketStreamReader is a Reader that reads one complete packet every time from a byte stream.
+// It first reads the packet length header, then read payload of exact length from the reader.
+type PacketStreamReader struct {
+	io.Reader
+}
+
+// ReadMultiBuffer implements buf.Reader.
+func (r *PacketStreamReader) ReadMultiBuffer() (buf.MultiBuffer, error) {
+	var lengthBuf [2]byte
+	if _, err := io.ReadFull(r, lengthBuf[:]); err != nil {
+		return nil, err
+	}
+	length := binary.BigEndian.Uint16(lengthBuf[:])
+
+	payload := buf.NewWithSize(int32(length))
+	if _, err := payload.ReadFullFrom(r, int32(length)); err != nil {
+		return nil, err
+	}
+	return buf.MultiBuffer{payload}, nil
+}


### PR DESCRIPTION
To make things easier, this PR is only scoped in VMESS zero security.

UDP proxying for VMESS zero is problematic, because VMESS zero does not attach any header to UDP-over-TCP traffic, causing source UDP packets to be fragmented into multiple packets, or merged into one packet.

Socks5 prefixed UDP packet with destination header, Trojan prefixed UDP packet with destination and length header. Considering `packetaddr` already does the job to prefix UDP packet with destination header, this PR implements a similar utility called `packetstream`, to make UDP packets correctly proxied on a stream by prefixing a length header.

When VMESS zero security is proxying UDP traffic, the `PacketStreamWriter` and `PacketStreamReader` will be used to correctly encode and recover UDP packets from the TCP stream.

This PR relies on https://github.com/v2fly/v2ray-core/pull/2336.

This PR is a draft, because I replaced the writer and reader globally for VMESS zero security, which is a breaking change for old servers and clients. I think it could be solved by introducing options or version number somewhere in the request header, but recently I don't have much time in proposing a mature solution, so I just enabled globally and adapted in both my clients and servers, and leave this draft for community to come up with a best compatible solution. 

