### PR TITLE
feat: copy some certificate related options for uTLS

### DIFF
--- a/transport/internet/tls/utls/utls.go
+++ b/transport/internet/tls/utls/utls.go
@@ -106,11 +106,15 @@ func (u uTLSClientConnection) GetConnectionApplicationProtocol() (string, error)
 
 func uTLSConfigFromTLSConfig(config *systls.Config) (*utls.Config, error) { // nolint: unparam
 	uconfig := &utls.Config{
-		Rand:       config.Rand,
-		Time:       config.Time,
-		RootCAs:    config.RootCAs,
-		NextProtos: config.NextProtos,
-		ServerName: config.ServerName,
+		Rand:                  config.Rand,
+		Time:                  config.Time,
+		RootCAs:               config.RootCAs,
+		NextProtos:            config.NextProtos,
+		ServerName:            config.ServerName,
+		VerifyPeerCertificate: config.VerifyPeerCertificate,
+		InsecureSkipVerify:    config.InsecureSkipVerify,
+		ClientAuth:            utls.ClientAuthType(config.ClientAuth),
+		ClientCAs:             config.ClientCAs,
 	}
 	return uconfig, nil
 }


### PR DESCRIPTION
`VerifyPeerCertificate` and `InsecureSkipVerify` are for verify remote server's certificate.
`ClientAuth` and `ClientCAs` are for client certificate auth, 

`SessionTicketsDisabled` will not be copied, because it will make fingerprints changed, and it seems that some browser not provide a simple way to disable session tickets, such as [Google Chrome](https://superuser.com/questions/461035/disable-google-chrome-session-restore-functionality).