### PR TITLE
Replace context.TODO() with context.Background() across codebase

### DIFF
--- a/app/observatory/multiobservatory/multi.go
+++ b/app/observatory/multiobservatory/multi.go
@@ -36,7 +36,7 @@ func New(ctx context.Context, config *Config) (*Observer, error) {
 
 func (x *Config) UnmarshalJSONPB(unmarshaler *jsonpb.Unmarshaler, bytes []byte) error {
 	var err error
-	x.Holders, err = taggedfeatures.LoadJSONConfig(context.TODO(), "service", "background", bytes)
+	x.Holders, err = taggedfeatures.LoadJSONConfig(context.Background(), "service", "background", bytes)
 	return err
 }
 

--- a/app/router/command/command_test.go
+++ b/app/router/command/command_test.go
@@ -220,7 +220,7 @@ func TestSerivceTestRoute(t *testing.T) {
 	r := new(router.Router)
 	mockCtl := gomock.NewController(t)
 	defer mockCtl.Finish()
-	common.Must(r.Init(context.TODO(), &router.Config{
+	common.Must(r.Init(context.Background(), &router.Config{
 		Rule: []*router.RoutingRule{
 			{
 				InboundTag: []string{"in"},

--- a/app/router/config.go
+++ b/app/router/config.go
@@ -202,7 +202,7 @@ func (br *BalancingRule) UnmarshalJSONPB(unmarshaler *jsonpb.Unmarshaler, bytes 
 	if stub.Strategy == "" {
 		stub.Strategy = "random"
 	}
-	settingsPack, err := v5cfg.LoadHeterogeneousConfigFromRawJSON(context.TODO(), "balancer", stub.Strategy, stub.StrategySettings)
+	settingsPack, err := v5cfg.LoadHeterogeneousConfigFromRawJSON(context.Background(), "balancer", stub.Strategy, stub.StrategySettings)
 	if err != nil {
 		return err
 	}

--- a/app/router/router_test.go
+++ b/app/router/router_test.go
@@ -41,7 +41,7 @@ func TestSimpleRouter(t *testing.T) {
 	mockHs := mocks.NewOutboundHandlerSelector(mockCtl)
 
 	r := new(Router)
-	common.Must(r.Init(context.TODO(), config, mockDNS, &mockOutboundManager{
+	common.Must(r.Init(context.Background(), config, mockDNS, &mockOutboundManager{
 		Manager:         mockOhm,
 		HandlerSelector: mockHs,
 	}, nil))
@@ -82,7 +82,7 @@ func TestSimpleBalancer(t *testing.T) {
 	mockHs.EXPECT().Select(gomock.Eq([]string{"test-"})).Return([]string{"test"})
 
 	r := new(Router)
-	common.Must(r.Init(context.TODO(), config, mockDNS, &mockOutboundManager{
+	common.Must(r.Init(context.Background(), config, mockDNS, &mockOutboundManager{
 		Manager:         mockOhm,
 		HandlerSelector: mockHs,
 	}, nil))
@@ -169,7 +169,7 @@ func TestIPOnDemand(t *testing.T) {
 	mockDNS.EXPECT().LookupIP(gomock.Eq("v2fly.org")).Return([]net.IP{{192, 168, 0, 1}}, nil).AnyTimes()
 
 	r := new(Router)
-	common.Must(r.Init(context.TODO(), config, mockDNS, nil, nil))
+	common.Must(r.Init(context.Background(), config, mockDNS, nil, nil))
 
 	ctx := session.ContextWithOutbound(context.Background(), &session.Outbound{Target: net.TCPDestination(net.DomainAddress("v2fly.org"), 80)})
 	route, err := r.PickRoute(routing_session.AsRoutingContext(ctx))
@@ -204,7 +204,7 @@ func TestIPIfNonMatchDomain(t *testing.T) {
 	mockDNS.EXPECT().LookupIP(gomock.Eq("v2fly.org")).Return([]net.IP{{192, 168, 0, 1}}, nil).AnyTimes()
 
 	r := new(Router)
-	common.Must(r.Init(context.TODO(), config, mockDNS, nil, nil))
+	common.Must(r.Init(context.Background(), config, mockDNS, nil, nil))
 
 	ctx := session.ContextWithOutbound(context.Background(), &session.Outbound{Target: net.TCPDestination(net.DomainAddress("v2fly.org"), 80)})
 	route, err := r.PickRoute(routing_session.AsRoutingContext(ctx))
@@ -238,7 +238,7 @@ func TestIPIfNonMatchIP(t *testing.T) {
 	mockDNS := mocks.NewDNSClient(mockCtl)
 
 	r := new(Router)
-	common.Must(r.Init(context.TODO(), config, mockDNS, nil, nil))
+	common.Must(r.Init(context.Background(), config, mockDNS, nil, nil))
 
 	ctx := session.ContextWithOutbound(context.Background(), &session.Outbound{Target: net.TCPDestination(net.LocalHostIP, 80)})
 	route, err := r.PickRoute(routing_session.AsRoutingContext(ctx))

--- a/app/subscription/specs/outbound_parser.go
+++ b/app/subscription/specs/outbound_parser.go
@@ -81,7 +81,7 @@ func (p *OutboundParser) ToSubscriptionServerConfig(config *OutboundConfig) (*Su
 }
 
 func loadHeterogeneousConfigFromRawJSONRestricted(interfaceType, name string, rawJSON json.RawMessage) (proto.Message, error) {
-	ctx := context.TODO()
+	ctx := context.Background()
 	ctx = registry.CreateRestrictedModeContext(ctx)
 	if len(rawJSON) == 0 {
 		rawJSON = []byte("{}")

--- a/infra/conf/v5cfg/common.go
+++ b/infra/conf/v5cfg/common.go
@@ -13,7 +13,7 @@ import (
 
 func loadHeterogeneousConfigFromRawJSON(interfaceType, name string, rawJSON json.RawMessage) (proto.Message, error) {
 	fsdef := envimpl.NewDefaultFileSystemDefaultImpl()
-	ctx := envctx.ContextWithEnvironment(context.TODO(), fsdef)
+	ctx := envctx.ContextWithEnvironment(context.Background(), fsdef)
 	if len(rawJSON) == 0 {
 		rawJSON = []byte("{}")
 	}

--- a/proxy/vmess/encoding/encoding_test.go
+++ b/proxy/vmess/encoding/encoding_test.go
@@ -43,7 +43,7 @@ func TestRequestSerialization(t *testing.T) {
 	}
 
 	buffer := buf.New()
-	client := NewClientSession(context.TODO(), true, protocol.DefaultIDHash, 0)
+	client := NewClientSession(context.Background(), true, protocol.DefaultIDHash, 0)
 	common.Must(client.EncodeRequestHeader(expectedRequest, buffer))
 
 	buffer2 := buf.New()
@@ -93,7 +93,7 @@ func TestInvalidRequest(t *testing.T) {
 	}
 
 	buffer := buf.New()
-	client := NewClientSession(context.TODO(), true, protocol.DefaultIDHash, 0)
+	client := NewClientSession(context.Background(), true, protocol.DefaultIDHash, 0)
 	common.Must(client.EncodeRequestHeader(expectedRequest, buffer))
 
 	buffer2 := buf.New()
@@ -134,7 +134,7 @@ func TestMuxRequest(t *testing.T) {
 	}
 
 	buffer := buf.New()
-	client := NewClientSession(context.TODO(), true, protocol.DefaultIDHash, 0)
+	client := NewClientSession(context.Background(), true, protocol.DefaultIDHash, 0)
 	common.Must(client.EncodeRequestHeader(expectedRequest, buffer))
 
 	buffer2 := buf.New()

--- a/testing/scenarios/grpc_test.go
+++ b/testing/scenarios/grpc_test.go
@@ -23,26 +23,28 @@ func TestGRPCDefault(t *testing.T) {
 	coreInst, InstMgrIfce := NewInstanceManagerCoreInstance()
 	defer coreInst.Close()
 
+	ctx := context.Background()
+
 	common.Must(InstMgrIfce.AddInstance(
-		context.TODO(),
+		ctx,
 		"grpc_client",
 		common.Must2(os.ReadFile("config/grpc_client.json")).([]byte),
 		"jsonv5"))
 
 	common.Must(InstMgrIfce.AddInstance(
-		context.TODO(),
+		ctx,
 		"grpc_server",
 		common.Must2(os.ReadFile("config/grpc_server.json")).([]byte),
 		"jsonv5"))
 
-	common.Must(InstMgrIfce.StartInstance(context.TODO(), "grpc_server"))
-	common.Must(InstMgrIfce.StartInstance(context.TODO(), "grpc_client"))
+	common.Must(InstMgrIfce.StartInstance(ctx, "grpc_server"))
+	common.Must(InstMgrIfce.StartInstance(ctx, "grpc_client"))
 
 	defer func() {
-		common.Must(InstMgrIfce.StopInstance(context.TODO(), "grpc_server"))
-		common.Must(InstMgrIfce.StopInstance(context.TODO(), "grpc_client"))
-		common.Must(InstMgrIfce.UntrackInstance(context.TODO(), "grpc_server"))
-		common.Must(InstMgrIfce.UntrackInstance(context.TODO(), "grpc_client"))
+		common.Must(InstMgrIfce.StopInstance(ctx, "grpc_server"))
+		common.Must(InstMgrIfce.StopInstance(ctx, "grpc_client"))
+		common.Must(InstMgrIfce.UntrackInstance(ctx, "grpc_server"))
+		common.Must(InstMgrIfce.UntrackInstance(ctx, "grpc_client"))
 		coreInst.Close()
 	}()
 
@@ -62,26 +64,28 @@ func TestGRPCWithServiceName(t *testing.T) {
 	coreInst, InstMgrIfce := NewInstanceManagerCoreInstance()
 	defer coreInst.Close()
 
+	ctx := context.Background()
+
 	common.Must(InstMgrIfce.AddInstance(
-		context.TODO(),
+		ctx,
 		"grpc_client",
 		common.Must2(os.ReadFile("config/grpc_servicename_client.json")).([]byte),
 		"jsonv5"))
 
 	common.Must(InstMgrIfce.AddInstance(
-		context.TODO(),
+		ctx,
 		"grpc_server",
 		common.Must2(os.ReadFile("config/grpc_servicename_server.json")).([]byte),
 		"jsonv5"))
 
-	common.Must(InstMgrIfce.StartInstance(context.TODO(), "grpc_server"))
-	common.Must(InstMgrIfce.StartInstance(context.TODO(), "grpc_client"))
+	common.Must(InstMgrIfce.StartInstance(ctx, "grpc_server"))
+	common.Must(InstMgrIfce.StartInstance(ctx, "grpc_client"))
 
 	defer func() {
-		common.Must(InstMgrIfce.StopInstance(context.TODO(), "grpc_server"))
-		common.Must(InstMgrIfce.StopInstance(context.TODO(), "grpc_client"))
-		common.Must(InstMgrIfce.UntrackInstance(context.TODO(), "grpc_server"))
-		common.Must(InstMgrIfce.UntrackInstance(context.TODO(), "grpc_client"))
+		common.Must(InstMgrIfce.StopInstance(ctx, "grpc_server"))
+		common.Must(InstMgrIfce.StopInstance(ctx, "grpc_client"))
+		common.Must(InstMgrIfce.UntrackInstance(ctx, "grpc_server"))
+		common.Must(InstMgrIfce.UntrackInstance(ctx, "grpc_client"))
 		coreInst.Close()
 	}()
 

--- a/testing/scenarios/httpupgrade_test.go
+++ b/testing/scenarios/httpupgrade_test.go
@@ -23,26 +23,28 @@ func TestHTTPUpgrade(t *testing.T) {
 	coreInst, InstMgrIfce := NewInstanceManagerCoreInstance()
 	defer coreInst.Close()
 
+	ctx := context.Background()
+
 	common.Must(InstMgrIfce.AddInstance(
-		context.TODO(),
+		ctx,
 		"httpupgrade_client",
 		common.Must2(os.ReadFile("config/httpupgrade_client.json")).([]byte),
 		"jsonv5"))
 
 	common.Must(InstMgrIfce.AddInstance(
-		context.TODO(),
+		ctx,
 		"httpupgrade_server",
 		common.Must2(os.ReadFile("config/httpupgrade_server.json")).([]byte),
 		"jsonv5"))
 
-	common.Must(InstMgrIfce.StartInstance(context.TODO(), "httpupgrade_server"))
-	common.Must(InstMgrIfce.StartInstance(context.TODO(), "httpupgrade_client"))
+	common.Must(InstMgrIfce.StartInstance(ctx, "httpupgrade_server"))
+	common.Must(InstMgrIfce.StartInstance(ctx, "httpupgrade_client"))
 
 	defer func() {
-		common.Must(InstMgrIfce.StopInstance(context.TODO(), "httpupgrade_server"))
-		common.Must(InstMgrIfce.StopInstance(context.TODO(), "httpupgrade_client"))
-		common.Must(InstMgrIfce.UntrackInstance(context.TODO(), "httpupgrade_server"))
-		common.Must(InstMgrIfce.UntrackInstance(context.TODO(), "httpupgrade_client"))
+		common.Must(InstMgrIfce.StopInstance(ctx, "httpupgrade_server"))
+		common.Must(InstMgrIfce.StopInstance(ctx, "httpupgrade_client"))
+		common.Must(InstMgrIfce.UntrackInstance(ctx, "httpupgrade_server"))
+		common.Must(InstMgrIfce.UntrackInstance(ctx, "httpupgrade_client"))
 		coreInst.Close()
 	}()
 
@@ -62,26 +64,28 @@ func TestHTTPUpgradeWithEarlyData(t *testing.T) {
 	coreInst, InstMgrIfce := NewInstanceManagerCoreInstance()
 	defer coreInst.Close()
 
+	ctx := context.Background()
+
 	common.Must(InstMgrIfce.AddInstance(
-		context.TODO(),
+		ctx,
 		"httpupgrade_client",
 		common.Must2(os.ReadFile("config/httpupgrade_earlydata_client.json")).([]byte),
 		"jsonv5"))
 
 	common.Must(InstMgrIfce.AddInstance(
-		context.TODO(),
+		ctx,
 		"httpupgrade_server",
 		common.Must2(os.ReadFile("config/httpupgrade_earlydata_server.json")).([]byte),
 		"jsonv5"))
 
-	common.Must(InstMgrIfce.StartInstance(context.TODO(), "httpupgrade_server"))
-	common.Must(InstMgrIfce.StartInstance(context.TODO(), "httpupgrade_client"))
+	common.Must(InstMgrIfce.StartInstance(ctx, "httpupgrade_server"))
+	common.Must(InstMgrIfce.StartInstance(ctx, "httpupgrade_client"))
 
 	defer func() {
-		common.Must(InstMgrIfce.StopInstance(context.TODO(), "httpupgrade_server"))
-		common.Must(InstMgrIfce.StopInstance(context.TODO(), "httpupgrade_client"))
-		common.Must(InstMgrIfce.UntrackInstance(context.TODO(), "httpupgrade_server"))
-		common.Must(InstMgrIfce.UntrackInstance(context.TODO(), "httpupgrade_client"))
+		common.Must(InstMgrIfce.StopInstance(ctx, "httpupgrade_server"))
+		common.Must(InstMgrIfce.StopInstance(ctx, "httpupgrade_client"))
+		common.Must(InstMgrIfce.UntrackInstance(ctx, "httpupgrade_server"))
+		common.Must(InstMgrIfce.UntrackInstance(ctx, "httpupgrade_client"))
 		coreInst.Close()
 	}()
 
@@ -101,26 +105,28 @@ func TestHTTPUpgradeWithShortEarlyData(t *testing.T) {
 	coreInst, InstMgrIfce := NewInstanceManagerCoreInstance()
 	defer coreInst.Close()
 
+	ctx := context.Background()
+
 	common.Must(InstMgrIfce.AddInstance(
-		context.TODO(),
+		ctx,
 		"httpupgrade_client",
 		common.Must2(os.ReadFile("config/httpupgrade_earlydataShortEarlyData_client.json")).([]byte),
 		"jsonv5"))
 
 	common.Must(InstMgrIfce.AddInstance(
-		context.TODO(),
+		ctx,
 		"httpupgrade_server",
 		common.Must2(os.ReadFile("config/httpupgrade_earlydataShortEarlyData_server.json")).([]byte),
 		"jsonv5"))
 
-	common.Must(InstMgrIfce.StartInstance(context.TODO(), "httpupgrade_server"))
-	common.Must(InstMgrIfce.StartInstance(context.TODO(), "httpupgrade_client"))
+	common.Must(InstMgrIfce.StartInstance(ctx, "httpupgrade_server"))
+	common.Must(InstMgrIfce.StartInstance(ctx, "httpupgrade_client"))
 
 	defer func() {
-		common.Must(InstMgrIfce.StopInstance(context.TODO(), "httpupgrade_server"))
-		common.Must(InstMgrIfce.StopInstance(context.TODO(), "httpupgrade_client"))
-		common.Must(InstMgrIfce.UntrackInstance(context.TODO(), "httpupgrade_server"))
-		common.Must(InstMgrIfce.UntrackInstance(context.TODO(), "httpupgrade_client"))
+		common.Must(InstMgrIfce.StopInstance(ctx, "httpupgrade_server"))
+		common.Must(InstMgrIfce.StopInstance(ctx, "httpupgrade_client"))
+		common.Must(InstMgrIfce.UntrackInstance(ctx, "httpupgrade_server"))
+		common.Must(InstMgrIfce.UntrackInstance(ctx, "httpupgrade_client"))
 		coreInst.Close()
 	}()
 

--- a/testing/scenarios/meek_test.go
+++ b/testing/scenarios/meek_test.go
@@ -23,26 +23,28 @@ func TestMeek(t *testing.T) {
 	coreInst, InstMgrIfce := NewInstanceManagerCoreInstance()
 	defer coreInst.Close()
 
+	ctx := context.Background()
+
 	common.Must(InstMgrIfce.AddInstance(
-		context.TODO(),
+		ctx,
 		"meek_client",
 		common.Must2(os.ReadFile("config/meek_client.json")).([]byte),
 		"jsonv5"))
 
 	common.Must(InstMgrIfce.AddInstance(
-		context.TODO(),
+		ctx,
 		"meek_server",
 		common.Must2(os.ReadFile("config/meek_server.json")).([]byte),
 		"jsonv5"))
 
-	common.Must(InstMgrIfce.StartInstance(context.TODO(), "meek_server"))
-	common.Must(InstMgrIfce.StartInstance(context.TODO(), "meek_client"))
+	common.Must(InstMgrIfce.StartInstance(ctx, "meek_server"))
+	common.Must(InstMgrIfce.StartInstance(ctx, "meek_client"))
 
 	defer func() {
-		common.Must(InstMgrIfce.StopInstance(context.TODO(), "meek_server"))
-		common.Must(InstMgrIfce.StopInstance(context.TODO(), "meek_client"))
-		common.Must(InstMgrIfce.UntrackInstance(context.TODO(), "meek_server"))
-		common.Must(InstMgrIfce.UntrackInstance(context.TODO(), "meek_client"))
+		common.Must(InstMgrIfce.StopInstance(ctx, "meek_server"))
+		common.Must(InstMgrIfce.StopInstance(ctx, "meek_client"))
+		common.Must(InstMgrIfce.UntrackInstance(ctx, "meek_server"))
+		common.Must(InstMgrIfce.UntrackInstance(ctx, "meek_client"))
 		coreInst.Close()
 	}()
 

--- a/testing/scenarios/mekya_test.go
+++ b/testing/scenarios/mekya_test.go
@@ -23,26 +23,28 @@ func TestMekya(t *testing.T) {
 	coreInst, InstMgrIfce := NewInstanceManagerCoreInstance()
 	defer coreInst.Close()
 
+	ctx := context.Background()
+
 	common.Must(InstMgrIfce.AddInstance(
-		context.TODO(),
+		ctx,
 		"mekya_client",
 		common.Must2(os.ReadFile("config/mekya_client.json")).([]byte),
 		"jsonv5"))
 
 	common.Must(InstMgrIfce.AddInstance(
-		context.TODO(),
+		ctx,
 		"mekya_server",
 		common.Must2(os.ReadFile("config/mekya_server.json")).([]byte),
 		"jsonv5"))
 
-	common.Must(InstMgrIfce.StartInstance(context.TODO(), "mekya_server"))
-	common.Must(InstMgrIfce.StartInstance(context.TODO(), "mekya_client"))
+	common.Must(InstMgrIfce.StartInstance(ctx, "mekya_server"))
+	common.Must(InstMgrIfce.StartInstance(ctx, "mekya_client"))
 
 	defer func() {
-		common.Must(InstMgrIfce.StopInstance(context.TODO(), "mekya_server"))
-		common.Must(InstMgrIfce.StopInstance(context.TODO(), "mekya_client"))
-		common.Must(InstMgrIfce.UntrackInstance(context.TODO(), "mekya_server"))
-		common.Must(InstMgrIfce.UntrackInstance(context.TODO(), "mekya_client"))
+		common.Must(InstMgrIfce.StopInstance(ctx, "mekya_server"))
+		common.Must(InstMgrIfce.StopInstance(ctx, "mekya_client"))
+		common.Must(InstMgrIfce.UntrackInstance(ctx, "mekya_server"))
+		common.Must(InstMgrIfce.UntrackInstance(ctx, "mekya_client"))
 		coreInst.Close()
 	}()
 


### PR DESCRIPTION
Replace context.TODO() with context.Background() across codebase

This change improves code quality by replacing temporary context.TODO() placeholders with proper context.Background() usage throughout the project.

Changes include:
- Test files: Updated scenario tests (meek, httpupgrade, grpc, mekya) and unit tests to use context.Background() with shared ctx variables
- Production code: Fixed context usage in config loading, subscription parsing, and observatory components

The context.TODO() was originally meant as a temporary placeholder, but these operations don't require cancellation, so context.Background() is more appropriate and explicit about the intent.

All existing tests pass with these changes, ensuring no functional regressions while improving code maintainability.