### PR TITLE
fix protocol matching in routing

### DIFF
--- a/app/dns/nameserver_doh.go
+++ b/app/dns/nameserver_doh.go
@@ -231,7 +231,7 @@ func (s *DoHNameServer) sendQuery(ctx context.Context, domain string, clientIP n
 			}
 
 			dnsCtx = session.ContextWithContent(dnsCtx, &session.Content{
-				Protocol:       "https",
+				Protocol:       "tls",
 				SkipDNSResolve: true,
 			})
 

--- a/common/protocol/http/sniff.go
+++ b/common/protocol/http/sniff.go
@@ -11,25 +11,12 @@ import (
 
 type version byte
 
-const (
-	HTTP1 version = iota
-	HTTP2
-)
-
 type SniffHeader struct {
-	version version
-	host    string
+	host string
 }
 
 func (h *SniffHeader) Protocol() string {
-	switch h.version {
-	case HTTP1:
-		return "http1"
-	case HTTP2:
-		return "http2"
-	default:
-		return "unknown"
-	}
+	return "http1"
 }
 
 func (h *SniffHeader) Domain() string {
@@ -62,9 +49,7 @@ func SniffHTTP(b []byte) (*SniffHeader, error) {
 		return nil, err
 	}
 
-	sh := &SniffHeader{
-		version: HTTP1,
-	}
+	sh := &SniffHeader{}
 
 	headers := bytes.Split(b, []byte{'\n'})
 	for i := 1; i < len(headers); i++ {

--- a/proxy/http/server.go
+++ b/proxy/http/server.go
@@ -242,9 +242,7 @@ func (s *Server) handlePlainHTTP(ctx context.Context, request *http.Request, wri
 		request.Header.Set("User-Agent", "")
 	}
 
-	content := &session.Content{
-		Protocol: "http/1.1",
-	}
+	content := &session.Content{}
 
 	content.SetAttribute(":method", strings.ToUpper(request.Method))
 	content.SetAttribute(":path", request.URL.Path)


### PR DESCRIPTION
protocol prefixes listed in document: `http`, `tls`, `bittorrent`

current possible protocols:
from sniffer: `http1`, `http2`(invalid value), `tls`, `quic`, `bittorrent`, `fakedns` 
from http inbound: `http/1.1` (matches `http`, incorrect if it has stream settings)
from internal dns: `dns` (TCP and UDP DNS), `https` (DoH, matches `http` instead of `tls`), `quic` (DoQ)

possible protocols after this change:
from sniffer: `http1`, `tls`, `quic`, `bittorrent`, `fakedns`
from internal dns: `dns` (TCP and UDP DNS), `tls` (DoH), `quic` (DoQ)