### PR TITLE
Add DomainStrategy to JSONv5 outbound

### DIFF
--- a/infra/conf/v5cfg/outbound.go
+++ b/infra/conf/v5cfg/outbound.go
@@ -2,6 +2,7 @@ package v5cfg
 
 import (
 	"context"
+	"strings"
 
 	"github.com/golang/protobuf/proto"
 
@@ -40,6 +41,16 @@ func (c OutboundConfig) BuildV5(ctx context.Context) (proto.Message, error) {
 
 	if c.MuxSettings != nil {
 		senderSettings.MultiplexSettings = c.MuxSettings.Build()
+	}
+	
+	senderSettings.DomainStrategy = proxyman.SenderConfig_AS_IS
+	switch strings.ToLower(c.DomainStrategy) {
+	case "useip", "use_ip", "use-ip":
+		senderSettings.DomainStrategy = proxyman.SenderConfig_USE_IP
+	case "useip4", "useipv4", "use_ip4", "use_ipv4", "use_ip_v4", "use-ip4", "use-ipv4", "use-ip-v4":
+		senderSettings.DomainStrategy = proxyman.SenderConfig_USE_IP4
+	case "useip6", "useipv6", "use_ip6", "use_ipv6", "use_ip_v6", "use-ip6", "use-ipv6", "use-ip-v6":
+		senderSettings.DomainStrategy = proxyman.SenderConfig_USE_IP6
 	}
 
 	if c.Settings == nil {

--- a/infra/conf/v5cfg/outbound.go
+++ b/infra/conf/v5cfg/outbound.go
@@ -2,8 +2,6 @@ package v5cfg
 
 import (
 	"context"
-	"strings"
-
 	"github.com/golang/protobuf/proto"
 
 	core "github.com/v2fly/v2ray-core/v5"
@@ -42,15 +40,18 @@ func (c OutboundConfig) BuildV5(ctx context.Context) (proto.Message, error) {
 	if c.MuxSettings != nil {
 		senderSettings.MultiplexSettings = c.MuxSettings.Build()
 	}
-	
+
 	senderSettings.DomainStrategy = proxyman.SenderConfig_AS_IS
-	switch strings.ToLower(c.DomainStrategy) {
-	case "useip", "use_ip", "use-ip":
+	switch c.DomainStrategy {
+	case "UseIP":
 		senderSettings.DomainStrategy = proxyman.SenderConfig_USE_IP
-	case "useip4", "useipv4", "use_ip4", "use_ipv4", "use_ip_v4", "use-ip4", "use-ipv4", "use-ip-v4":
+	case "UseIP4":
 		senderSettings.DomainStrategy = proxyman.SenderConfig_USE_IP4
-	case "useip6", "useipv6", "use_ip6", "use_ipv6", "use_ip_v6", "use-ip6", "use-ipv6", "use-ip-v6":
+	case "UseIP6":
 		senderSettings.DomainStrategy = proxyman.SenderConfig_USE_IP6
+	case "AsIs", "":
+	default:
+		return nil, newError("unknown domain strategy: ", c.DomainStrategy)
 	}
 
 	if c.Settings == nil {

--- a/infra/conf/v5cfg/skeleton.go
+++ b/infra/conf/v5cfg/skeleton.go
@@ -31,13 +31,14 @@ type InboundConfig struct {
 }
 
 type OutboundConfig struct {
-	Protocol      string                `json:"protocol"`
-	SendThrough   *cfgcommon.Address    `json:"sendThrough"`
-	Tag           string                `json:"tag"`
-	Settings      json.RawMessage       `json:"settings"`
-	StreamSetting *StreamConfig         `json:"streamSettings"`
-	ProxySettings *proxycfg.ProxyConfig `json:"proxySettings"`
-	MuxSettings   *muxcfg.MuxConfig     `json:"mux"`
+	Protocol       string                `json:"protocol"`
+	SendThrough    *cfgcommon.Address    `json:"sendThrough"`
+	Tag            string                `json:"tag"`
+	Settings       json.RawMessage       `json:"settings"`
+	StreamSetting  *StreamConfig         `json:"streamSettings"`
+	ProxySettings  *proxycfg.ProxyConfig `json:"proxySettings"`
+	MuxSettings    *muxcfg.MuxConfig     `json:"mux"`
+	DomainStrategy string                `json:"domainStrategy"`
 }
 
 type StreamConfig struct {


### PR DESCRIPTION
Added `domainStrategy` field for `outbound` in JSONv5 configuration file. This feature was introduced in #2334 and is only available in the JSONv4 configuration format.

This pull request:
- Repair and close #2448
- Restore the ability to use internal DNS resolution with "freedom" outbound. Related commit 40d75fa.

Credits:
- @Vigilans for the feature implementation
- @YVjXuB for report the problem

Usage:
```json
{
	"outbounds": [
		{
			"protocol": "freedom",
			"tag": "freedom",
			"domainStrategy": "USE_IP"
			// USE_IP, Use_IP, UseIP, USE_IPV4, Use_IPv4, UseIPv4, USE_IPV6, Use_IPv6, UseIPv6
		}
	]
}
```

I was not able to create single commit by using web editor, please consider using squash when merging this pull request.