### PR TITLE
routing/balancer: fix fallbackTag missing on leastping balancer

### DIFF
--- a/app/router/config.go
+++ b/app/router/config.go
@@ -144,7 +144,7 @@ func (br *BalancingRule) Build(ohm outbound.Manager, dispatcher routing.Dispatch
 		return &Balancer{
 			selectors: br.OutboundSelector,
 			strategy:  &LeastPingStrategy{config: s},
-			ohm:       ohm,
+			ohm:       ohm, fallbackTag: br.FallbackTag,
 		}, nil
 	case "leastload":
 		i, err := serial.GetInstanceOf(br.StrategySettings)


### PR DESCRIPTION
This fix fallbackTag not working when balancer type is set to "leastping"

Fixes #3100 