### PR TITLE
build: set v2ray binary as an entrypoint

### DIFF
--- a/release/container/Containerfile
+++ b/release/container/Containerfile
@@ -16,4 +16,5 @@ ENV v2ray.location.asset=/opt/v2ray/share
 
 COPY ./ /opt/v2ray/
 
-CMD ["/opt/v2ray/bin/v2ray"]
+ENTRYPOINT [ "/opt/v2ray/bin/v2ray" ]
+CMD [ "run", "-config", "/etc/v2ray/config.json" ]


### PR DESCRIPTION
Use command to add args.
Also, add a default command to make it backward compatible with v4.