### PR TITLE
Reduce WS memory usage

### DIFF
--- a/transport/internet/websocket/hub.go
+++ b/transport/internet/websocket/hub.go
@@ -29,8 +29,8 @@ type requestHandler struct {
 }
 
 var upgrader = &websocket.Upgrader{
-	ReadBufferSize:   4 * 1024,
-	WriteBufferSize:  4 * 1024,
+	ReadBufferSize:   0,
+	WriteBufferSize:  0,
 	HandshakeTimeout: time.Second * 4,
 	CheckOrigin: func(r *http.Request) bool {
 		return true


### PR DESCRIPTION
This can reduce the memory usage of websockets with multiple concurrency
see https://github.com/gorilla/websocket/issues/223