### PR TITLE
QUIC sniffer: Fix potential slice panic

### DIFF
--- a/common/protocol/quic/sniff.go
+++ b/common/protocol/quic/sniff.go
@@ -118,7 +118,7 @@ func SniffQUIC(b []byte) (*SniffHeader, error) {
 		}
 
 		hdrLen := len(b) - int(buffer.Len())
-		if len(b) < hdrLen+int(packetLen) {
+		if len(b) < hdrLen+int(packetLen) || len(b) < hdrLen+20{
 			return nil, common.ErrNoClue // Not enough data to read as a QUIC packet. QUIC is UDP-based, so this is unlikely to happen.
 		}
 

--- a/common/protocol/quic/sniff.go
+++ b/common/protocol/quic/sniff.go
@@ -116,9 +116,13 @@ func SniffQUIC(b []byte) (*SniffHeader, error) {
 		if err != nil {
 			return nil, errNotQuic
 		}
+		// packet is impossible to shorter than this
+		if packetLen < 4 {
+			return nil, errNotQuic
+		}
 
 		hdrLen := len(b) - int(buffer.Len())
-		if len(b) < hdrLen+int(packetLen) || len(b) < hdrLen+20{
+		if len(b) < hdrLen+int(packetLen) {
 			return nil, common.ErrNoClue // Not enough data to read as a QUIC packet. QUIC is UDP-based, so this is unlikely to happen.
 		}
 
@@ -166,10 +170,6 @@ func SniffQUIC(b []byte) (*SniffHeader, error) {
 		}
 
 		extHdrLen := hdrLen + int(packetNumberLength)
-		// very strange packet length, maybe a fake QUIC header
-		if int(packetNumberLength) > int(packetLen) {
-			return nil, errNotQuic
-		}
 		copy(b[extHdrLen:hdrLen+4], origPNBytes[packetNumberLength:])
 		data := b[extHdrLen : int(packetLen)+hdrLen]
 

--- a/common/protocol/quic/sniff.go
+++ b/common/protocol/quic/sniff.go
@@ -166,6 +166,10 @@ func SniffQUIC(b []byte) (*SniffHeader, error) {
 		}
 
 		extHdrLen := hdrLen + int(packetNumberLength)
+		// very stange packet length, maybe a fake QUIC header
+		if packetNumberLength > int(packetLen) {
+			return nil, errNotQuic
+		}
 		copy(b[extHdrLen:hdrLen+4], origPNBytes[packetNumberLength:])
 		data := b[extHdrLen : int(packetLen)+hdrLen]
 

--- a/common/protocol/quic/sniff.go
+++ b/common/protocol/quic/sniff.go
@@ -166,7 +166,7 @@ func SniffQUIC(b []byte) (*SniffHeader, error) {
 		}
 
 		extHdrLen := hdrLen + int(packetNumberLength)
-		// very stange packet length, maybe a fake QUIC header
+		// very strange packet length, maybe a fake QUIC header
 		if int(packetNumberLength) > int(packetLen) {
 			return nil, errNotQuic
 		}

--- a/common/protocol/quic/sniff.go
+++ b/common/protocol/quic/sniff.go
@@ -167,7 +167,7 @@ func SniffQUIC(b []byte) (*SniffHeader, error) {
 
 		extHdrLen := hdrLen + int(packetNumberLength)
 		// very stange packet length, maybe a fake QUIC header
-		if packetNumberLength > int(packetLen) {
+		if int(packetNumberLength) > int(packetLen) {
 			return nil, errNotQuic
 		}
 		copy(b[extHdrLen:hdrLen+4], origPNBytes[packetNumberLength:])

--- a/common/protocol/quic/sniff_test.go
+++ b/common/protocol/quic/sniff_test.go
@@ -239,3 +239,21 @@ func TestSniffQUICComplex(t *testing.T) {
 		})
 	}
 }
+
+func TestSniffFakeQUICPacketWithInvalidPacketNumberLength(t *testing.T) {
+	pkt, err := hex.DecodeString("cb00000001081c8c6d5aeb53d54400000090709b8600000000000000000000000000000000")
+	common.Must(err)
+	_, err = quic.SniffQUIC(pkt)
+	if err == nil {
+		t.Error("failed")
+	}
+}
+
+func TestSniffFakeQUICPacketWithTooShortData(t *testing.T) {
+	pkt, err := hex.DecodeString("cb00000001081c8c6d5aeb53d54400000090709b86")
+	common.Must(err)
+	_, err = quic.SniffQUIC(pkt)
+	if err == nil {
+		t.Error("failed")
+	}
+}


### PR DESCRIPTION
From https://github.com/XTLS/Xray-core/issues/3914

概述：
一些奇怪的数据包 读出的 packet number length 有可能会大于 length 本身 导致切片读取错误(b[17:15]这样) 样例数据在原issue有 可自行验证 想了一下比较简单的粗暴的方法大概就是检验后直接返回错误

先发到这里的原因是Xray的是从fly这copy的(其实这个错误从最开始的旧QUIC嗅探嗅探器就存在的样子)

CC: @Vigilans