### PR TITLE
Improve container image tags and timestamp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: Release
 
 on:
   release:
-    types: [prereleased]
+    types:
+      - prereleased
+      - released
   push:
     branches:
       - master
@@ -176,6 +178,7 @@ jobs:
           file_glob: true
           file: ./v2ray-${{ steps.get_filename.outputs.ASSET_NAME }}.zip*
           tag: ${{ github.ref }}
+          overwrite: true
 
   signature:
     runs-on: ubuntu-latest
@@ -249,6 +252,7 @@ jobs:
           file_glob: true
           file: build_artifacts/Release.unsigned*
           tag: ${{ github.ref }}
+          overwrite: true
 
       - name: Upload extra package
         uses: svenstaro/upload-release-action@v2
@@ -258,27 +262,10 @@ jobs:
           file_glob: true
           file: build_artifacts/v2ray-extra.zip
           tag: ${{ github.ref }}
+          overwrite: true
   buildContainer:
     if: github.event_name == 'release'
     needs: signature
-    strategy:
-      fail-fast: false
-      matrix:
-        variant: [std, extra]
-        arch:
-          - v2Name: 32
-            containerName: 386
-          - v2Name: 64
-            containerName: amd64
-          - v2Name: arm32-v6
-            containerName: arm/v6
-          - v2Name: arm32-v7a
-            containerName: arm/v7
-          - v2Name: arm64-v8a
-            containerName: arm64
-          - v2Name: arm64-v8a
-            containerName: arm64/v8
-
     name: Build And Push image
     runs-on: ubuntu-latest
     env:
@@ -286,6 +273,19 @@ jobs:
       REGISTRY_PASSWORD: ${{ github.token }}
       IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
       RELEASE_REPO: ${{ github.repository }}
+      VERSION: ${{ github.event.release.tag_name }}
+      TIMESTAMP: ${{ github.event.release.created_at }}
+      PRERELEASE: ${{ github.event.release.prerelease }}
+      VARIANTS: | # <v2ray variant>:<image tag suffix>
+        std:
+        extra:-extra
+      ARCHS: | # <v2ray arch name>:<container arch name>
+        32:386
+        64:amd64
+        arm32-v6:arm/v6
+        arm32-v7a:arm/v7
+        arm64-v8a:arm64
+        arm64-v8a:arm64/v8
     steps:
       - uses: actions/checkout@v3
 
@@ -296,26 +296,47 @@ jobs:
           password: ${{ env.REGISTRY_PASSWORD }}
           registry: ${{ env.IMAGE_REGISTRY }}
 
-      - name: Download Assets
-        run: |
-          bash ./release/container/downloadAssets.sh ${{  github.ref_name }} ${{ matrix.arch.v2Name }} ${{ matrix.arch.containerName }} ${{ matrix.variant }}
-
-      - name: Buildah Action
+      - name: Build Images
         id: build-image
-        uses: redhat-actions/buildah-build@v2
-        with:
-          image: v2ray
-          tags: ${{  github.ref_name }}-${{ matrix.arch.v2Name }}-${{ matrix.variant }}
-          containerfiles: |
-            ./release/container/Containerfile
-          build-args: |
-            TARGETPLATFORM=${{ matrix.arch.containerName }}
-            VARIANT=${{ matrix.variant }}
-          archs: ${{ matrix.arch.containerName }}
-          context: context/linux/${{ matrix.arch.containerName }}/${{ matrix.variant }}
-          extra-args: |
-            --squash
-            --timestamp 0
+        run: |
+          image=v2ray
+          tags=
+
+          timestamp=$(date -d $TIMESTAMP +%s)
+          versions="$VERSION" # full version (v1.2.3)
+          versions="$versions $(echo $VERSION | cut -d. -f1,2)" # minor version (v1.2)
+          if [ $PRERELEASE = false ]; then
+            versions="$versions $(echo $VERSION | cut -d. -f1)" # major version (v1)
+            versions="$versions latest"
+          fi
+
+          formatEach() {
+            format=$1
+            shift 1
+            echo "$@" | xargs -n1 | xargs -i echo "$format" | xargs
+          }
+
+          for variant in $VARIANTS; do
+            v2Variant=$(echo $variant | cut -d: -f1)
+            containerVariant=$(echo $variant | cut -d: -f2)
+            variantTags=$(formatEach "{}$containerVariant" $versions)
+            tags="$tags $variantTags"
+            for arch in $ARCHS; do
+              v2Arch=$(echo $arch | cut -d: -f1)
+              containerArch=$(echo $arch | cut -d: -f2)
+              bash ./release/container/downloadAssets.sh $VERSION $v2Arch $containerArch $v2Variant
+              buildah bud \
+                $(formatEach "--tag $image:{}" $variantTags) \
+                --file ./release/container/Containerfile \
+                --platform linux/$containerArch \
+                --timestamp $timestamp \
+                --squash \
+                ./context/linux/$containerArch/$v2Variant
+            done
+          done
+
+          echo image=$image >> $GITHUB_OUTPUT
+          echo tags=$tags >> $GITHUB_OUTPUT
 
       - name: Push To ghcr.io
         uses: redhat-actions/push-to-registry@v2

--- a/release/container/Containerfile
+++ b/release/container/Containerfile
@@ -1,9 +1,6 @@
-FROM docker.io/library/golang@sha256:d19ee8512191c8b8e967246d4a7d0de4f4133a30bd9ce982e9b70a0c596dbf18 AS builder
-
-FROM --platform=${TARGETPLATFORM} scratch
-
-ARG TARGETPLATFORM
-ARG VARIANT
+# golang:1.21.4 linux/amd64
+FROM docker.io/library/golang@sha256:337543447173c2238c78d4851456760dcc57c1dfa8c3bcd94cbee8b0f7b32ad0 AS builder
+FROM scratch
 
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/


### PR DESCRIPTION
resolves #2477 

This implementation builds for all platforms in one workflow step. I think it makes sense since all binaries are already ready at that time.
Another option is to keep using strategy matrix but we will have to upload all image manifest archives to workflow artifacts and merge them in another workflow job as demonstrated [here](https://github.com/redhat-actions/buildah-build/issues/121#issuecomment-1683691170), which seems not worth the trouble in our case. But I am open for discussion.

Currently for each release, these tags will be added for different version ranges and variations. Take v5.11.0 for example:
* v5.11.0 (no suffix for std variation)
* v5.11
* v5.11.0-extra
* v5.11-extra

Besides, if it's not marked as a prerelease, these additional tags will be added:
* v5
* latest
* v5-extra
* latest-extra

I also updated the timestamp to release creation time instead of 0. This should keep the reproducibility and make it more user-friendly to have a reasonable created time.

As for the Containerfile change, I think it's important to copy those files from an updated image, especially certificates store.

One successful test run for building job can be found [here](https://github.com/Qusic/v2ray-core/actions/runs/6841680854/job/18602309397). (Pushing job failed due to permission issue)