### PR TITLE
Fix CI breakage in 5.7.0

### DIFF
--- a/.github/linters/.golangci.yml
+++ b/.github/linters/.golangci.yml
@@ -52,3 +52,9 @@ linters-settings:
       - name: blank-imports
         severity: warning
         disabled: true
+  depguard:
+    rules:
+      Main:
+        deny:
+          - pkg: "github.com/pkg/errors"
+            desc: Should be replaced by standard lib errors package

--- a/transport/internet/request/roundtripper/httprt/httprt.go
+++ b/transport/internet/request/roundtripper/httprt/httprt.go
@@ -75,8 +75,7 @@ type httpTripperServer struct {
 	listener net.Listener
 	assembly request.TransportServerAssembly
 
-	listenAddress net.Addr
-	config        *ServerConfig
+	config *ServerConfig
 }
 
 func (h *httpTripperServer) OnTransportServerAssemblyReady(assembly request.TransportServerAssembly) {


### PR DESCRIPTION
This merge request restore ci linter's status to passing by:
- remove unused attribute from http roundtripper
- reduce dependency restrictions to denylist