### PR TITLE
Revert "fix domain socket abstract name"

### DIFF
--- a/transport/internet/domainsocket/config.go
+++ b/transport/internet/domainsocket/config.go
@@ -16,8 +16,8 @@ func (c *Config) GetUnixAddr() (*net.UnixAddr, error) {
 	if path == "" {
 		return nil, newError("empty domain socket path")
 	}
-	if c.Abstract && path[0] != '\x00' {
-		path = "\x00" + path
+	if c.Abstract && path[0] != '@' {
+		path = "@" + path
 	}
 	if c.Abstract && c.Padding {
 		raw := []byte(path)


### PR DESCRIPTION
Partially revert 263fbf5. See #164 and https://github.com/golang/go/issues/63579. It has got fixed but not backported.