### PR TITLE
Feat: Parse both X-Forwarded-For and X-Real-IP

### DIFF
--- a/common/protocol/http/headers.go
+++ b/common/protocol/http/headers.go
@@ -9,8 +9,7 @@ import (
 )
 
 // ParseXForwardedFor parses X-Forwarded-For header in http headers, and return the IP list in it.
-func ParseXForwardedFor(header http.Header) []net.Address {
-	xff := header.Get("X-Forwarded-For")
+func ParseXForwardedFor(xff string) []net.Address {
 	if xff == "" {
 		return nil
 	}

--- a/common/protocol/http/headers_test.go
+++ b/common/protocol/http/headers_test.go
@@ -14,9 +14,7 @@ import (
 )
 
 func TestParseXForwardedFor(t *testing.T) {
-	header := http.Header{}
-	header.Add("X-Forwarded-For", "129.78.138.66, 129.78.64.103")
-	addrs := ParseXForwardedFor(header)
+	addrs := ParseXForwardedFor("129.78.138.66, 129.78.64.103")
 	if r := cmp.Diff(addrs, []net.Address{net.ParseAddress("129.78.138.66"), net.ParseAddress("129.78.64.103")}); r != "" {
 		t.Error(r)
 	}

--- a/transport/internet/http/hub.go
+++ b/transport/internet/http/hub.go
@@ -92,11 +92,15 @@ func (l *Listener) ServeHTTP(writer http.ResponseWriter, request *http.Request) 
 		}
 	}
 
-	forwardedAddress := http_proto.ParseXForwardedFor(request.Header)
-	if len(forwardedAddress) > 0 && forwardedAddress[0].Family().IsIP() {
+	if forwardedAddrs := http_proto.ParseXForwardedFor(request.Header.Get("X-Forwarded-For")); len(forwardedAddrs) > 0 && forwardedAddrs[0].Family().IsIP() {
 		remoteAddr = &net.TCPAddr{
-			IP:   forwardedAddress[0].IP(),
-			Port: 0,
+			IP:   forwardedAddrs[0].IP(),
+			Port: int(0),
+		}
+	} else if forwardedAddr := net.ParseAddress(request.Header.Get("X-Real-Ip")); forwardedAddr.Family().IsIP() {
+		remoteAddr = &net.TCPAddr{
+			IP:   forwardedAddr.IP(),
+			Port: int(0),
 		}
 	}
 


### PR DESCRIPTION
Fix #2148
Now use X-Forwarded-For firstly, X-Real-IP secondly and the socket address thirdly.
Applied for h2/websocket/grpc.