### PR TITLE
hysteria2, grpc: fix the use of GetTLSConfig

### DIFF
--- a/transport/internet/grpc/dial.go
+++ b/transport/internet/grpc/dial.go
@@ -52,7 +52,7 @@ func dialgRPC(ctx context.Context, dest net.Destination, streamSettings *interne
 
 	transportCredentials := insecure.NewCredentials()
 	if config != nil {
-		transportCredentials = credentials.NewTLS(config.GetTLSConfig())
+		transportCredentials = credentials.NewTLS(config.GetTLSConfig(tls.WithDestination(dest)))
 	}
 	dialOption := grpc.WithTransportCredentials(transportCredentials)
 

--- a/transport/internet/hysteria2/dialer.go
+++ b/transport/internet/hysteria2/dialer.go
@@ -24,12 +24,12 @@ var RunningClient map[dialerConf](hyClient.Client)
 var ClientMutex sync.Mutex
 var MBps uint64 = 1000000 / 8 // MByte
 
-func GetClientTLSConfig(streamSettings *internet.MemoryStreamConfig) (*hyClient.TLSConfig, error) {
+func GetClientTLSConfig(dest net.Destination, streamSettings *internet.MemoryStreamConfig) (*hyClient.TLSConfig, error) {
 	config := tls.ConfigFromStreamSettings(streamSettings)
 	if config == nil {
 		return nil, newError(Hy2MustNeedTLS)
 	}
-	tlsConfig := config.GetTLSConfig()
+	tlsConfig := config.GetTLSConfig(tls.WithDestination(dest))
 
 	return &hyClient.TLSConfig{
 		RootCAs:               tlsConfig.RootCAs,
@@ -67,7 +67,7 @@ func (f *connFactory) New(addr net.Addr) (net.PacketConn, error) {
 }
 
 func NewHyClient(dest net.Destination, streamSettings *internet.MemoryStreamConfig) (hyClient.Client, error) {
-	tlsConfig, err := GetClientTLSConfig(streamSettings)
+	tlsConfig, err := GetClientTLSConfig(dest, streamSettings)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When reviewing https://github.com/v2fly/v2ray-core/pull/3162#discussion_r1783655151, I found that hysteria2 and grpc dialer do not fill `ServerName` with server address if `ServerName` is not specified. All other dialers use `config.GetTLSConfig(tls.WithDestination(dest))` or `security.OptionWithDestination{Dest: dest})`.