### PR TITLE
Fix websocket early data connection close

### DIFF
--- a/transport/internet/websocket/connforwarder.go
+++ b/transport/internet/websocket/connforwarder.go
@@ -42,7 +42,11 @@ func (c *connectionForwarder) Write(p []byte) (n int, err error) {
 
 func (c *connectionForwarder) Close() error {
 	if c.shouldWait {
-		<-c.delayedDialFinish.Done()
+		select {
+		case <-c.delayedDialFinish.Done():
+		default:
+			c.finishedDial()
+		}
 		if c.ReadWriteCloser == nil {
 			return newError("unable to close delayed dial websocket connection as it do not exist")
 		}


### PR DESCRIPTION
`Close()` can be blocked by `c.dialer.Dial`.