### PR TITLE
Add support to allow tls=0 in vmess:// subscription

### DIFF
--- a/app/subscription/entries/nonnative/definitions/vmess.jsont
+++ b/app/subscription/entries/nonnative/definitions/vmess.jsont
@@ -25,7 +25,7 @@
     {{end}}
 
 {{ $security_type := tryGet . "root_!link_host_!base64_!json_tls_!unquoted" "root_!json_tls" "<default>"}}
-{{ $security_type = $security_type | unalias "none" "" "false"}}
+{{ $security_type = $security_type | unalias "none" "" "false" "0"}}
 
 {{if assertValueIsOneOf $security_type "tls" "utls" "none"| not }}
     unknown security type {{end}}


### PR DESCRIPTION
Add support to allow an alternative value for vmess:// link: tls = 0
(Fix https://github.com/v2fly/v2ray-core/issues/2907)