### PR TITLE
Add Keep-Alive to removed headers in RemoveHopByHopHeaders

### DIFF
--- a/common/protocol/http/headers.go
+++ b/common/protocol/http/headers.go
@@ -35,6 +35,7 @@ func RemoveHopByHopHeaders(header http.Header) {
 	header.Del("Trailers")
 	header.Del("Transfer-Encoding")
 	header.Del("Upgrade")
+	header.Del("Keep-Alive")
 
 	connections := header.Get("Connection")
 	header.Del("Connection")


### PR DESCRIPTION
This merge request add Keep-Alive header to removed hop by hop headers in http protocol proxy as per requested by https://www.rfc-editor.org/rfc/rfc9110.html.