### PR TITLE
fix multiarch buildah command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,13 +325,15 @@ jobs:
               v2Arch=$(echo $arch | cut -d: -f1)
               containerArch=$(echo $arch | cut -d: -f2)
               bash ./release/container/downloadAssets.sh $VERSION $v2Arch $containerArch $v2Variant
-              buildah bud \
-                $(formatEach "--tag $image:{}" $variantTags) \
-                --file ./release/container/Containerfile \
-                --platform linux/$containerArch \
-                --timestamp $timestamp \
-                --squash \
-                ./context/linux/$containerArch/$v2Variant
+              for tag in $variantTags; do
+                buildah bud \
+                  --manifest $image:$tag \
+                  --file ./release/container/Containerfile \
+                  --platform linux/$containerArch \
+                  --timestamp $timestamp \
+                  --squash \
+                  ./context/linux/$containerArch/$v2Variant
+              done
             done
           done
 


### PR DESCRIPTION
follow up fix for #2757 😳

It seems the newly published images are single-arch. Went through a few manuals and it turned out that we should use `--manifest` instead of `--tag`.
Also `buildah` doesn't supports more than one `--manifest` arguments in one build, so we have to build each (`v5`, `v5.15`, `v5.15.0`, etc) separately even if they are identical images/manifests.

Ideally we can move `downloadAssets.sh`'s logic into Containerfile itself so we can build for multiple archs concurrently. However that would be a big change and I'd rather leave it as is for now.