### PR TITLE
fix: unexpected path in httpugprade

### DIFF
--- a/transport/internet/httpupgrade/config.go
+++ b/transport/internet/httpupgrade/config.go
@@ -1,0 +1,12 @@
+package httpupgrade
+
+func (c *Config) GetNormalizedPath() string {
+	path := c.Path
+	if path == "" {
+		return "/"
+	}
+	if path[0] != '/' {
+		return "/" + path
+	}
+	return path
+}

--- a/transport/internet/httpupgrade/dialer.go
+++ b/transport/internet/httpupgrade/dialer.go
@@ -20,7 +20,7 @@ func dialhttpUpgrade(ctx context.Context, dest net.Destination, streamSettings *
 	if err != nil {
 		return nil, newError("failed to dial request to ", dest).Base(err)
 	}
-	req, err := http.NewRequest("GET", "/"+transportConfiguration.Path, nil)
+	req, err := http.NewRequest("GET", transportConfiguration.GetNormalizedPath(), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
resolves: [#2740](https://github.com/v2fly/v2ray-core/issues/2740)

### Test the different performances of `http.NewRequest` for `//s123/randomstring123` and `/s123/randomstring123`

```golang
package main

import (
	"fmt"
	"net/http"
	"os"
)

func main() {
	f1()
	f2()
}

func f1() {
	fmt.Println("f1:")
	s := "//s123/randomstring123"
	req, _ := http.NewRequest("GET", s, nil)
	req.Write(os.Stdout)
}

func f2() {
	fmt.Println("f2:")
	s := "/s123/randomstring123"
	req, _ := http.NewRequest("GET", s, nil)
	req.Write(os.Stdout)
}
```
### Output：

```shell
go run .
f1:
GET /randomstring123 HTTP/1.1
Host: s123
User-Agent: Go-http-client/1.1

f2:
GET /s123/randomstring123 HTTP/1.1
Host: 
User-Agent: Go-http-client/1.1
```
