### PR TITLE
fix: replace deprecated package with new package

### DIFF
--- a/app/observatory/burst/burstobserver.go
+++ b/app/observatory/burst/burstobserver.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 
 	core "github.com/v2fly/v2ray-core/v5"
 	"github.com/v2fly/v2ray-core/v5/app/observatory"

--- a/app/observatory/command/command.go
+++ b/app/observatory/command/command.go
@@ -8,8 +8,8 @@ package command
 import (
 	"context"
 
-	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 
 	core "github.com/v2fly/v2ray-core/v5"
 	"github.com/v2fly/v2ray-core/v5/app/observatory"

--- a/app/observatory/multiobservatory/multi.go
+++ b/app/observatory/multiobservatory/multi.go
@@ -2,9 +2,8 @@ package multiobservatory
 
 import (
 	"context"
-
-	"github.com/golang/protobuf/jsonpb"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/v2fly/v2ray-core/v5/common"
 	"github.com/v2fly/v2ray-core/v5/common/taggedfeatures"
@@ -34,7 +33,7 @@ func New(ctx context.Context, config *Config) (*Observer, error) {
 	return &Observer{config: config, ctx: ctx, TaggedFeatures: holder}, nil
 }
 
-func (x *Config) UnmarshalJSONPB(unmarshaler *jsonpb.Unmarshaler, bytes []byte) error {
+func (x *Config) UnmarshalJSONPB(unmarshaler *protojson.UnmarshalOptions, bytes []byte) error {
 	var err error
 	x.Holders, err = taggedfeatures.LoadJSONConfig(context.TODO(), "service", "background", bytes)
 	return err

--- a/app/observatory/observer.go
+++ b/app/observatory/observer.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 
 	core "github.com/v2fly/v2ray-core/v5"
 	"github.com/v2fly/v2ray-core/v5/common"

--- a/app/router/config.go
+++ b/app/router/config.go
@@ -6,8 +6,7 @@ package router
 import (
 	"context"
 	"encoding/json"
-
-	"github.com/golang/protobuf/jsonpb"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/v2fly/v2ray-core/v5/app/router/routercommon"
 	"github.com/v2fly/v2ray-core/v5/common/net"
@@ -174,7 +173,7 @@ func (br *BalancingRule) Build(ohm outbound.Manager, dispatcher routing.Dispatch
 	}
 }
 
-func (br *BalancingRule) UnmarshalJSONPB(unmarshaler *jsonpb.Unmarshaler, bytes []byte) error {
+func (br *BalancingRule) UnmarshalJSONPB(unmarshaler *protojson.UnmarshalOptions, bytes []byte) error {
 	type BalancingRuleStub struct {
 		Tag              string          `protobuf:"bytes,1,opt,name=tag,proto3" json:"tag,omitempty"`
 		OutboundSelector []string        `protobuf:"bytes,2,rep,name=outbound_selector,json=outboundSelector,proto3" json:"outbound_selector,omitempty"`

--- a/app/router/strategy_leastload.go
+++ b/app/router/strategy_leastload.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 
 	core "github.com/v2fly/v2ray-core/v5"
 	"github.com/v2fly/v2ray-core/v5/app/observatory"

--- a/common/net/address.go
+++ b/common/net/address.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"strings"
 
-	"github.com/golang/protobuf/jsonpb"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 var (
@@ -212,7 +212,7 @@ func NewIPOrDomain(addr Address) *IPOrDomain {
 	}
 }
 
-func (d *IPOrDomain) UnmarshalJSONPB(unmarshaler *jsonpb.Unmarshaler, bytes []byte) error {
+func (d *IPOrDomain) UnmarshalJSONPB(unmarshaler *protojson.UnmarshalOptions, bytes []byte) error {
 	var ipOrDomain string
 	if err := json.Unmarshal(bytes, &ipOrDomain); err != nil {
 		return err

--- a/features/extension/observatory.go
+++ b/features/extension/observatory.go
@@ -3,7 +3,7 @@ package extension
 import (
 	"context"
 
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/v2fly/v2ray-core/v5/features"
 )

--- a/infra/conf/cfgcommon/testassist/general.go
+++ b/infra/conf/cfgcommon/testassist/general.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/v2fly/v2ray-core/v5/common"
 	"github.com/v2fly/v2ray-core/v5/infra/conf/cfgcommon"

--- a/infra/conf/cfgcommon/testassist/general.go
+++ b/infra/conf/cfgcommon/testassist/general.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"google.golang.org/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 
 	"github.com/v2fly/v2ray-core/v5/common"
 	"github.com/v2fly/v2ray-core/v5/infra/conf/cfgcommon"

--- a/infra/conf/v4/v2ray_test.go
+++ b/infra/conf/v4/v2ray_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	core "github.com/v2fly/v2ray-core/v5"


### PR DESCRIPTION
This commit replaces the deprecated package `github.com/golang/protobuf` with the new package `google.golang.org/protobuf`.