### PR TITLE
Fix infinite loop when parsing empty nonnative subscription content

### DIFF
--- a/app/subscription/entries/nonnative/nonnative.go
+++ b/app/subscription/entries/nonnative/nonnative.go
@@ -30,6 +30,10 @@ func (a *AbstractNonNativeLink) fromBytes(bytes []byte) {
 }
 
 func (a *AbstractNonNativeLink) extractValue(content, prefix string) {
+	if content == "" {
+		return
+	}
+
 	{
 		// check if the content is a link
 		match, err := regexp.Match("[a-zA-Z0-9]+:((\\/\\/)|\\?)", []byte(content))


### PR DESCRIPTION
This pull request fixes issue mentioned in https://github.com/v2fly/v2ray-core/issues/3206 that there is an infinite loop when vmess link are processed.

Root cause of error: an empty string is a valid base64 string, thus triggering an infinite processing loop. 