### PR TITLE
Fix unreleased cache buffer in QUIC sniffing

### DIFF
--- a/common/protocol/quic/sniff.go
+++ b/common/protocol/quic/sniff.go
@@ -54,6 +54,9 @@ func SniffQUIC(b []byte) (*SniffHeader, error) {
 	cryptoData := bytespool.Alloc(int32(len(b)))
 	defer bytespool.Free(cryptoData)
 
+	cache := buf.New()
+	defer cache.Release()
+
 	// Parse QUIC packets
 	for len(b) > 0 {
 		buffer := buf.FromBytes(b)
@@ -139,9 +142,7 @@ func SniffQUIC(b []byte) (*SniffHeader, error) {
 			return nil, err
 		}
 
-		cache := buf.New()
-		defer cache.Release()
-
+		cache.Clear()
 		mask := cache.Extend(int32(block.BlockSize()))
 		block.Encrypt(mask, b[hdrLen+4:hdrLen+4+16])
 		b[0] ^= mask[0] & 0xf


### PR DESCRIPTION
May address https://github.com/v2fly/v2ray-core/issues/3316

In the issue report, witness two byte slices's addresses provided to`seal`:
```
github.com/v2fly/v2ray-core/v5/common/crypto.(*AEADAuthenticator).Seal(0xc00b3f0240, {0xc001567012, 0x0, 0x7ee}, {0xc001567000, 0x168, 0x800})
```
The dst's address is **0xc001567012**, the plain text's address is **0xc001567000**.

The dst's code is: https://github.com/v2fly/v2ray-core/blob/14bc04a889b65827aa6fffd310d329f6b47d0cf7/common/crypto/auth.go#L264-L269

The plain text's code is: https://github.com/v2fly/v2ray-core/blob/14bc04a889b65827aa6fffd310d329f6b47d0cf7/common/crypto/auth.go#L295-L304

Apparently, `eb` and `temp` are pointing to the same buffer. It means `buf.New()` returns a buffer twice.

So I found issue in QUIC sniffing in this PR:
```go
for len(b) > 0 {
	cache := buf.New()
	defer cache.Release()
}
```
All but last buffers assigned to `cache` will not be released if looping more than once. It may overflow the pool and make `buf.New()` works incorrectly.