### PR TITLE
Fix incorrect UDP length in Torjan Packet Addr

### DIFF
--- a/proxy/trojan/client.go
+++ b/proxy/trojan/client.go
@@ -92,7 +92,7 @@ func (c *Client) Process(ctx context.Context, link *transport.Link, dialer inter
 			defer timer.SetTimeout(sessionPolicy.Timeouts.DownlinkOnly)
 
 			var buffer [2048]byte
-			_, addr, err := packetConn.ReadFrom(buffer[:])
+			n, addr, err := packetConn.ReadFrom(buffer[:])
 			if err != nil {
 				return newError("failed to read a packet").Base(err)
 			}
@@ -103,7 +103,7 @@ func (c *Client) Process(ctx context.Context, link *transport.Link, dialer inter
 			packetWriter := &PacketWriter{Writer: connWriter, Target: dest}
 
 			// write some request payload to buffer
-			if _, err := packetWriter.WriteTo(buffer[:], addr); err != nil {
+			if _, err := packetWriter.WriteTo(buffer[:n], addr); err != nil {
 				return newError("failed to write a request payload").Base(err)
 			}
 


### PR DESCRIPTION
This pull request fix a bug introduced in https://github.com/v2fly/v2ray-core/pull/2225 that result in a broken UDP implementation in Trojan protocol when Packet Addr is used.