### PR TITLE
Allow setting permission on CopyFile helper

### DIFF
--- a/common/platform/filesystem/file.go
+++ b/common/platform/filesystem/file.go
@@ -45,12 +45,12 @@ func ReadAsset(file string) ([]byte, error) {
 	return ReadFile(platform.GetAssetLocation(file))
 }
 
-func CopyFile(dst string, src string) error {
+func CopyFile(dst string, src string, perm os.FileMode) error {
 	bytes, err := ReadFile(src)
 	if err != nil {
 		return err
 	}
-	f, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY, 0o644)
+	f, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY, perm)
 	if err != nil {
 		return err
 	}

--- a/infra/conf/rule/rule_test.go
+++ b/infra/conf/rule/rule_test.go
@@ -39,7 +39,7 @@ func init() {
 func TestToCidrList(t *testing.T) {
 	t.Log(os.Getenv("v2ray.location.asset"))
 
-	common.Must(filesystem.CopyFile(platform.GetAssetLocation("geoiptestrouter.dat"), platform.GetAssetLocation("geoip.dat")))
+	common.Must(filesystem.CopyFile(platform.GetAssetLocation("geoiptestrouter.dat"), platform.GetAssetLocation("geoip.dat"), 0o600))
 
 	ips := cfgcommon.StringList([]string{
 		"geoip:us",


### PR DESCRIPTION
This is a security enhancement that avoid unsafe by default permission that allow read from other users. 