### PR TITLE
Apply DomainStrategy to outbound target

### DIFF
--- a/app/proxyman/outbound/handler.go
+++ b/app/proxyman/outbound/handler.go
@@ -151,6 +151,18 @@ func (h *Handler) Tag() string {
 
 // Dispatch implements proxy.Outbound.Dispatch.
 func (h *Handler) Dispatch(ctx context.Context, link *transport.Link) {
+	if h.senderSettings != nil && h.senderSettings.DomainStrategy != proxyman.SenderConfig_AS_IS {
+		outbound := session.OutboundFromContext(ctx)
+		if outbound == nil {
+			outbound = new(session.Outbound)
+			ctx = session.ContextWithOutbound(ctx, outbound)
+		}
+		if outbound.Target.Address != nil && outbound.Target.Address.Family().IsDomain() {
+			if addr := h.resolveIP(ctx, outbound.Target.Address.Domain(), h.Address()); addr != nil {
+				outbound.Target.Address = addr
+			}
+		}
+	}
 	if h.mux != nil && (h.mux.Enabled || session.MuxPreferedFromContext(ctx)) {
 		if err := h.mux.Dispatch(ctx, link); err != nil {
 			err := newError("failed to process mux outbound traffic").Base(err)


### PR DESCRIPTION
Fixes https://github.com/v2fly/v2ray-core/issues/2448#issuecomment-1567714796

For outbounds like SOCKS5, VMESS, `domainStrategy` will only take effect on proxy server's address (because `domainStrategy` only applies for dialing). 

This PR applies `domainStrategy` to outbound handler's `Dispatch` method, so all outbound targets will be affected by `domainStrategy`. Therefore `domainStrategy` for SOCKS5 and VMESS will behave like Freedom outbound.

#### Prior behavior for SOCKS5, VMESS:

* √ Remote proxy server's address is affected by `domainStrategy`. 
* x Actual target address is not affected by `domainStrategy`.

#### After this PR

* √ Remote proxy server's address is affected by `domainStrategy`. 
* √ Actual target address will be affected by `domainStrategy`.
 
