### PR TITLE
Add timeout for http request roundtripper

### DIFF
--- a/transport/internet/request/roundtripper/httprt/httprt.go
+++ b/transport/internet/request/roundtripper/httprt/httprt.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	gonet "net"
 	"net/http"
+	"time"
 
 	"github.com/v2fly/v2ray-core/v5/transport/internet/transportcommon"
 
@@ -119,7 +120,14 @@ func (h *httpTripperServer) Start() error {
 	}
 	h.listener = listener
 	go func() {
-		err := http.Serve(listener, h)
+		httpServer := http.Server{
+			ReadHeaderTimeout: 15 * time.Second,
+			ReadTimeout:       15 * time.Second,
+			WriteTimeout:      10 * time.Second,
+			IdleTimeout:       30 * time.Second,
+		}
+		httpServer.Handler = h
+		err := httpServer.Serve(h.listener)
 		if err != nil {
 			newError("unable to serve listener for http tripper server").Base(err).WriteToLog()
 		}


### PR DESCRIPTION
This merge request add timeout for http round tripper to avoid attack with slow request. Beaware in typical usage, the requests are already authenticated before it reachs V2Ray. 