### PR TITLE
Fix buffer leak in mkcp transport protocol

### DIFF
--- a/transport/internet/kcp/connection.go
+++ b/transport/internet/kcp/connection.go
@@ -390,7 +390,9 @@ func (c *Connection) writeMultiBufferInternal(reader io.Reader) error {
 	}()
 
 	var b *buf.Buffer
-	defer b.Release()
+	defer func() {
+		b.Release()
+	}()
 
 	for {
 		for {
@@ -537,6 +539,7 @@ func (c *Connection) Terminate() {
 	c.closer.Close()
 	c.sendingWorker.Release()
 	c.receivingWorker.Release()
+	c.output.Release()
 }
 
 func (c *Connection) HandleOption(opt SegmentOption) {

--- a/transport/internet/kcp/output.go
+++ b/transport/internet/kcp/output.go
@@ -10,6 +10,7 @@ import (
 
 type SegmentWriter interface {
 	Write(seg Segment) error
+	Release()
 }
 
 type SimpleSegmentWriter struct {
@@ -36,6 +37,10 @@ func (w *SimpleSegmentWriter) Write(seg Segment) error {
 	return err
 }
 
+func (w *SimpleSegmentWriter) Release() {
+	w.buffer.Release()
+}
+
 type RetryableWriter struct {
 	writer SegmentWriter
 }
@@ -50,4 +55,8 @@ func (w *RetryableWriter) Write(seg Segment) error {
 	return retry.Timed(5, 100).On(func() error {
 		return w.writer.Write(seg)
 	})
+}
+
+func (w *RetryableWriter) Release() {
+	w.writer.Release()
 }


### PR DESCRIPTION
This PR fixes two issues where buffers were not released.
1. `defer b.Release()` not woking because b is always null.
https://github.com/v2fly/v2ray-core/blob/77d2d1b1728decf4a6c3433b46992cb7f6cc8794/transport/internet/kcp/connection.go#L392-L393

2. SimpleSegmentWriter.buffer never release.
https://github.com/v2fly/v2ray-core/blob/77d2d1b1728decf4a6c3433b46992cb7f6cc8794/transport/internet/kcp/output.go#L24