### PR TITLE
Drop unsupported domain address type in packet addr

### DIFF
--- a/common/net/packetaddr/connection_adaptor.go
+++ b/common/net/packetaddr/connection_adaptor.go
@@ -79,6 +79,11 @@ func (c *packetConnectionAdaptor) ReadFrom(p []byte) (n int, addr gonet.Addr, er
 }
 
 func (c *packetConnectionAdaptor) WriteTo(p []byte, addr gonet.Addr) (n int, err error) {
+	_, ok := addr.(*gonet.UDPAddr)
+	if !ok {
+		// address other than UDPAddr is not supported, and will be dropped.
+		return 0, nil
+	}
 	payloadLen := len(p)
 	var buffer *buf.Buffer
 	buffer, err = AttachAddressToPacket(buf.FromBytes(p), addr)

--- a/common/net/packetaddr/packetaddr.go
+++ b/common/net/packetaddr/packetaddr.go
@@ -2,6 +2,7 @@ package packetaddr
 
 import (
 	"bytes"
+	"github.com/v2fly/v2ray-core/v5/common/errors"
 	gonet "net"
 
 	"github.com/v2fly/v2ray-core/v5/common/buf"
@@ -44,6 +45,9 @@ func ExtractAddressFromPacket(data *buf.Buffer) (*buf.Buffer, gonet.Addr, error)
 	address, port, err := addrParser.ReadAddressPort(&packetBuf, bytes.NewReader(data.Bytes()))
 	if err != nil {
 		return nil, nil, err
+	}
+	if address.Family().IsDomain() {
+		return nil, nil, errors.New("invalid address type")
 	}
 	addr := &gonet.UDPAddr{
 		IP:   address.IP(),

--- a/transport/internet/udp/dispatcher_packetaddr.go
+++ b/transport/internet/udp/dispatcher_packetaddr.go
@@ -27,6 +27,12 @@ func (p PacketAddrDispatcher) Dispatch(ctx context.Context, destination net.Dest
 	if destination.Network != net.Network_UDP {
 		return
 	}
+
+	// Processing of domain address is unsupported as it adds unpredictable overhead, it will be dropped.
+	if destination.Address.Family().IsDomain() {
+		return
+	}
+
 	p.conn.WriteTo(payload.Bytes(), &net.UDPAddr{IP: destination.Address.IP(), Port: int(destination.Port.Value())})
 }
 


### PR DESCRIPTION
Currently packetAddr does not works with domain address and will panic when encountered one.
This patch will drop packets with a domain address to prevent panic, while long term solution is being considered.
See also: https://github.com/v2fly/v2ray-core/issues/2783