### PR TITLE
fix(transport): support to set permission for UDS and correctly close lock file

### DIFF
--- a/transport/internet/grpc/hub.go
+++ b/transport/internet/grpc/hub.go
@@ -23,7 +23,6 @@ type Listener struct {
 	handler internet.ConnHandler
 	local   net.Addr
 	config  *Config
-	locker  *internet.FileLocker // for unix domain socket
 
 	s *grpc.Server
 }
@@ -95,10 +94,6 @@ func Listen(ctx context.Context, address net.Address, port net.Port, settings *i
 			if err != nil {
 				newError("failed to listen on ", address).Base(err).AtError().WriteToLog(session.ExportIDToError(ctx))
 				return
-			}
-			locker := ctx.Value(address.Domain())
-			if locker != nil {
-				listener.locker = locker.(*internet.FileLocker)
 			}
 		} else { // tcp
 			streamListener, err = internet.ListenSystem(ctx, &net.TCPAddr{

--- a/transport/internet/http/hub.go
+++ b/transport/internet/http/hub.go
@@ -25,7 +25,6 @@ type Listener struct {
 	handler internet.ConnHandler
 	local   net.Addr
 	config  *Config
-	locker  *internet.FileLocker // for unix domain socket
 }
 
 func (l *Listener) Addr() net.Addr {
@@ -33,9 +32,6 @@ func (l *Listener) Addr() net.Addr {
 }
 
 func (l *Listener) Close() error {
-	if l.locker != nil {
-		l.locker.Release()
-	}
 	return l.server.Close()
 }
 
@@ -170,10 +166,6 @@ func Listen(ctx context.Context, address net.Address, port net.Port, streamSetti
 			if err != nil {
 				newError("failed to listen on ", address).Base(err).AtError().WriteToLog(session.ExportIDToError(ctx))
 				return
-			}
-			locker := ctx.Value(address.Domain())
-			if locker != nil {
-				listener.locker = locker.(*internet.FileLocker)
 			}
 		} else { // tcp
 			streamListener, err = internet.ListenSystem(ctx, &net.TCPAddr{

--- a/transport/internet/transportcommon/listener.go
+++ b/transport/internet/transportcommon/listener.go
@@ -10,22 +10,10 @@ import (
 	"github.com/v2fly/v2ray-core/v5/transport/internet"
 )
 
-type combinedListener struct {
-	net.Listener
-	locker *internet.FileLocker
-}
-
-func (l *combinedListener) Close() error {
-	if l.locker != nil {
-		l.locker.Release()
-	}
-	return l.Listener.Close()
-}
-
 func ListenWithSecuritySettings(ctx context.Context, address net.Address, port net.Port, streamSettings *internet.MemoryStreamConfig) (
 	net.Listener, error,
 ) {
-	var l combinedListener
+	var l net.Listener
 
 	transportEnvironment := envctx.EnvironmentFromContext(ctx).(environment.TransportEnvironment)
 	transportListener := transportEnvironment.Listener()
@@ -39,11 +27,7 @@ func ListenWithSecuritySettings(ctx context.Context, address net.Address, port n
 			return nil, newError("failed to listen unix domain socket on ", address).Base(err)
 		}
 		newError("listening unix domain socket on ", address).WriteToLog(session.ExportIDToError(ctx))
-		locker := ctx.Value(address.Domain())
-		if locker != nil {
-			l.locker = locker.(*internet.FileLocker)
-		}
-		l.Listener = listener
+		l = listener
 	} else { // tcp
 		listener, err := transportListener.Listen(ctx, &net.TCPAddr{
 			IP:   address.IP(),
@@ -53,11 +37,11 @@ func ListenWithSecuritySettings(ctx context.Context, address net.Address, port n
 			return nil, newError("failed to listen TCP on ", address, ":", port).Base(err)
 		}
 		newError("listening TCP on ", address, ":", port).WriteToLog(session.ExportIDToError(ctx))
-		l.Listener = listener
+		l = listener
 	}
 
 	if streamSettings.SocketSettings != nil && streamSettings.SocketSettings.AcceptProxyProtocol {
 		newError("accepting PROXY protocol").AtWarning().WriteToLog(session.ExportIDToError(ctx))
 	}
-	return &l, nil
+	return l, nil
 }


### PR DESCRIPTION
Fixes: #2554.

This PR add support to set permission for UDS when set listen field like `"listen": "/dev/shm/v2fly.sock,0666"`. And move the "close lock file" logic to system listen creator. As the previous logic would _never_ close and remove the lock file (the parent context could not got the value set by child).


