### PR TITLE
fix(router): panic caused by concurrent map read and write (v2fly#2523)

### DIFF
--- a/app/router/weight.go
+++ b/app/router/weight.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 type weightScaler func(value, weight float64) float64
@@ -26,10 +27,13 @@ type WeightManager struct {
 	cache         map[string]float64
 	scaler        weightScaler
 	defaultWeight float64
+	mu            sync.Mutex
 }
 
 // Get gets the weight of specified tag
 func (s *WeightManager) Get(tag string) float64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	weight, ok := s.cache[tag]
 	if ok {
 		return weight


### PR DESCRIPTION
As discussion in #2523, add mutex to protect field `cache` may solve the problem.