### PR TITLE
Update TLS Mirror with TLS1.2 AEAD support, defer_instance_derived_write_time, transport_layer_padding, h2_do_not_wait_for_download_finish

### DIFF
--- a/transport/internet/tls/config.go
+++ b/transport/internet/tls/config.go
@@ -294,6 +294,13 @@ func (c *Config) GetTLSConfig(opts ...Option) *tls.Config {
 		}
 	}
 
+	if c.Ciphersuites != nil && len(c.Ciphersuites) > 0 {
+		config.CipherSuites = make([]uint16, 0, len(c.Ciphersuites))
+		for _, cs := range c.Ciphersuites {
+			config.CipherSuites = append(config.CipherSuites, uint16(cs))
+		}
+	}
+
 	return config
 }
 

--- a/transport/internet/tls/config.pb.go
+++ b/transport/internet/tls/config.pb.go
@@ -235,8 +235,11 @@ type Config struct {
 	Ech_DOHserver string `protobuf:"bytes,17,opt,name=ech_DOHserver,json=echDOHserver,proto3" json:"ech_DOHserver,omitempty"`
 	// domain to query for https record
 	EchQueryDomain string `protobuf:"bytes,18,opt,name=ech_query_domain,json=echQueryDomain,proto3" json:"ech_query_domain,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// cipher suites to to be offered or accepted.
+	// This is an developer option.
+	Ciphersuites  []uint32 `protobuf:"varint,19,rep,packed,name=ciphersuites,proto3" json:"ciphersuites,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Config) Reset() {
@@ -367,6 +370,13 @@ func (x *Config) GetEchQueryDomain() string {
 	return ""
 }
 
+func (x *Config) GetCiphersuites() []uint32 {
+	if x != nil {
+		return x.Ciphersuites
+	}
+	return nil
+}
+
 var File_transport_internet_tls_config_proto protoreflect.FileDescriptor
 
 const file_transport_internet_tls_config_proto_rawDesc = "" +
@@ -382,7 +392,7 @@ const file_transport_internet_tls_config_proto_rawDesc = "" +
 	"\fENCIPHERMENT\x10\x00\x12\x14\n" +
 	"\x10AUTHORITY_VERIFY\x10\x01\x12\x13\n" +
 	"\x0fAUTHORITY_ISSUE\x10\x02\x12\x1b\n" +
-	"\x17AUTHORITY_VERIFY_CLIENT\x10\x03\"\xa0\a\n" +
+	"\x17AUTHORITY_VERIFY_CLIENT\x10\x03\"\xc4\a\n" +
 	"\x06Config\x12-\n" +
 	"\x0eallow_insecure\x18\x01 \x01(\bB\x06\x82\xb5\x18\x02(\x01R\rallowInsecure\x12P\n" +
 	"\vcertificate\x18\x02 \x03(\v2..v2ray.core.transport.internet.tls.CertificateR\vcertificate\x12\x1f\n" +
@@ -402,7 +412,8 @@ const file_transport_internet_tls_config_proto_rawDesc = "" +
 	"\n" +
 	"ech_config\x18\x10 \x01(\fR\techConfig\x12#\n" +
 	"\rech_DOHserver\x18\x11 \x01(\tR\fechDOHserver\x12(\n" +
-	"\x10ech_query_domain\x18\x12 \x01(\tR\x0eechQueryDomain\"I\n" +
+	"\x10ech_query_domain\x18\x12 \x01(\tR\x0eechQueryDomain\x12\"\n" +
+	"\fciphersuites\x18\x13 \x03(\rR\fciphersuites\"I\n" +
 	"\n" +
 	"TLSVersion\x12\v\n" +
 	"\aDefault\x10\x00\x12\n" +

--- a/transport/internet/tls/config.proto
+++ b/transport/internet/tls/config.proto
@@ -87,4 +87,8 @@ message Config {
 
   // domain to query for https record
   string ech_query_domain = 18;
+
+  // cipher suites to to be offered or accepted.
+  // This is an developer option.
+  repeated uint32 ciphersuites = 19;
 }

--- a/transport/internet/tlsmirror/httponconnection/errors.generated.go
+++ b/transport/internet/tlsmirror/httponconnection/errors.generated.go
@@ -1,0 +1,9 @@
+package httponconnection
+
+import "github.com/v2fly/v2ray-core/v5/common/errors"
+
+type errPathObjHolder struct{}
+
+func newError(values ...interface{}) *errors.Error {
+	return errors.New(values...).WithPathObj(errPathObjHolder{})
+}

--- a/transport/internet/tlsmirror/httponconnection/singleconnhttp.go
+++ b/transport/internet/tlsmirror/httponconnection/singleconnhttp.go
@@ -1,0 +1,82 @@
+package httponconnection
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+
+	"golang.org/x/net/http2"
+)
+
+//go:generate go run github.com/v2fly/v2ray-core/v5/common/errors/errorgen
+
+type HttpRequestTransport interface {
+	http.RoundTripper
+}
+
+func newHTTPRequestTransportH1(conn net.Conn) HttpRequestTransport {
+	return &httpRequestTransportH1{
+		conn:      conn,
+		bufReader: bufio.NewReader(conn),
+	}
+}
+
+type httpRequestTransportH1 struct {
+	conn      net.Conn
+	bufReader *bufio.Reader
+}
+
+func (h *httpRequestTransportH1) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Proto = "HTTP/1.1"
+	req.ProtoMajor = 1
+	req.ProtoMinor = 1
+
+	err := req.Write(h.conn)
+	if err != nil {
+		return nil, err
+	}
+	return http.ReadResponse(h.bufReader, req)
+}
+
+func newHTTPRequestTransportH2(conn net.Conn) HttpRequestTransport {
+	transport := &http2.Transport{}
+	clientConn, err := transport.NewClientConn(conn)
+	if err != nil {
+		return nil
+	}
+	return &httpRequestTransportH2{
+		transport:        transport,
+		clientConnection: clientConn,
+	}
+}
+
+type httpRequestTransportH2 struct {
+	transport        *http2.Transport
+	clientConnection *http2.ClientConn
+}
+
+func (h *httpRequestTransportH2) RoundTrip(request *http.Request) (*http.Response, error) {
+	request.ProtoMajor = 2
+	request.ProtoMinor = 0
+
+	response, err := h.clientConnection.RoundTrip(request)
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func newSingleConnectionHTTPTransport(conn net.Conn, alpn string) (HttpRequestTransport, error) {
+	switch alpn {
+	case "h2":
+		return newHTTPRequestTransportH2(conn), nil
+	case "http/1.1", "":
+		return newHTTPRequestTransportH1(conn), nil
+	default:
+		return nil, newError("unknown alpn: " + alpn).AtWarning()
+	}
+}
+
+func NewSingleConnectionHTTPTransport(conn net.Conn, alpn string) (HttpRequestTransport, error) {
+	return newSingleConnectionHTTPTransport(conn, alpn)
+}

--- a/transport/internet/tlsmirror/interface.go
+++ b/transport/internet/tlsmirror/interface.go
@@ -31,11 +31,14 @@ type PartialTLSRecordRejectProfile interface {
 
 type MessageHook func(message *TLSRecord) (drop bool, ok error)
 
+type ExplicitNonceDetection func(cipherSuite uint16) bool
+
 type InsertableTLSConn interface {
 	common.Closable
 	GetHandshakeRandom() ([]byte, []byte, error)
 	InsertC2SMessage(message *TLSRecord) error
 	InsertS2CMessage(message *TLSRecord) error
+	GetApplicationDataExplicitNonceReservedOverheadHeaderLength() (int, error)
 }
 
 const TrafficGeneratorManagedConnectionContextKey = "TrafficGeneratorManagedConnection-ku63HMMD-kduCPhr8-DN4y6WEa"

--- a/transport/internet/tlsmirror/interface.go
+++ b/transport/internet/tlsmirror/interface.go
@@ -46,4 +46,5 @@ const TrafficGeneratorManagedConnectionContextKey = "TrafficGeneratorManagedConn
 type TrafficGeneratorManagedConnection interface {
 	RecallTrafficGenerator() error
 	WaitConnectionReady() context.Context
+	IsConnectionInvalidated() bool
 }

--- a/transport/internet/tlsmirror/mirrorbase/conn.go
+++ b/transport/internet/tlsmirror/mirrorbase/conn.go
@@ -170,7 +170,7 @@ func (c *conn) c2sWorker() {
 			// memory consistency synchronization for value c.tls12ExplicitNonce is required!!!
 			if *c.tls12ExplicitNonce {
 				if record.RecordType == mirrorcommon.TLSRecord_RecordType_application_data {
-					nonce := c.s2cExplicitNonceCounterGenerator()
+					nonce := c.c2sExplicitNonceCounterGenerator()
 					copy(record.Fragment, nonce)
 				}
 			}
@@ -217,7 +217,7 @@ func (c *conn) c2sWorker() {
 				return
 			}
 
-			c.c2sExplicitNonceCounterGenerator = crypto.GenerateIncreasingNonce([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
+			c.c2sExplicitNonceCounterGenerator = reverseBytesGeneratorByteOrder(crypto.GenerateIncreasingNonce([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}))
 		}
 
 		if c.OnC2SMessage != nil {
@@ -291,7 +291,7 @@ func (c *conn) s2cWorker() {
 			// memory consistency synchronization for value c.tls12ExplicitNonce is required!!!
 			if *c.tls12ExplicitNonce {
 				if record.RecordType == mirrorcommon.TLSRecord_RecordType_application_data {
-					nonce := c.c2sExplicitNonceCounterGenerator()
+					nonce := c.s2cExplicitNonceCounterGenerator()
 					copy(record.Fragment, nonce)
 				}
 			}
@@ -329,7 +329,7 @@ func (c *conn) s2cWorker() {
 				c.done()
 				return
 			}
-			c.c2sExplicitNonceCounterGenerator = crypto.GenerateIncreasingNonce([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
+			c.s2cExplicitNonceCounterGenerator = reverseBytesGeneratorByteOrder(crypto.GenerateIncreasingNonce([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}))
 		}
 
 		if c.OnS2CMessage != nil {

--- a/transport/internet/tlsmirror/mirrorbase/conn.go
+++ b/transport/internet/tlsmirror/mirrorbase/conn.go
@@ -8,6 +8,7 @@ import (
 	"net"
 
 	"github.com/v2fly/v2ray-core/v5/common"
+	"github.com/v2fly/v2ray-core/v5/common/crypto"
 	"github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror"
 	"github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/mirrorcommon"
 )
@@ -15,15 +16,19 @@ import (
 // NewMirroredTLSConn creates a new mirrored TLS connection.
 // No stable interface
 func NewMirroredTLSConn(ctx context.Context, clientConn net.Conn, serverConn net.Conn, onC2SMessage, onS2CMessage tlsmirror.MessageHook, closable common.Closable, explicitNonceDetection tlsmirror.ExplicitNonceDetection) tlsmirror.InsertableTLSConn {
+
+	explicitNonceDetectionReady, explicitNonceDetectionOver := context.WithCancel(ctx)
 	c := &conn{
-		ctx:                    ctx,
-		clientConn:             clientConn,
-		serverConn:             serverConn,
-		c2sInsert:              make(chan *tlsmirror.TLSRecord, 100),
-		s2cInsert:              make(chan *tlsmirror.TLSRecord, 100),
-		OnC2SMessage:           onC2SMessage,
-		OnS2CMessage:           onS2CMessage,
-		explicitNonceDetection: explicitNonceDetection,
+		ctx:                         ctx,
+		clientConn:                  clientConn,
+		serverConn:                  serverConn,
+		c2sInsert:                   make(chan *tlsmirror.TLSRecord, 100),
+		s2cInsert:                   make(chan *tlsmirror.TLSRecord, 100),
+		OnC2SMessage:                onC2SMessage,
+		OnS2CMessage:                onS2CMessage,
+		explicitNonceDetection:      explicitNonceDetection,
+		explicitNonceDetectionReady: explicitNonceDetectionReady,
+		explicitNonceDetectionOver:  explicitNonceDetectionOver,
 	}
 	c.ctx, c.done = context.WithCancel(ctx)
 	go c.c2sWorker()
@@ -58,10 +63,15 @@ type conn struct {
 	isServerRandomReady bool
 	ServerRandom        [32]byte
 
-	tls12ExplicitNonce *bool
+	tls12ExplicitNonce               *bool
+	explicitNonceDetectionReady      context.Context
+	explicitNonceDetectionOver       context.CancelFunc
+	c2sExplicitNonceCounterGenerator crypto.BytesGenerator
+	s2cExplicitNonceCounterGenerator crypto.BytesGenerator
 }
 
 func (c *conn) GetHandshakeRandom() ([]byte, []byte, error) {
+	// TODO: the value of c.isClientRandomReady, c.isServerRandomReady, c.ClientRandom, c.ServerRandom has incorrect memory consistency assumptions.
 	if !c.isClientRandomReady || !c.isServerRandomReady {
 		return nil, nil, newError("client random or server random not ready")
 	}
@@ -155,7 +165,15 @@ func (c *conn) c2sWorker() {
 	}
 	go func() {
 		for c.ctx.Err() == nil {
+			// implicit memory consistency synchronization capture read for c.tls12ExplicitNonce
 			record := <-c.c2sInsert
+			// memory consistency synchronization for value c.tls12ExplicitNonce is required!!!
+			if *c.tls12ExplicitNonce {
+				if record.RecordType == mirrorcommon.TLSRecord_RecordType_application_data {
+					nonce := c.s2cExplicitNonceCounterGenerator()
+					copy(record.Fragment, nonce)
+				}
+			}
 			err := recordWriter.WriteRecord(record, false)
 			if err != nil {
 				c.done()
@@ -164,6 +182,7 @@ func (c *conn) c2sWorker() {
 			}
 		}
 	}()
+	explicitNonceSessionAndChangeCipherSpecWasLastMessage := false
 	for c.ctx.Err() == nil {
 		record, err := recordReader.ReadNextRecord()
 		if err != nil {
@@ -172,6 +191,35 @@ func (c *conn) c2sWorker() {
 			newError("failed to read TLS record").Base(err).AtWarning().WriteToLog()
 			return
 		}
+
+		if record.RecordType == mirrorcommon.TLSRecord_RecordType_change_cipher_spec {
+			// implicit memory consistency synchronization capture read for c.tls12ExplicitNonce
+			if c.explicitNonceDetectionReady.Err() == nil {
+				drainCopy(c.clientConn, nil, c.serverConn)
+				c.done()
+				newError("received client to server change cipher spec before server hello").Base(err).AtWarning().WriteToLog()
+				return
+			}
+			// memory consistency synchronization for value c.tls12ExplicitNonce is required!!!
+			if *c.tls12ExplicitNonce {
+				explicitNonceSessionAndChangeCipherSpecWasLastMessage = true
+			}
+		}
+
+		if record.RecordType == mirrorcommon.TLSRecord_RecordType_handshake &&
+			explicitNonceSessionAndChangeCipherSpecWasLastMessage {
+			// verify if the first 8 bytes are 0x00
+			if len(record.Fragment) < 8 || !bytes.Equal(record.Fragment[:8],
+				[]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}) {
+				newError("unexpected explicit nonce header at tls 12 finish").AtWarning().WriteToLog()
+				drainCopy(c.clientConn, nil, c.serverConn)
+				c.done()
+				return
+			}
+
+			c.c2sExplicitNonceCounterGenerator = crypto.GenerateIncreasingNonce([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
+		}
+
 		if c.OnC2SMessage != nil {
 			drop, err := c.OnC2SMessage(record)
 			if err != nil {
@@ -186,6 +234,7 @@ func (c *conn) c2sWorker() {
 		duplicatedRecord := mirrorcommon.DuplicateRecord(*record)
 		c.c2sInsert <- &duplicatedRecord
 	}
+	drainCopy(c.serverConn, nil, c.clientConn)
 }
 
 func (c *conn) s2cWorker() {
@@ -219,6 +268,8 @@ func (c *conn) s2cWorker() {
 
 	isTLS12ExplicitNonce := c.explicitNonceDetection(serverHello.CipherSuite)
 	c.tls12ExplicitNonce = &isTLS12ExplicitNonce
+	// implicit memory consistency synchronization release write for c.tls12ExplicitNonce
+	c.explicitNonceDetectionOver()
 
 	serverSocketReader := &readerWithInitialData{initialData: s2cReminderData, innerReader: c.serverConn}
 	serverSocket := bufio.NewReaderSize(serverSocketReader, 65536)
@@ -235,7 +286,15 @@ func (c *conn) s2cWorker() {
 	}
 	go func() {
 		for c.ctx.Err() == nil {
+			// implicit memory consistency synchronization capture read for c.tls12ExplicitNonce
 			record := <-c.s2cInsert
+			// memory consistency synchronization for value c.tls12ExplicitNonce is required!!!
+			if *c.tls12ExplicitNonce {
+				if record.RecordType == mirrorcommon.TLSRecord_RecordType_application_data {
+					nonce := c.c2sExplicitNonceCounterGenerator()
+					copy(record.Fragment, nonce)
+				}
+			}
 			err := recordWriter.WriteRecord(record, false)
 			if err != nil {
 				c.done()
@@ -244,14 +303,35 @@ func (c *conn) s2cWorker() {
 			}
 		}
 	}()
+	explicitNonceSessionAndChangeCipherSpecWasLastMessage := false
 	for c.ctx.Err() == nil {
 		record, err := recordReader.ReadNextRecord()
 		if err != nil {
+			newError("failed to read TLS record").Base(err).AtWarning().WriteToLog()
 			drainCopy(c.clientConn, nil, c.serverConn)
 			c.done()
-			newError("failed to read TLS record").Base(err).AtWarning().WriteToLog()
 			return
 		}
+
+		if record.RecordType == mirrorcommon.TLSRecord_RecordType_change_cipher_spec {
+			if *c.tls12ExplicitNonce {
+				explicitNonceSessionAndChangeCipherSpecWasLastMessage = true
+			}
+		}
+
+		if record.RecordType == mirrorcommon.TLSRecord_RecordType_handshake &&
+			explicitNonceSessionAndChangeCipherSpecWasLastMessage {
+			// verify if the first 8 bytes are 0x00
+			if len(record.Fragment) < 8 || !bytes.Equal(record.Fragment[:8],
+				[]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}) {
+				newError("unexpected explicit nonce header at tls 12 finish").AtWarning().WriteToLog()
+				drainCopy(c.clientConn, nil, c.serverConn)
+				c.done()
+				return
+			}
+			c.c2sExplicitNonceCounterGenerator = crypto.GenerateIncreasingNonce([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
+		}
+
 		if c.OnS2CMessage != nil {
 			drop, err := c.OnS2CMessage(record)
 			if err != nil {
@@ -266,6 +346,7 @@ func (c *conn) s2cWorker() {
 		duplicatedRecord := mirrorcommon.DuplicateRecord(*record)
 		c.s2cInsert <- &duplicatedRecord
 	}
+	drainCopy(c.clientConn, nil, c.serverConn)
 }
 
 func drainCopy(dst io.Writer, initData []byte, src io.Reader) {

--- a/transport/internet/tlsmirror/mirrorbase/conn.go
+++ b/transport/internet/tlsmirror/mirrorbase/conn.go
@@ -169,9 +169,12 @@ func (c *conn) c2sWorker() {
 			record := <-c.c2sInsert
 			// memory consistency synchronization for value c.tls12ExplicitNonce is required!!!
 			if *c.tls12ExplicitNonce {
-				if record.RecordType == mirrorcommon.TLSRecord_RecordType_application_data {
-					nonce := c.c2sExplicitNonceCounterGenerator()
-					copy(record.Fragment, nonce)
+				if record.RecordType == mirrorcommon.TLSRecord_RecordType_application_data ||
+					record.RecordType == mirrorcommon.TLSRecord_RecordType_alert {
+					if len(record.Fragment) >= 8 {
+						nonce := c.c2sExplicitNonceCounterGenerator()
+						copy(record.Fragment, nonce)
+					}
 				}
 			}
 			err := recordWriter.WriteRecord(record, false)
@@ -290,9 +293,12 @@ func (c *conn) s2cWorker() {
 			record := <-c.s2cInsert
 			// memory consistency synchronization for value c.tls12ExplicitNonce is required!!!
 			if *c.tls12ExplicitNonce {
-				if record.RecordType == mirrorcommon.TLSRecord_RecordType_application_data {
-					nonce := c.s2cExplicitNonceCounterGenerator()
-					copy(record.Fragment, nonce)
+				if record.RecordType == mirrorcommon.TLSRecord_RecordType_application_data ||
+					record.RecordType == mirrorcommon.TLSRecord_RecordType_alert {
+					if len(record.Fragment) >= 8 {
+						nonce := c.s2cExplicitNonceCounterGenerator()
+						copy(record.Fragment, nonce)
+					}
 				}
 			}
 			err := recordWriter.WriteRecord(record, false)

--- a/transport/internet/tlsmirror/mirrorbase/crypto.go
+++ b/transport/internet/tlsmirror/mirrorbase/crypto.go
@@ -1,0 +1,19 @@
+package mirrorbase
+
+import (
+	"github.com/v2fly/v2ray-core/v5/common/crypto"
+)
+
+func reverseBytesGeneratorByteOrder(generator crypto.BytesGenerator) crypto.BytesGenerator {
+	var reverseResult [8]byte
+	return func() []byte {
+		result := generator()
+		if len(result) != 8 {
+			panic("reverseBytesGeneratorByteOrder requires a generator that returns exactly 8 bytes")
+		}
+		for i := 0; i < 8; i++ {
+			reverseResult[i] = result[7-i]
+		}
+		return reverseResult[:]
+	}
+}

--- a/transport/internet/tlsmirror/mirrorbase/crypto_test.go
+++ b/transport/internet/tlsmirror/mirrorbase/crypto_test.go
@@ -1,0 +1,27 @@
+package mirrorbase
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"testing"
+
+	"github.com/v2fly/v2ray-core/v5/common/crypto"
+)
+
+func TestTLS12ExplicitNonceGeneration(t *testing.T) {
+	generator := reverseBytesGeneratorByteOrder(crypto.GenerateIncreasingNonce([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}))
+
+	firstValue := generator()
+	if diff := cmp.Diff(firstValue, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}); diff != "" {
+		t.Errorf("Unexpected first value: %s", diff)
+	}
+
+	secondValue := generator()
+	if diff := cmp.Diff(secondValue, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}); diff != "" {
+		t.Errorf("Unexpected second value: %s", diff)
+	}
+
+	thirdValue := generator()
+	if diff := cmp.Diff(thirdValue, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03}); diff != "" {
+		t.Errorf("Unexpected third value: %s", diff)
+	}
+}

--- a/transport/internet/tlsmirror/mirrorcommon/record_consts.go
+++ b/transport/internet/tlsmirror/mirrorcommon/record_consts.go
@@ -4,4 +4,5 @@ const (
 	TLSRecord_RecordType_application_data   = 23
 	TLSRecord_RecordType_handshake          = 22
 	TLSRecord_RecordType_change_cipher_spec = 20
+	TLSRecord_RecordType_alert              = 21
 )

--- a/transport/internet/tlsmirror/mirrorcommon/record_consts.go
+++ b/transport/internet/tlsmirror/mirrorcommon/record_consts.go
@@ -1,6 +1,7 @@
 package mirrorcommon
 
 const (
-	TLSRecord_RecordType_application_data = 23
-	TLSRecord_RecordType_handshake        = 22
+	TLSRecord_RecordType_application_data   = 23
+	TLSRecord_RecordType_handshake          = 22
+	TLSRecord_RecordType_change_cipher_spec = 20
 )

--- a/transport/internet/tlsmirror/mirrorcrypto/derive_key.go
+++ b/transport/internet/tlsmirror/mirrorcrypto/derive_key.go
@@ -20,12 +20,12 @@ func DeriveEncryptionKey(primaryKey, clientRandom, serverRandom []byte, tag stri
 	combined := append(primaryKey, clientRandom...) // nolint: gocritic
 	combined = append(combined, serverRandom...)
 
-	encryptionKey, err := hkdf.Expand(sha256.New, combined, "v2ray-sp76YMKM-EkGrFUNL-rTJRJMkU:tlsmirror-encryption", 16)
+	encryptionKey, err := hkdf.Expand(sha256.New, combined, "v2ray-sp76YMKM-EkGrFUNL-rTJRJMkU:tlsmirror-encryption"+tag, 16)
 	if err != nil {
 		return nil, nil, newError("unable to derive encryption key").Base(err)
 	}
 
-	nonceMask, err := hkdf.Expand(sha256.New, combined, "v2ray-sp76YMKM-EkGrFUNL-rTJRJMkU:tlsmirror-noncemask", 12)
+	nonceMask, err := hkdf.Expand(sha256.New, combined, "v2ray-sp76YMKM-EkGrFUNL-rTJRJMkU:tlsmirror-noncemask"+tag, 12)
 	if err != nil {
 		return nil, nil, newError("unable to derive nonce mask").Base(err)
 	}

--- a/transport/internet/tlsmirror/server/ciphersuits_lookup.go
+++ b/transport/internet/tlsmirror/server/ciphersuits_lookup.go
@@ -1,0 +1,42 @@
+package server
+
+func newEmptyCipherSuiteLookuper() *ciphersuiteLookuper {
+	return &ciphersuiteLookuper{
+		ciphersuiteMap: make(map[uint16]bool),
+	}
+}
+
+func newCipherSuiteLookuperFromUint32Array(source []uint32) (*ciphersuiteLookuper, error) {
+	if len(source) == 0 {
+		return nil, newError("ciphersuite list is empty")
+	}
+	ciphersuiteUint16Array := make([]uint16, len(source))
+	for i, ciphersuite := range source {
+		if ciphersuite > 0xFFFF {
+			return nil, newError("ciphersuite value out of range: ", ciphersuite)
+		}
+		ciphersuiteUint16Array[i] = uint16(ciphersuite)
+	}
+	return newCipherSuiteLookuperFromUint16Array(ciphersuiteUint16Array), nil
+}
+
+func newCipherSuiteLookuperFromUint16Array(source []uint16) *ciphersuiteLookuper {
+	ciphersuiteMap := make(map[uint16]bool, len(source))
+	for _, ciphersuite := range source {
+		ciphersuiteMap[ciphersuite] = true
+	}
+	return &ciphersuiteLookuper{
+		ciphersuiteMap: ciphersuiteMap,
+	}
+}
+
+type ciphersuiteLookuper struct {
+	ciphersuiteMap map[uint16]bool
+}
+
+func (l *ciphersuiteLookuper) Lookup(ciphersuite uint16) bool {
+	if result, ok := l.ciphersuiteMap[ciphersuite]; ok {
+		return result
+	}
+	return false
+}

--- a/transport/internet/tlsmirror/server/client.go
+++ b/transport/internet/tlsmirror/server/client.go
@@ -155,10 +155,10 @@ func (d *persistentMirrorTLSDialer) handleIncomingCarrierConnection(ctx context.
 	}
 
 	var firstWriteDelay time.Duration
-	if d.config.DeferFirstPayloadWriteTime != nil {
-		firstWriteDelay = time.Duration(d.config.DeferFirstPayloadWriteTime.BaseNanoseconds)
-		if d.config.DeferFirstPayloadWriteTime.UniformRandomMultiplierNanoseconds > 0 {
-			uniformRandomAdd := big.NewInt(int64(d.config.DeferFirstPayloadWriteTime.UniformRandomMultiplierNanoseconds))
+	if d.config.DeferInstanceDerivedWriteTime != nil {
+		firstWriteDelay = time.Duration(d.config.DeferInstanceDerivedWriteTime.BaseNanoseconds)
+		if d.config.DeferInstanceDerivedWriteTime.UniformRandomMultiplierNanoseconds > 0 {
+			uniformRandomAdd := big.NewInt(int64(d.config.DeferInstanceDerivedWriteTime.UniformRandomMultiplierNanoseconds))
 			uniformRandomAddBigInt, err := cryptoRand.Int(cryptoRand.Reader, uniformRandomAdd)
 			if err != nil {
 				newError("failed to generate random delay").Base(err).AtWarning().WriteToLog()

--- a/transport/internet/tlsmirror/server/client.go
+++ b/transport/internet/tlsmirror/server/client.go
@@ -182,6 +182,14 @@ func (d *persistentMirrorTLSDialer) handleIncomingReadyConnection(conn internet.
 					case <-controller.WaitConnectionReady().Done():
 						waitedForReady = true
 						// TODO: connection might become invalid and never ready, handle this case
+						if controller.IsConnectionInvalidated() {
+							newError("connection is invalidated, skipping").AtWarning().WriteToLog()
+							return
+						}
+					case <-ctx.Done():
+						return
+					case <-d.ctx.Done():
+						return
 					}
 				}
 			}

--- a/transport/internet/tlsmirror/server/client.go
+++ b/transport/internet/tlsmirror/server/client.go
@@ -168,15 +168,16 @@ func (d *persistentMirrorTLSDialer) handleIncomingCarrierConnection(ctx context.
 
 	ctx, cancel := context.WithCancel(ctx)
 	cconnState := &clientConnState{
-		ctx:             ctx,
-		done:            cancel,
-		localAddr:       conn.LocalAddr(),
-		remoteAddr:      conn.RemoteAddr(),
-		handler:         d.handleIncomingReadyConnection,
-		primaryKey:      d.config.PrimaryKey,
-		readPipe:        make(chan []byte, 1),
-		firstWrite:      true,
-		firstWriteDelay: firstWriteDelay,
+		ctx:                   ctx,
+		done:                  cancel,
+		localAddr:             conn.LocalAddr(),
+		remoteAddr:            conn.RemoteAddr(),
+		handler:               d.handleIncomingReadyConnection,
+		primaryKey:            d.config.PrimaryKey,
+		readPipe:              make(chan []byte, 1),
+		firstWrite:            true,
+		firstWriteDelay:       firstWriteDelay,
+		transportLayerPadding: d.config.TransportLayerPadding,
 	}
 
 	cconnState.mirrorConn = mirrorbase.NewMirroredTLSConn(ctx, conn, forwardConn, cconnState.onC2SMessage, cconnState.onS2CMessage, conn,

--- a/transport/internet/tlsmirror/server/client_conn.go
+++ b/transport/internet/tlsmirror/server/client_conn.go
@@ -158,8 +158,8 @@ func (s *clientConnState) WriteMessage(message []byte) error {
 	if err != nil {
 		return newError("failed to get explicit nonce reserved overhead header length").Base(err)
 	}
-	buffer := make([]byte, 0, explicitNonceReservedOverheadHeaderLength+len(message)+s.encryptor.NonceSize())
-	buffer, err = s.encryptor.Seal(buffer[explicitNonceReservedOverheadHeaderLength:], message)
+	buffer := make([]byte, explicitNonceReservedOverheadHeaderLength, explicitNonceReservedOverheadHeaderLength+len(message)+s.encryptor.NonceSize())
+	buffer, err = s.encryptor.Seal(buffer[:], message)
 	if err != nil {
 		return newError("failed to encrypt message").Base(err)
 	}

--- a/transport/internet/tlsmirror/server/client_conn.go
+++ b/transport/internet/tlsmirror/server/client_conn.go
@@ -96,6 +96,7 @@ func (s *clientConnState) Write(b []byte) (n int, err error) {
 }
 
 func (s *clientConnState) Close() error {
+	// TODO: Only recall the connection, not close it.
 	s.done()
 	return nil
 }

--- a/transport/internet/tlsmirror/server/config.pb.go
+++ b/transport/internet/tlsmirror/server/config.pb.go
@@ -18,15 +18,16 @@ const (
 )
 
 type Config struct {
-	state                    protoimpl.MessageState `protogen:"open.v1"`
-	ForwardAddress           string                 `protobuf:"bytes,1,opt,name=forward_address,json=forwardAddress,proto3" json:"forward_address,omitempty"`
-	ForwardPort              uint32                 `protobuf:"varint,2,opt,name=forward_port,json=forwardPort,proto3" json:"forward_port,omitempty"`
-	ForwardTag               string                 `protobuf:"bytes,3,opt,name=forward_tag,json=forwardTag,proto3" json:"forward_tag,omitempty"`
-	CarrierConnectionTag     string                 `protobuf:"bytes,4,opt,name=carrier_connection_tag,json=carrierConnectionTag,proto3" json:"carrier_connection_tag,omitempty"`
-	EmbeddedTrafficGenerator *tlstrafficgen.Config  `protobuf:"bytes,5,opt,name=embedded_traffic_generator,json=embeddedTrafficGenerator,proto3" json:"embedded_traffic_generator,omitempty"`
-	PrimaryKey               []byte                 `protobuf:"bytes,6,opt,name=primary_key,json=primaryKey,proto3" json:"primary_key,omitempty"`
-	unknownFields            protoimpl.UnknownFields
-	sizeCache                protoimpl.SizeCache
+	state                     protoimpl.MessageState `protogen:"open.v1"`
+	ForwardAddress            string                 `protobuf:"bytes,1,opt,name=forward_address,json=forwardAddress,proto3" json:"forward_address,omitempty"`
+	ForwardPort               uint32                 `protobuf:"varint,2,opt,name=forward_port,json=forwardPort,proto3" json:"forward_port,omitempty"`
+	ForwardTag                string                 `protobuf:"bytes,3,opt,name=forward_tag,json=forwardTag,proto3" json:"forward_tag,omitempty"`
+	CarrierConnectionTag      string                 `protobuf:"bytes,4,opt,name=carrier_connection_tag,json=carrierConnectionTag,proto3" json:"carrier_connection_tag,omitempty"`
+	EmbeddedTrafficGenerator  *tlstrafficgen.Config  `protobuf:"bytes,5,opt,name=embedded_traffic_generator,json=embeddedTrafficGenerator,proto3" json:"embedded_traffic_generator,omitempty"`
+	PrimaryKey                []byte                 `protobuf:"bytes,6,opt,name=primary_key,json=primaryKey,proto3" json:"primary_key,omitempty"`
+	ExplicitNonceCiphersuites []uint32               `protobuf:"varint,7,rep,packed,name=explicit_nonce_ciphersuites,json=explicitNonceCiphersuites,proto3" json:"explicit_nonce_ciphersuites,omitempty"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
 }
 
 func (x *Config) Reset() {
@@ -101,11 +102,18 @@ func (x *Config) GetPrimaryKey() []byte {
 	return nil
 }
 
+func (x *Config) GetExplicitNonceCiphersuites() []uint32 {
+	if x != nil {
+		return x.ExplicitNonceCiphersuites
+	}
+	return nil
+}
+
 var File_transport_internet_tlsmirror_server_config_proto protoreflect.FileDescriptor
 
 const file_transport_internet_tlsmirror_server_config_proto_rawDesc = "" +
 	"\n" +
-	"0transport/internet/tlsmirror/server/config.proto\x12.v2ray.core.transport.internet.tlsmirror.server\x1a common/protoext/extensions.proto\x1a7transport/internet/tlsmirror/tlstrafficgen/config.proto\"\xf6\x02\n" +
+	"0transport/internet/tlsmirror/server/config.proto\x12.v2ray.core.transport.internet.tlsmirror.server\x1a common/protoext/extensions.proto\x1a7transport/internet/tlsmirror/tlstrafficgen/config.proto\"\xb6\x03\n" +
 	"\x06Config\x12'\n" +
 	"\x0fforward_address\x18\x01 \x01(\tR\x0eforwardAddress\x12!\n" +
 	"\fforward_port\x18\x02 \x01(\rR\vforwardPort\x12\x1f\n" +
@@ -114,7 +122,8 @@ const file_transport_internet_tlsmirror_server_config_proto_rawDesc = "" +
 	"\x16carrier_connection_tag\x18\x04 \x01(\tR\x14carrierConnectionTag\x12{\n" +
 	"\x1aembedded_traffic_generator\x18\x05 \x01(\v2=.v2ray.core.transport.internet.tlsmirror.tlstrafficgen.ConfigR\x18embeddedTrafficGenerator\x12\x1f\n" +
 	"\vprimary_key\x18\x06 \x01(\fR\n" +
-	"primaryKey:+\x82\xb5\x18'\n" +
+	"primaryKey\x12>\n" +
+	"\x1bexplicit_nonce_ciphersuites\x18\a \x03(\rR\x19explicitNonceCiphersuites:+\x82\xb5\x18'\n" +
 	"\ttransport\x12\ttlsmirror\x8a\xff)\ttlsmirror\x90\xff)\x01B\xab\x01\n" +
 	"2com.v2ray.core.transport.internet.tlsmirror.serverP\x01ZBgithub.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/server\xaa\x02.V2Ray.Core.Transport.Internet.Tlsmirror.Serverb\x06proto3"
 

--- a/transport/internet/tlsmirror/server/config.pb.go
+++ b/transport/internet/tlsmirror/server/config.pb.go
@@ -17,22 +17,75 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type TimeSpec struct {
+	state                              protoimpl.MessageState `protogen:"open.v1"`
+	BaseNanoseconds                    uint64                 `protobuf:"varint,1,opt,name=base_nanoseconds,json=baseNanoseconds,proto3" json:"base_nanoseconds,omitempty"`
+	UniformRandomMultiplierNanoseconds uint64                 `protobuf:"varint,2,opt,name=uniform_random_multiplier_nanoseconds,json=uniformRandomMultiplierNanoseconds,proto3" json:"uniform_random_multiplier_nanoseconds,omitempty"`
+	unknownFields                      protoimpl.UnknownFields
+	sizeCache                          protoimpl.SizeCache
+}
+
+func (x *TimeSpec) Reset() {
+	*x = TimeSpec{}
+	mi := &file_transport_internet_tlsmirror_server_config_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TimeSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TimeSpec) ProtoMessage() {}
+
+func (x *TimeSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_transport_internet_tlsmirror_server_config_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TimeSpec.ProtoReflect.Descriptor instead.
+func (*TimeSpec) Descriptor() ([]byte, []int) {
+	return file_transport_internet_tlsmirror_server_config_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *TimeSpec) GetBaseNanoseconds() uint64 {
+	if x != nil {
+		return x.BaseNanoseconds
+	}
+	return 0
+}
+
+func (x *TimeSpec) GetUniformRandomMultiplierNanoseconds() uint64 {
+	if x != nil {
+		return x.UniformRandomMultiplierNanoseconds
+	}
+	return 0
+}
+
 type Config struct {
-	state                     protoimpl.MessageState `protogen:"open.v1"`
-	ForwardAddress            string                 `protobuf:"bytes,1,opt,name=forward_address,json=forwardAddress,proto3" json:"forward_address,omitempty"`
-	ForwardPort               uint32                 `protobuf:"varint,2,opt,name=forward_port,json=forwardPort,proto3" json:"forward_port,omitempty"`
-	ForwardTag                string                 `protobuf:"bytes,3,opt,name=forward_tag,json=forwardTag,proto3" json:"forward_tag,omitempty"`
-	CarrierConnectionTag      string                 `protobuf:"bytes,4,opt,name=carrier_connection_tag,json=carrierConnectionTag,proto3" json:"carrier_connection_tag,omitempty"`
-	EmbeddedTrafficGenerator  *tlstrafficgen.Config  `protobuf:"bytes,5,opt,name=embedded_traffic_generator,json=embeddedTrafficGenerator,proto3" json:"embedded_traffic_generator,omitempty"`
-	PrimaryKey                []byte                 `protobuf:"bytes,6,opt,name=primary_key,json=primaryKey,proto3" json:"primary_key,omitempty"`
-	ExplicitNonceCiphersuites []uint32               `protobuf:"varint,7,rep,packed,name=explicit_nonce_ciphersuites,json=explicitNonceCiphersuites,proto3" json:"explicit_nonce_ciphersuites,omitempty"`
-	unknownFields             protoimpl.UnknownFields
-	sizeCache                 protoimpl.SizeCache
+	state                      protoimpl.MessageState `protogen:"open.v1"`
+	ForwardAddress             string                 `protobuf:"bytes,1,opt,name=forward_address,json=forwardAddress,proto3" json:"forward_address,omitempty"`
+	ForwardPort                uint32                 `protobuf:"varint,2,opt,name=forward_port,json=forwardPort,proto3" json:"forward_port,omitempty"`
+	ForwardTag                 string                 `protobuf:"bytes,3,opt,name=forward_tag,json=forwardTag,proto3" json:"forward_tag,omitempty"`
+	CarrierConnectionTag       string                 `protobuf:"bytes,4,opt,name=carrier_connection_tag,json=carrierConnectionTag,proto3" json:"carrier_connection_tag,omitempty"`
+	EmbeddedTrafficGenerator   *tlstrafficgen.Config  `protobuf:"bytes,5,opt,name=embedded_traffic_generator,json=embeddedTrafficGenerator,proto3" json:"embedded_traffic_generator,omitempty"`
+	PrimaryKey                 []byte                 `protobuf:"bytes,6,opt,name=primary_key,json=primaryKey,proto3" json:"primary_key,omitempty"`
+	ExplicitNonceCiphersuites  []uint32               `protobuf:"varint,7,rep,packed,name=explicit_nonce_ciphersuites,json=explicitNonceCiphersuites,proto3" json:"explicit_nonce_ciphersuites,omitempty"`
+	DeferFirstPayloadWriteTime *TimeSpec              `protobuf:"bytes,8,opt,name=defer_first_payload_write_time,json=deferFirstPayloadWriteTime,proto3" json:"defer_first_payload_write_time,omitempty"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *Config) Reset() {
 	*x = Config{}
-	mi := &file_transport_internet_tlsmirror_server_config_proto_msgTypes[0]
+	mi := &file_transport_internet_tlsmirror_server_config_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -44,7 +97,7 @@ func (x *Config) String() string {
 func (*Config) ProtoMessage() {}
 
 func (x *Config) ProtoReflect() protoreflect.Message {
-	mi := &file_transport_internet_tlsmirror_server_config_proto_msgTypes[0]
+	mi := &file_transport_internet_tlsmirror_server_config_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57,7 +110,7 @@ func (x *Config) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Config.ProtoReflect.Descriptor instead.
 func (*Config) Descriptor() ([]byte, []int) {
-	return file_transport_internet_tlsmirror_server_config_proto_rawDescGZIP(), []int{0}
+	return file_transport_internet_tlsmirror_server_config_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *Config) GetForwardAddress() string {
@@ -109,11 +162,21 @@ func (x *Config) GetExplicitNonceCiphersuites() []uint32 {
 	return nil
 }
 
+func (x *Config) GetDeferFirstPayloadWriteTime() *TimeSpec {
+	if x != nil {
+		return x.DeferFirstPayloadWriteTime
+	}
+	return nil
+}
+
 var File_transport_internet_tlsmirror_server_config_proto protoreflect.FileDescriptor
 
 const file_transport_internet_tlsmirror_server_config_proto_rawDesc = "" +
 	"\n" +
-	"0transport/internet/tlsmirror/server/config.proto\x12.v2ray.core.transport.internet.tlsmirror.server\x1a common/protoext/extensions.proto\x1a7transport/internet/tlsmirror/tlstrafficgen/config.proto\"\xb6\x03\n" +
+	"0transport/internet/tlsmirror/server/config.proto\x12.v2ray.core.transport.internet.tlsmirror.server\x1a common/protoext/extensions.proto\x1a7transport/internet/tlsmirror/tlstrafficgen/config.proto\"\x88\x01\n" +
+	"\bTimeSpec\x12)\n" +
+	"\x10base_nanoseconds\x18\x01 \x01(\x04R\x0fbaseNanoseconds\x12Q\n" +
+	"%uniform_random_multiplier_nanoseconds\x18\x02 \x01(\x04R\"uniformRandomMultiplierNanoseconds\"\xb4\x04\n" +
 	"\x06Config\x12'\n" +
 	"\x0fforward_address\x18\x01 \x01(\tR\x0eforwardAddress\x12!\n" +
 	"\fforward_port\x18\x02 \x01(\rR\vforwardPort\x12\x1f\n" +
@@ -123,7 +186,8 @@ const file_transport_internet_tlsmirror_server_config_proto_rawDesc = "" +
 	"\x1aembedded_traffic_generator\x18\x05 \x01(\v2=.v2ray.core.transport.internet.tlsmirror.tlstrafficgen.ConfigR\x18embeddedTrafficGenerator\x12\x1f\n" +
 	"\vprimary_key\x18\x06 \x01(\fR\n" +
 	"primaryKey\x12>\n" +
-	"\x1bexplicit_nonce_ciphersuites\x18\a \x03(\rR\x19explicitNonceCiphersuites:+\x82\xb5\x18'\n" +
+	"\x1bexplicit_nonce_ciphersuites\x18\a \x03(\rR\x19explicitNonceCiphersuites\x12|\n" +
+	"\x1edefer_first_payload_write_time\x18\b \x01(\v28.v2ray.core.transport.internet.tlsmirror.server.TimeSpecR\x1adeferFirstPayloadWriteTime:+\x82\xb5\x18'\n" +
 	"\ttransport\x12\ttlsmirror\x8a\xff)\ttlsmirror\x90\xff)\x01B\xab\x01\n" +
 	"2com.v2ray.core.transport.internet.tlsmirror.serverP\x01ZBgithub.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/server\xaa\x02.V2Ray.Core.Transport.Internet.Tlsmirror.Serverb\x06proto3"
 
@@ -139,18 +203,20 @@ func file_transport_internet_tlsmirror_server_config_proto_rawDescGZIP() []byte 
 	return file_transport_internet_tlsmirror_server_config_proto_rawDescData
 }
 
-var file_transport_internet_tlsmirror_server_config_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_transport_internet_tlsmirror_server_config_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_transport_internet_tlsmirror_server_config_proto_goTypes = []any{
-	(*Config)(nil),               // 0: v2ray.core.transport.internet.tlsmirror.server.Config
-	(*tlstrafficgen.Config)(nil), // 1: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Config
+	(*TimeSpec)(nil),             // 0: v2ray.core.transport.internet.tlsmirror.server.TimeSpec
+	(*Config)(nil),               // 1: v2ray.core.transport.internet.tlsmirror.server.Config
+	(*tlstrafficgen.Config)(nil), // 2: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Config
 }
 var file_transport_internet_tlsmirror_server_config_proto_depIdxs = []int32{
-	1, // 0: v2ray.core.transport.internet.tlsmirror.server.Config.embedded_traffic_generator:type_name -> v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Config
-	1, // [1:1] is the sub-list for method output_type
-	1, // [1:1] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	2, // 0: v2ray.core.transport.internet.tlsmirror.server.Config.embedded_traffic_generator:type_name -> v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Config
+	0, // 1: v2ray.core.transport.internet.tlsmirror.server.Config.defer_first_payload_write_time:type_name -> v2ray.core.transport.internet.tlsmirror.server.TimeSpec
+	2, // [2:2] is the sub-list for method output_type
+	2, // [2:2] is the sub-list for method input_type
+	2, // [2:2] is the sub-list for extension type_name
+	2, // [2:2] is the sub-list for extension extendee
+	0, // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_transport_internet_tlsmirror_server_config_proto_init() }
@@ -164,7 +230,7 @@ func file_transport_internet_tlsmirror_server_config_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_transport_internet_tlsmirror_server_config_proto_rawDesc), len(file_transport_internet_tlsmirror_server_config_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   1,
+			NumMessages:   2,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/transport/internet/tlsmirror/server/config.pb.go
+++ b/transport/internet/tlsmirror/server/config.pb.go
@@ -114,18 +114,18 @@ func (x *TransportLayerPadding) GetEnabled() bool {
 }
 
 type Config struct {
-	state                      protoimpl.MessageState `protogen:"open.v1"`
-	ForwardAddress             string                 `protobuf:"bytes,1,opt,name=forward_address,json=forwardAddress,proto3" json:"forward_address,omitempty"`
-	ForwardPort                uint32                 `protobuf:"varint,2,opt,name=forward_port,json=forwardPort,proto3" json:"forward_port,omitempty"`
-	ForwardTag                 string                 `protobuf:"bytes,3,opt,name=forward_tag,json=forwardTag,proto3" json:"forward_tag,omitempty"`
-	CarrierConnectionTag       string                 `protobuf:"bytes,4,opt,name=carrier_connection_tag,json=carrierConnectionTag,proto3" json:"carrier_connection_tag,omitempty"`
-	EmbeddedTrafficGenerator   *tlstrafficgen.Config  `protobuf:"bytes,5,opt,name=embedded_traffic_generator,json=embeddedTrafficGenerator,proto3" json:"embedded_traffic_generator,omitempty"`
-	PrimaryKey                 []byte                 `protobuf:"bytes,6,opt,name=primary_key,json=primaryKey,proto3" json:"primary_key,omitempty"`
-	ExplicitNonceCiphersuites  []uint32               `protobuf:"varint,7,rep,packed,name=explicit_nonce_ciphersuites,json=explicitNonceCiphersuites,proto3" json:"explicit_nonce_ciphersuites,omitempty"`
-	DeferFirstPayloadWriteTime *TimeSpec              `protobuf:"bytes,8,opt,name=defer_first_payload_write_time,json=deferFirstPayloadWriteTime,proto3" json:"defer_first_payload_write_time,omitempty"`
-	TransportLayerPadding      *TransportLayerPadding `protobuf:"bytes,9,opt,name=transport_layer_padding,json=transportLayerPadding,proto3" json:"transport_layer_padding,omitempty"`
-	unknownFields              protoimpl.UnknownFields
-	sizeCache                  protoimpl.SizeCache
+	state                         protoimpl.MessageState `protogen:"open.v1"`
+	ForwardAddress                string                 `protobuf:"bytes,1,opt,name=forward_address,json=forwardAddress,proto3" json:"forward_address,omitempty"`
+	ForwardPort                   uint32                 `protobuf:"varint,2,opt,name=forward_port,json=forwardPort,proto3" json:"forward_port,omitempty"`
+	ForwardTag                    string                 `protobuf:"bytes,3,opt,name=forward_tag,json=forwardTag,proto3" json:"forward_tag,omitempty"`
+	CarrierConnectionTag          string                 `protobuf:"bytes,4,opt,name=carrier_connection_tag,json=carrierConnectionTag,proto3" json:"carrier_connection_tag,omitempty"`
+	EmbeddedTrafficGenerator      *tlstrafficgen.Config  `protobuf:"bytes,5,opt,name=embedded_traffic_generator,json=embeddedTrafficGenerator,proto3" json:"embedded_traffic_generator,omitempty"`
+	PrimaryKey                    []byte                 `protobuf:"bytes,6,opt,name=primary_key,json=primaryKey,proto3" json:"primary_key,omitempty"`
+	ExplicitNonceCiphersuites     []uint32               `protobuf:"varint,7,rep,packed,name=explicit_nonce_ciphersuites,json=explicitNonceCiphersuites,proto3" json:"explicit_nonce_ciphersuites,omitempty"`
+	DeferInstanceDerivedWriteTime *TimeSpec              `protobuf:"bytes,8,opt,name=defer_instance_derived_write_time,json=deferInstanceDerivedWriteTime,proto3" json:"defer_instance_derived_write_time,omitempty"`
+	TransportLayerPadding         *TransportLayerPadding `protobuf:"bytes,9,opt,name=transport_layer_padding,json=transportLayerPadding,proto3" json:"transport_layer_padding,omitempty"`
+	unknownFields                 protoimpl.UnknownFields
+	sizeCache                     protoimpl.SizeCache
 }
 
 func (x *Config) Reset() {
@@ -207,9 +207,9 @@ func (x *Config) GetExplicitNonceCiphersuites() []uint32 {
 	return nil
 }
 
-func (x *Config) GetDeferFirstPayloadWriteTime() *TimeSpec {
+func (x *Config) GetDeferInstanceDerivedWriteTime() *TimeSpec {
 	if x != nil {
-		return x.DeferFirstPayloadWriteTime
+		return x.DeferInstanceDerivedWriteTime
 	}
 	return nil
 }
@@ -230,7 +230,7 @@ const file_transport_internet_tlsmirror_server_config_proto_rawDesc = "" +
 	"\x10base_nanoseconds\x18\x01 \x01(\x04R\x0fbaseNanoseconds\x12Q\n" +
 	"%uniform_random_multiplier_nanoseconds\x18\x02 \x01(\x04R\"uniformRandomMultiplierNanoseconds\"1\n" +
 	"\x15TransportLayerPadding\x12\x18\n" +
-	"\aenabled\x18\x01 \x01(\bR\aenabled\"\xb3\x05\n" +
+	"\aenabled\x18\x01 \x01(\bR\aenabled\"\xba\x05\n" +
 	"\x06Config\x12'\n" +
 	"\x0fforward_address\x18\x01 \x01(\tR\x0eforwardAddress\x12!\n" +
 	"\fforward_port\x18\x02 \x01(\rR\vforwardPort\x12\x1f\n" +
@@ -240,8 +240,8 @@ const file_transport_internet_tlsmirror_server_config_proto_rawDesc = "" +
 	"\x1aembedded_traffic_generator\x18\x05 \x01(\v2=.v2ray.core.transport.internet.tlsmirror.tlstrafficgen.ConfigR\x18embeddedTrafficGenerator\x12\x1f\n" +
 	"\vprimary_key\x18\x06 \x01(\fR\n" +
 	"primaryKey\x12>\n" +
-	"\x1bexplicit_nonce_ciphersuites\x18\a \x03(\rR\x19explicitNonceCiphersuites\x12|\n" +
-	"\x1edefer_first_payload_write_time\x18\b \x01(\v28.v2ray.core.transport.internet.tlsmirror.server.TimeSpecR\x1adeferFirstPayloadWriteTime\x12}\n" +
+	"\x1bexplicit_nonce_ciphersuites\x18\a \x03(\rR\x19explicitNonceCiphersuites\x12\x82\x01\n" +
+	"!defer_instance_derived_write_time\x18\b \x01(\v28.v2ray.core.transport.internet.tlsmirror.server.TimeSpecR\x1ddeferInstanceDerivedWriteTime\x12}\n" +
 	"\x17transport_layer_padding\x18\t \x01(\v2E.v2ray.core.transport.internet.tlsmirror.server.TransportLayerPaddingR\x15transportLayerPadding:+\x82\xb5\x18'\n" +
 	"\ttransport\x12\ttlsmirror\x8a\xff)\ttlsmirror\x90\xff)\x01B\xab\x01\n" +
 	"2com.v2ray.core.transport.internet.tlsmirror.serverP\x01ZBgithub.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/server\xaa\x02.V2Ray.Core.Transport.Internet.Tlsmirror.Serverb\x06proto3"
@@ -267,7 +267,7 @@ var file_transport_internet_tlsmirror_server_config_proto_goTypes = []any{
 }
 var file_transport_internet_tlsmirror_server_config_proto_depIdxs = []int32{
 	3, // 0: v2ray.core.transport.internet.tlsmirror.server.Config.embedded_traffic_generator:type_name -> v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Config
-	0, // 1: v2ray.core.transport.internet.tlsmirror.server.Config.defer_first_payload_write_time:type_name -> v2ray.core.transport.internet.tlsmirror.server.TimeSpec
+	0, // 1: v2ray.core.transport.internet.tlsmirror.server.Config.defer_instance_derived_write_time:type_name -> v2ray.core.transport.internet.tlsmirror.server.TimeSpec
 	1, // 2: v2ray.core.transport.internet.tlsmirror.server.Config.transport_layer_padding:type_name -> v2ray.core.transport.internet.tlsmirror.server.TransportLayerPadding
 	3, // [3:3] is the sub-list for method output_type
 	3, // [3:3] is the sub-list for method input_type

--- a/transport/internet/tlsmirror/server/config.pb.go
+++ b/transport/internet/tlsmirror/server/config.pb.go
@@ -69,6 +69,50 @@ func (x *TimeSpec) GetUniformRandomMultiplierNanoseconds() uint64 {
 	return 0
 }
 
+type TransportLayerPadding struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Enabled       bool                   `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TransportLayerPadding) Reset() {
+	*x = TransportLayerPadding{}
+	mi := &file_transport_internet_tlsmirror_server_config_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TransportLayerPadding) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TransportLayerPadding) ProtoMessage() {}
+
+func (x *TransportLayerPadding) ProtoReflect() protoreflect.Message {
+	mi := &file_transport_internet_tlsmirror_server_config_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TransportLayerPadding.ProtoReflect.Descriptor instead.
+func (*TransportLayerPadding) Descriptor() ([]byte, []int) {
+	return file_transport_internet_tlsmirror_server_config_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *TransportLayerPadding) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
 type Config struct {
 	state                      protoimpl.MessageState `protogen:"open.v1"`
 	ForwardAddress             string                 `protobuf:"bytes,1,opt,name=forward_address,json=forwardAddress,proto3" json:"forward_address,omitempty"`
@@ -79,13 +123,14 @@ type Config struct {
 	PrimaryKey                 []byte                 `protobuf:"bytes,6,opt,name=primary_key,json=primaryKey,proto3" json:"primary_key,omitempty"`
 	ExplicitNonceCiphersuites  []uint32               `protobuf:"varint,7,rep,packed,name=explicit_nonce_ciphersuites,json=explicitNonceCiphersuites,proto3" json:"explicit_nonce_ciphersuites,omitempty"`
 	DeferFirstPayloadWriteTime *TimeSpec              `protobuf:"bytes,8,opt,name=defer_first_payload_write_time,json=deferFirstPayloadWriteTime,proto3" json:"defer_first_payload_write_time,omitempty"`
+	TransportLayerPadding      *TransportLayerPadding `protobuf:"bytes,9,opt,name=transport_layer_padding,json=transportLayerPadding,proto3" json:"transport_layer_padding,omitempty"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *Config) Reset() {
 	*x = Config{}
-	mi := &file_transport_internet_tlsmirror_server_config_proto_msgTypes[1]
+	mi := &file_transport_internet_tlsmirror_server_config_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -97,7 +142,7 @@ func (x *Config) String() string {
 func (*Config) ProtoMessage() {}
 
 func (x *Config) ProtoReflect() protoreflect.Message {
-	mi := &file_transport_internet_tlsmirror_server_config_proto_msgTypes[1]
+	mi := &file_transport_internet_tlsmirror_server_config_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -110,7 +155,7 @@ func (x *Config) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Config.ProtoReflect.Descriptor instead.
 func (*Config) Descriptor() ([]byte, []int) {
-	return file_transport_internet_tlsmirror_server_config_proto_rawDescGZIP(), []int{1}
+	return file_transport_internet_tlsmirror_server_config_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *Config) GetForwardAddress() string {
@@ -169,6 +214,13 @@ func (x *Config) GetDeferFirstPayloadWriteTime() *TimeSpec {
 	return nil
 }
 
+func (x *Config) GetTransportLayerPadding() *TransportLayerPadding {
+	if x != nil {
+		return x.TransportLayerPadding
+	}
+	return nil
+}
+
 var File_transport_internet_tlsmirror_server_config_proto protoreflect.FileDescriptor
 
 const file_transport_internet_tlsmirror_server_config_proto_rawDesc = "" +
@@ -176,7 +228,9 @@ const file_transport_internet_tlsmirror_server_config_proto_rawDesc = "" +
 	"0transport/internet/tlsmirror/server/config.proto\x12.v2ray.core.transport.internet.tlsmirror.server\x1a common/protoext/extensions.proto\x1a7transport/internet/tlsmirror/tlstrafficgen/config.proto\"\x88\x01\n" +
 	"\bTimeSpec\x12)\n" +
 	"\x10base_nanoseconds\x18\x01 \x01(\x04R\x0fbaseNanoseconds\x12Q\n" +
-	"%uniform_random_multiplier_nanoseconds\x18\x02 \x01(\x04R\"uniformRandomMultiplierNanoseconds\"\xb4\x04\n" +
+	"%uniform_random_multiplier_nanoseconds\x18\x02 \x01(\x04R\"uniformRandomMultiplierNanoseconds\"1\n" +
+	"\x15TransportLayerPadding\x12\x18\n" +
+	"\aenabled\x18\x01 \x01(\bR\aenabled\"\xb3\x05\n" +
 	"\x06Config\x12'\n" +
 	"\x0fforward_address\x18\x01 \x01(\tR\x0eforwardAddress\x12!\n" +
 	"\fforward_port\x18\x02 \x01(\rR\vforwardPort\x12\x1f\n" +
@@ -187,7 +241,8 @@ const file_transport_internet_tlsmirror_server_config_proto_rawDesc = "" +
 	"\vprimary_key\x18\x06 \x01(\fR\n" +
 	"primaryKey\x12>\n" +
 	"\x1bexplicit_nonce_ciphersuites\x18\a \x03(\rR\x19explicitNonceCiphersuites\x12|\n" +
-	"\x1edefer_first_payload_write_time\x18\b \x01(\v28.v2ray.core.transport.internet.tlsmirror.server.TimeSpecR\x1adeferFirstPayloadWriteTime:+\x82\xb5\x18'\n" +
+	"\x1edefer_first_payload_write_time\x18\b \x01(\v28.v2ray.core.transport.internet.tlsmirror.server.TimeSpecR\x1adeferFirstPayloadWriteTime\x12}\n" +
+	"\x17transport_layer_padding\x18\t \x01(\v2E.v2ray.core.transport.internet.tlsmirror.server.TransportLayerPaddingR\x15transportLayerPadding:+\x82\xb5\x18'\n" +
 	"\ttransport\x12\ttlsmirror\x8a\xff)\ttlsmirror\x90\xff)\x01B\xab\x01\n" +
 	"2com.v2ray.core.transport.internet.tlsmirror.serverP\x01ZBgithub.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/server\xaa\x02.V2Ray.Core.Transport.Internet.Tlsmirror.Serverb\x06proto3"
 
@@ -203,20 +258,22 @@ func file_transport_internet_tlsmirror_server_config_proto_rawDescGZIP() []byte 
 	return file_transport_internet_tlsmirror_server_config_proto_rawDescData
 }
 
-var file_transport_internet_tlsmirror_server_config_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_transport_internet_tlsmirror_server_config_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_transport_internet_tlsmirror_server_config_proto_goTypes = []any{
-	(*TimeSpec)(nil),             // 0: v2ray.core.transport.internet.tlsmirror.server.TimeSpec
-	(*Config)(nil),               // 1: v2ray.core.transport.internet.tlsmirror.server.Config
-	(*tlstrafficgen.Config)(nil), // 2: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Config
+	(*TimeSpec)(nil),              // 0: v2ray.core.transport.internet.tlsmirror.server.TimeSpec
+	(*TransportLayerPadding)(nil), // 1: v2ray.core.transport.internet.tlsmirror.server.TransportLayerPadding
+	(*Config)(nil),                // 2: v2ray.core.transport.internet.tlsmirror.server.Config
+	(*tlstrafficgen.Config)(nil),  // 3: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Config
 }
 var file_transport_internet_tlsmirror_server_config_proto_depIdxs = []int32{
-	2, // 0: v2ray.core.transport.internet.tlsmirror.server.Config.embedded_traffic_generator:type_name -> v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Config
+	3, // 0: v2ray.core.transport.internet.tlsmirror.server.Config.embedded_traffic_generator:type_name -> v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Config
 	0, // 1: v2ray.core.transport.internet.tlsmirror.server.Config.defer_first_payload_write_time:type_name -> v2ray.core.transport.internet.tlsmirror.server.TimeSpec
-	2, // [2:2] is the sub-list for method output_type
-	2, // [2:2] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	1, // 2: v2ray.core.transport.internet.tlsmirror.server.Config.transport_layer_padding:type_name -> v2ray.core.transport.internet.tlsmirror.server.TransportLayerPadding
+	3, // [3:3] is the sub-list for method output_type
+	3, // [3:3] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_transport_internet_tlsmirror_server_config_proto_init() }
@@ -230,7 +287,7 @@ func file_transport_internet_tlsmirror_server_config_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_transport_internet_tlsmirror_server_config_proto_rawDesc), len(file_transport_internet_tlsmirror_server_config_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/transport/internet/tlsmirror/server/config.proto
+++ b/transport/internet/tlsmirror/server/config.proto
@@ -9,6 +9,11 @@ option java_multiple_files = true;
 import "common/protoext/extensions.proto";
 import "transport/internet/tlsmirror/tlstrafficgen/config.proto";
 
+message TimeSpec {
+  uint64 base_nanoseconds = 1;
+  uint64 uniform_random_multiplier_nanoseconds = 2;
+}
+
 message Config {
   option (v2ray.core.common.protoext.message_opt).type = "transport";
   option (v2ray.core.common.protoext.message_opt).short_name = "tlsmirror";
@@ -27,4 +32,6 @@ message Config {
   bytes primary_key = 6;
 
   repeated uint32 explicit_nonce_ciphersuites = 7;
+
+  TimeSpec defer_first_payload_write_time = 8;
 }

--- a/transport/internet/tlsmirror/server/config.proto
+++ b/transport/internet/tlsmirror/server/config.proto
@@ -25,4 +25,6 @@ message Config {
   v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Config embedded_traffic_generator = 5;
 
   bytes primary_key = 6;
+
+  repeated uint32 explicit_nonce_ciphersuites = 7;
 }

--- a/transport/internet/tlsmirror/server/config.proto
+++ b/transport/internet/tlsmirror/server/config.proto
@@ -37,7 +37,7 @@ message Config {
 
   repeated uint32 explicit_nonce_ciphersuites = 7;
 
-  TimeSpec defer_first_payload_write_time = 8;
+  TimeSpec defer_instance_derived_write_time = 8;
 
   TransportLayerPadding transport_layer_padding = 9;
 }

--- a/transport/internet/tlsmirror/server/config.proto
+++ b/transport/internet/tlsmirror/server/config.proto
@@ -14,6 +14,10 @@ message TimeSpec {
   uint64 uniform_random_multiplier_nanoseconds = 2;
 }
 
+message TransportLayerPadding {
+  bool enabled = 1;
+}
+
 message Config {
   option (v2ray.core.common.protoext.message_opt).type = "transport";
   option (v2ray.core.common.protoext.message_opt).short_name = "tlsmirror";
@@ -34,4 +38,6 @@ message Config {
   repeated uint32 explicit_nonce_ciphersuites = 7;
 
   TimeSpec defer_first_payload_write_time = 8;
+
+  TransportLayerPadding transport_layer_padding = 9;
 }

--- a/transport/internet/tlsmirror/server/conn.go
+++ b/transport/internet/tlsmirror/server/conn.go
@@ -145,7 +145,7 @@ func (s *connState) WriteMessage(message []byte) error {
 		return newError("failed to get explicit nonce reserved overhead header length").Base(err)
 	}
 
-	buffer := make([]byte, 0, explicitNonceReservedOverheadHeaderLength+len(message)+s.decryptor.NonceSize())
+	buffer := make([]byte, explicitNonceReservedOverheadHeaderLength, explicitNonceReservedOverheadHeaderLength+len(message)+s.decryptor.NonceSize())
 	buffer, err = s.encryptor.Seal(buffer[:], message)
 	if err != nil {
 		return newError("failed to encrypt message").Base(err)

--- a/transport/internet/tlsmirror/server/conn.go
+++ b/transport/internet/tlsmirror/server/conn.go
@@ -69,7 +69,8 @@ func (s *connState) Read(b []byte) (n int, err error) {
 }
 
 func (s *connState) Write(b []byte) (n int, err error) {
-	if s.firstWrite {
+	payloadSize := len(b)
+	if s.firstWrite && s.firstWriteDelay > 0 {
 		firstWriteDelayTimer := time.NewTimer(s.firstWriteDelay)
 		defer firstWriteDelayTimer.Stop()
 		select {
@@ -80,13 +81,13 @@ func (s *connState) Write(b []byte) (n int, err error) {
 		}
 	}
 	if s.transportLayerPadding != nil && s.transportLayerPadding.Enabled {
-		b = Pack(b, 0)
+		b = Pack(bytes.Clone(b), 0)
 	}
 	err = s.WriteMessage(b)
 	if err != nil {
 		return 0, err
 	}
-	n = len(b)
+	n = payloadSize
 	return n, nil
 }
 

--- a/transport/internet/tlsmirror/server/hub.go
+++ b/transport/internet/tlsmirror/server/hub.go
@@ -18,7 +18,7 @@ func ListenTLSMirror(ctx context.Context, address net.Address, port net.Port,
 		return nil, newError("failed to listen TLS mirror").Base(err)
 	}
 
-	tlsMirrorServer := &Server{ctx: ctx, listener: listener, config: tlsMirrorSettings, handler: handler}
+	tlsMirrorServer := NewServer(ctx, listener, tlsMirrorSettings, handler)
 
 	go tlsMirrorServer.accepts()
 

--- a/transport/internet/tlsmirror/server/padding.go
+++ b/transport/internet/tlsmirror/server/padding.go
@@ -47,7 +47,7 @@ func Pad(paddingLength int) []byte {
 	case 4:
 		return []byte{0, 0, 0, 0}
 	default:
-		return append(make([]byte, paddingLength-4), byte(paddingLength>>24), byte(paddingLength>>16), byte(paddingLength>>8), byte(paddingLength))
+		return append(make([]byte, paddingLength))
 	}
 
 }

--- a/transport/internet/tlsmirror/server/padding.go
+++ b/transport/internet/tlsmirror/server/padding.go
@@ -1,0 +1,75 @@
+package server
+
+// this file defines methods to pad packets
+// with a given number of bytes, and to unpack the padding from a padded packet.
+// The packet format is as follows if the desired output length is greater than
+// 4 bytes:
+// | data | padding | data length |
+// The data length is a 32-bit big-endian integer that represents the length of
+// the data in bytes.
+// If the desired output length is 4 bytes or less, the packet format is as
+// follows:
+// | padding |
+// No payload will be included in the packet.
+
+import "encoding/binary"
+
+// Pack pads the given data with the given number of bytes, and appends the
+// length of the data to the end of the data. The returned byte slice
+// contains the padded data.
+// This generates a packet with a length of
+// len(data_OWNERSHIP_RELINQUISHED) + padding + 2
+// @param data_OWNERSHIP_RELINQUISHED - The payload, this reference is consumed and should not be used after this call.
+// @param padding - The number of padding bytes to add to the data.
+func Pack(data_OWNERSHIP_RELINQUISHED []byte, paddingLength int) []byte {
+	data := append(data_OWNERSHIP_RELINQUISHED, make([]byte, paddingLength)...)
+	dataLength := len(data_OWNERSHIP_RELINQUISHED)
+	data = binary.BigEndian.AppendUint32(data, uint32(dataLength))
+	return data
+}
+
+// Pad returns a padding packet of padding length.
+// If the padding length is less than 0, nil is returned.
+// @param padding - The number of padding bytes to add to the data.
+func Pad(paddingLength int) []byte {
+	if assertPaddingLengthIsNotNegative := paddingLength < 0; assertPaddingLengthIsNotNegative {
+		return nil
+	}
+	switch paddingLength {
+	case 0:
+		return []byte{}
+	case 1:
+		return []byte{0}
+	case 2:
+		return []byte{0, 0}
+	case 3:
+		return []byte{0, 0, 0}
+	case 4:
+		return []byte{0, 0, 0, 0}
+	default:
+		return append(make([]byte, paddingLength-4), byte(paddingLength>>24), byte(paddingLength>>16), byte(paddingLength>>8), byte(paddingLength))
+	}
+
+}
+
+// Unpack extracts the data and padding from the given padded data. It
+// returns the data and the number of padding bytes.
+// the data may be nil.
+// @param wrappedData_OWNERSHIP_RELINQUISHED - The packet, this reference is consumed and should not be used after this call.
+func Unpack(wrappedData_OWNERSHIP_RELINQUISHED []byte) ([]byte, int) {
+	dataLength := len(wrappedData_OWNERSHIP_RELINQUISHED)
+	if dataLength < 4 {
+		return nil, dataLength
+	}
+
+	dataLen := int(binary.BigEndian.Uint32(wrappedData_OWNERSHIP_RELINQUISHED[dataLength-4:]))
+	if dataLen > len(wrappedData_OWNERSHIP_RELINQUISHED)-4 {
+		return nil, 0
+	}
+	paddingLength := dataLength - dataLen - 4
+	if paddingLength < 0 {
+		return nil, paddingLength
+	}
+
+	return wrappedData_OWNERSHIP_RELINQUISHED[:dataLen], paddingLength
+}

--- a/transport/internet/tlsmirror/server/server.go
+++ b/transport/internet/tlsmirror/server/server.go
@@ -96,15 +96,16 @@ func (s *Server) accept(clientConn net.Conn, serverConn net.Conn) {
 	}
 
 	conn := &connState{
-		ctx:             ctx,
-		done:            cancel,
-		localAddr:       clientConn.LocalAddr(),
-		remoteAddr:      clientConn.RemoteAddr(),
-		primaryKey:      s.config.PrimaryKey,
-		handler:         s.onIncomingReadyConnection,
-		readPipe:        make(chan []byte, 1),
-		firstWrite:      true,
-		firstWriteDelay: firstWriteDelay,
+		ctx:                   ctx,
+		done:                  cancel,
+		localAddr:             clientConn.LocalAddr(),
+		remoteAddr:            clientConn.RemoteAddr(),
+		primaryKey:            s.config.PrimaryKey,
+		handler:               s.onIncomingReadyConnection,
+		readPipe:              make(chan []byte, 1),
+		firstWrite:            true,
+		firstWriteDelay:       firstWriteDelay,
+		transportLayerPadding: s.config.TransportLayerPadding,
 	}
 
 	conn.mirrorConn = mirrorbase.NewMirroredTLSConn(ctx, clientConn, serverConn, conn.onC2SMessage, nil, conn,

--- a/transport/internet/tlsmirror/server/server.go
+++ b/transport/internet/tlsmirror/server/server.go
@@ -81,10 +81,10 @@ func (s *Server) accept(clientConn net.Conn, serverConn net.Conn) {
 	ctx, cancel := context.WithCancel(s.ctx)
 
 	firstWriteDelay := time.Duration(0)
-	if s.config.DeferFirstPayloadWriteTime != nil {
-		firstWriteDelay = time.Duration(s.config.DeferFirstPayloadWriteTime.BaseNanoseconds)
-		if s.config.DeferFirstPayloadWriteTime.UniformRandomMultiplierNanoseconds > 0 {
-			uniformRandomAdd := big.NewInt(int64(s.config.DeferFirstPayloadWriteTime.UniformRandomMultiplierNanoseconds))
+	if s.config.DeferInstanceDerivedWriteTime != nil {
+		firstWriteDelay = time.Duration(s.config.DeferInstanceDerivedWriteTime.BaseNanoseconds)
+		if s.config.DeferInstanceDerivedWriteTime.UniformRandomMultiplierNanoseconds > 0 {
+			uniformRandomAdd := big.NewInt(int64(s.config.DeferInstanceDerivedWriteTime.UniformRandomMultiplierNanoseconds))
 			uniformRandomAddBigInt, err := cryptoRand.Int(cryptoRand.Reader, uniformRandomAdd)
 			if err != nil {
 				newError("failed to generate random delay").Base(err).AtWarning().WriteToLog()

--- a/transport/internet/tlsmirror/tlstrafficgen/config.pb.go
+++ b/transport/internet/tlsmirror/tlstrafficgen/config.pb.go
@@ -16,6 +16,58 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type TimeSpec struct {
+	state                              protoimpl.MessageState `protogen:"open.v1"`
+	BaseNanoseconds                    uint64                 `protobuf:"varint,1,opt,name=base_nanoseconds,json=baseNanoseconds,proto3" json:"base_nanoseconds,omitempty"`
+	UniformRandomMultiplierNanoseconds uint64                 `protobuf:"varint,2,opt,name=uniform_random_multiplier_nanoseconds,json=uniformRandomMultiplierNanoseconds,proto3" json:"uniform_random_multiplier_nanoseconds,omitempty"`
+	unknownFields                      protoimpl.UnknownFields
+	sizeCache                          protoimpl.SizeCache
+}
+
+func (x *TimeSpec) Reset() {
+	*x = TimeSpec{}
+	mi := &file_transport_internet_tlsmirror_tlstrafficgen_config_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TimeSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TimeSpec) ProtoMessage() {}
+
+func (x *TimeSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_transport_internet_tlsmirror_tlstrafficgen_config_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TimeSpec.ProtoReflect.Descriptor instead.
+func (*TimeSpec) Descriptor() ([]byte, []int) {
+	return file_transport_internet_tlsmirror_tlstrafficgen_config_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *TimeSpec) GetBaseNanoseconds() uint64 {
+	if x != nil {
+		return x.BaseNanoseconds
+	}
+	return 0
+}
+
+func (x *TimeSpec) GetUniformRandomMultiplierNanoseconds() uint64 {
+	if x != nil {
+		return x.UniformRandomMultiplierNanoseconds
+	}
+	return 0
+}
+
 type Header struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -27,7 +79,7 @@ type Header struct {
 
 func (x *Header) Reset() {
 	*x = Header{}
-	mi := &file_transport_internet_tlsmirror_tlstrafficgen_config_proto_msgTypes[0]
+	mi := &file_transport_internet_tlsmirror_tlstrafficgen_config_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -39,7 +91,7 @@ func (x *Header) String() string {
 func (*Header) ProtoMessage() {}
 
 func (x *Header) ProtoReflect() protoreflect.Message {
-	mi := &file_transport_internet_tlsmirror_tlstrafficgen_config_proto_msgTypes[0]
+	mi := &file_transport_internet_tlsmirror_tlstrafficgen_config_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -52,7 +104,7 @@ func (x *Header) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Header.ProtoReflect.Descriptor instead.
 func (*Header) Descriptor() ([]byte, []int) {
-	return file_transport_internet_tlsmirror_tlstrafficgen_config_proto_rawDescGZIP(), []int{0}
+	return file_transport_internet_tlsmirror_tlstrafficgen_config_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *Header) GetName() string {
@@ -86,7 +138,7 @@ type TransferCandidate struct {
 
 func (x *TransferCandidate) Reset() {
 	*x = TransferCandidate{}
-	mi := &file_transport_internet_tlsmirror_tlstrafficgen_config_proto_msgTypes[1]
+	mi := &file_transport_internet_tlsmirror_tlstrafficgen_config_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -98,7 +150,7 @@ func (x *TransferCandidate) String() string {
 func (*TransferCandidate) ProtoMessage() {}
 
 func (x *TransferCandidate) ProtoReflect() protoreflect.Message {
-	mi := &file_transport_internet_tlsmirror_tlstrafficgen_config_proto_msgTypes[1]
+	mi := &file_transport_internet_tlsmirror_tlstrafficgen_config_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -111,7 +163,7 @@ func (x *TransferCandidate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransferCandidate.ProtoReflect.Descriptor instead.
 func (*TransferCandidate) Descriptor() ([]byte, []int) {
-	return file_transport_internet_tlsmirror_tlstrafficgen_config_proto_rawDescGZIP(), []int{1}
+	return file_transport_internet_tlsmirror_tlstrafficgen_config_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *TransferCandidate) GetWeight() int32 {
@@ -129,24 +181,24 @@ func (x *TransferCandidate) GetGotoLocation() int64 {
 }
 
 type Step struct {
-	state                protoimpl.MessageState `protogen:"open.v1"`
-	Name                 string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Host                 string                 `protobuf:"bytes,8,opt,name=host,proto3" json:"host,omitempty"`
-	Path                 string                 `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
-	Method               string                 `protobuf:"bytes,3,opt,name=method,proto3" json:"method,omitempty"`
-	WaitAtLeast          float32                `protobuf:"fixed32,4,opt,name=wait_at_least,json=waitAtLeast,proto3" json:"wait_at_least,omitempty"`
-	WaitAtMost           float32                `protobuf:"fixed32,5,opt,name=wait_at_most,json=waitAtMost,proto3" json:"wait_at_most,omitempty"`
-	NextStep             []*TransferCandidate   `protobuf:"bytes,6,rep,name=next_step,json=nextStep,proto3" json:"next_step,omitempty"`
-	ConnectionReady      bool                   `protobuf:"varint,7,opt,name=connection_ready,json=connectionReady,proto3" json:"connection_ready,omitempty"`
-	Headers              []*Header              `protobuf:"bytes,9,rep,name=headers,proto3" json:"headers,omitempty"`
-	ConnectionRecallExit bool                   `protobuf:"varint,10,opt,name=connection_recall_exit,json=connectionRecallExit,proto3" json:"connection_recall_exit,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	state                        protoimpl.MessageState `protogen:"open.v1"`
+	Name                         string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Host                         string                 `protobuf:"bytes,8,opt,name=host,proto3" json:"host,omitempty"`
+	Path                         string                 `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
+	Method                       string                 `protobuf:"bytes,3,opt,name=method,proto3" json:"method,omitempty"`
+	NextStep                     []*TransferCandidate   `protobuf:"bytes,6,rep,name=next_step,json=nextStep,proto3" json:"next_step,omitempty"`
+	ConnectionReady              bool                   `protobuf:"varint,7,opt,name=connection_ready,json=connectionReady,proto3" json:"connection_ready,omitempty"`
+	Headers                      []*Header              `protobuf:"bytes,9,rep,name=headers,proto3" json:"headers,omitempty"`
+	ConnectionRecallExit         bool                   `protobuf:"varint,10,opt,name=connection_recall_exit,json=connectionRecallExit,proto3" json:"connection_recall_exit,omitempty"`
+	WaitTime                     *TimeSpec              `protobuf:"bytes,11,opt,name=wait_time,json=waitTime,proto3" json:"wait_time,omitempty"`
+	H2DoNotWaitForDownloadFinish bool                   `protobuf:"varint,12,opt,name=h2_do_not_wait_for_download_finish,json=h2DoNotWaitForDownloadFinish,proto3" json:"h2_do_not_wait_for_download_finish,omitempty"`
+	unknownFields                protoimpl.UnknownFields
+	sizeCache                    protoimpl.SizeCache
 }
 
 func (x *Step) Reset() {
 	*x = Step{}
-	mi := &file_transport_internet_tlsmirror_tlstrafficgen_config_proto_msgTypes[2]
+	mi := &file_transport_internet_tlsmirror_tlstrafficgen_config_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -158,7 +210,7 @@ func (x *Step) String() string {
 func (*Step) ProtoMessage() {}
 
 func (x *Step) ProtoReflect() protoreflect.Message {
-	mi := &file_transport_internet_tlsmirror_tlstrafficgen_config_proto_msgTypes[2]
+	mi := &file_transport_internet_tlsmirror_tlstrafficgen_config_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -171,7 +223,7 @@ func (x *Step) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Step.ProtoReflect.Descriptor instead.
 func (*Step) Descriptor() ([]byte, []int) {
-	return file_transport_internet_tlsmirror_tlstrafficgen_config_proto_rawDescGZIP(), []int{2}
+	return file_transport_internet_tlsmirror_tlstrafficgen_config_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *Step) GetName() string {
@@ -202,20 +254,6 @@ func (x *Step) GetMethod() string {
 	return ""
 }
 
-func (x *Step) GetWaitAtLeast() float32 {
-	if x != nil {
-		return x.WaitAtLeast
-	}
-	return 0
-}
-
-func (x *Step) GetWaitAtMost() float32 {
-	if x != nil {
-		return x.WaitAtMost
-	}
-	return 0
-}
-
 func (x *Step) GetNextStep() []*TransferCandidate {
 	if x != nil {
 		return x.NextStep
@@ -244,6 +282,20 @@ func (x *Step) GetConnectionRecallExit() bool {
 	return false
 }
 
+func (x *Step) GetWaitTime() *TimeSpec {
+	if x != nil {
+		return x.WaitTime
+	}
+	return nil
+}
+
+func (x *Step) GetH2DoNotWaitForDownloadFinish() bool {
+	if x != nil {
+		return x.H2DoNotWaitForDownloadFinish
+	}
+	return false
+}
+
 type Config struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
 	Steps            []*Step                `protobuf:"bytes,1,rep,name=steps,proto3" json:"steps,omitempty"`
@@ -254,7 +306,7 @@ type Config struct {
 
 func (x *Config) Reset() {
 	*x = Config{}
-	mi := &file_transport_internet_tlsmirror_tlstrafficgen_config_proto_msgTypes[3]
+	mi := &file_transport_internet_tlsmirror_tlstrafficgen_config_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -266,7 +318,7 @@ func (x *Config) String() string {
 func (*Config) ProtoMessage() {}
 
 func (x *Config) ProtoReflect() protoreflect.Message {
-	mi := &file_transport_internet_tlsmirror_tlstrafficgen_config_proto_msgTypes[3]
+	mi := &file_transport_internet_tlsmirror_tlstrafficgen_config_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -279,7 +331,7 @@ func (x *Config) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Config.ProtoReflect.Descriptor instead.
 func (*Config) Descriptor() ([]byte, []int) {
-	return file_transport_internet_tlsmirror_tlstrafficgen_config_proto_rawDescGZIP(), []int{3}
+	return file_transport_internet_tlsmirror_tlstrafficgen_config_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *Config) GetSteps() []*Step {
@@ -300,27 +352,29 @@ var File_transport_internet_tlsmirror_tlstrafficgen_config_proto protoreflect.Fi
 
 const file_transport_internet_tlsmirror_tlstrafficgen_config_proto_rawDesc = "" +
 	"\n" +
-	"7transport/internet/tlsmirror/tlstrafficgen/config.proto\x125v2ray.core.transport.internet.tlsmirror.tlstrafficgen\x1a\x19google/protobuf/any.proto\"J\n" +
+	"7transport/internet/tlsmirror/tlstrafficgen/config.proto\x125v2ray.core.transport.internet.tlsmirror.tlstrafficgen\x1a\x19google/protobuf/any.proto\"\x88\x01\n" +
+	"\bTimeSpec\x12)\n" +
+	"\x10base_nanoseconds\x18\x01 \x01(\x04R\x0fbaseNanoseconds\x12Q\n" +
+	"%uniform_random_multiplier_nanoseconds\x18\x02 \x01(\x04R\"uniformRandomMultiplierNanoseconds\"J\n" +
 	"\x06Header\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value\x12\x16\n" +
 	"\x06values\x18\x03 \x03(\tR\x06values\"P\n" +
 	"\x11TransferCandidate\x12\x16\n" +
 	"\x06weight\x18\x01 \x01(\x05R\x06weight\x12#\n" +
-	"\rgoto_location\x18\x02 \x01(\x03R\fgotoLocation\"\xc1\x03\n" +
+	"\rgoto_location\x18\x02 \x01(\x03R\fgotoLocation\"\xa3\x04\n" +
 	"\x04Step\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04host\x18\b \x01(\tR\x04host\x12\x12\n" +
 	"\x04path\x18\x02 \x01(\tR\x04path\x12\x16\n" +
-	"\x06method\x18\x03 \x01(\tR\x06method\x12\"\n" +
-	"\rwait_at_least\x18\x04 \x01(\x02R\vwaitAtLeast\x12 \n" +
-	"\fwait_at_most\x18\x05 \x01(\x02R\n" +
-	"waitAtMost\x12e\n" +
+	"\x06method\x18\x03 \x01(\tR\x06method\x12e\n" +
 	"\tnext_step\x18\x06 \x03(\v2H.v2ray.core.transport.internet.tlsmirror.tlstrafficgen.TransferCandidateR\bnextStep\x12)\n" +
 	"\x10connection_ready\x18\a \x01(\bR\x0fconnectionReady\x12W\n" +
 	"\aheaders\x18\t \x03(\v2=.v2ray.core.transport.internet.tlsmirror.tlstrafficgen.HeaderR\aheaders\x124\n" +
 	"\x16connection_recall_exit\x18\n" +
-	" \x01(\bR\x14connectionRecallExit\"\x9e\x01\n" +
+	" \x01(\bR\x14connectionRecallExit\x12\\\n" +
+	"\twait_time\x18\v \x01(\v2?.v2ray.core.transport.internet.tlsmirror.tlstrafficgen.TimeSpecR\bwaitTime\x12H\n" +
+	"\"h2_do_not_wait_for_download_finish\x18\f \x01(\bR\x1ch2DoNotWaitForDownloadFinish\"\x9e\x01\n" +
 	"\x06Config\x12Q\n" +
 	"\x05steps\x18\x01 \x03(\v2;.v2ray.core.transport.internet.tlsmirror.tlstrafficgen.StepR\x05steps\x12A\n" +
 	"\x11security_settings\x18\x02 \x01(\v2\x14.google.protobuf.AnyR\x10securitySettingsB\xc0\x01\n" +
@@ -338,24 +392,26 @@ func file_transport_internet_tlsmirror_tlstrafficgen_config_proto_rawDescGZIP() 
 	return file_transport_internet_tlsmirror_tlstrafficgen_config_proto_rawDescData
 }
 
-var file_transport_internet_tlsmirror_tlstrafficgen_config_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_transport_internet_tlsmirror_tlstrafficgen_config_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_transport_internet_tlsmirror_tlstrafficgen_config_proto_goTypes = []any{
-	(*Header)(nil),            // 0: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Header
-	(*TransferCandidate)(nil), // 1: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.TransferCandidate
-	(*Step)(nil),              // 2: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Step
-	(*Config)(nil),            // 3: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Config
-	(*anypb.Any)(nil),         // 4: google.protobuf.Any
+	(*TimeSpec)(nil),          // 0: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.TimeSpec
+	(*Header)(nil),            // 1: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Header
+	(*TransferCandidate)(nil), // 2: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.TransferCandidate
+	(*Step)(nil),              // 3: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Step
+	(*Config)(nil),            // 4: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Config
+	(*anypb.Any)(nil),         // 5: google.protobuf.Any
 }
 var file_transport_internet_tlsmirror_tlstrafficgen_config_proto_depIdxs = []int32{
-	1, // 0: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Step.next_step:type_name -> v2ray.core.transport.internet.tlsmirror.tlstrafficgen.TransferCandidate
-	0, // 1: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Step.headers:type_name -> v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Header
-	2, // 2: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Config.steps:type_name -> v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Step
-	4, // 3: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Config.security_settings:type_name -> google.protobuf.Any
-	4, // [4:4] is the sub-list for method output_type
-	4, // [4:4] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	2, // 0: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Step.next_step:type_name -> v2ray.core.transport.internet.tlsmirror.tlstrafficgen.TransferCandidate
+	1, // 1: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Step.headers:type_name -> v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Header
+	0, // 2: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Step.wait_time:type_name -> v2ray.core.transport.internet.tlsmirror.tlstrafficgen.TimeSpec
+	3, // 3: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Config.steps:type_name -> v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Step
+	5, // 4: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Config.security_settings:type_name -> google.protobuf.Any
+	5, // [5:5] is the sub-list for method output_type
+	5, // [5:5] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_transport_internet_tlsmirror_tlstrafficgen_config_proto_init() }
@@ -369,7 +425,7 @@ func file_transport_internet_tlsmirror_tlstrafficgen_config_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_transport_internet_tlsmirror_tlstrafficgen_config_proto_rawDesc), len(file_transport_internet_tlsmirror_tlstrafficgen_config_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/transport/internet/tlsmirror/tlstrafficgen/config.proto
+++ b/transport/internet/tlsmirror/tlstrafficgen/config.proto
@@ -8,6 +8,11 @@ option java_multiple_files = true;
 
 import "google/protobuf/any.proto";
 
+message TimeSpec {
+  uint64 base_nanoseconds = 1;
+  uint64 uniform_random_multiplier_nanoseconds = 2;
+}
+
 message Header {
   string name = 1;
   string value = 2;
@@ -24,12 +29,12 @@ message Step {
   string host = 8;
   string path = 2;
   string method = 3;
-  float wait_at_least = 4;
-  float wait_at_most = 5;
   repeated TransferCandidate next_step = 6;
   bool connection_ready = 7;
   repeated Header headers = 9;
   bool connection_recall_exit = 10;
+  TimeSpec wait_time = 11;
+  bool h2_do_not_wait_for_download_finish = 12;
 }
 
 message Config {

--- a/transport/internet/tlsmirror/tlstrafficgen/trafficgen.go
+++ b/transport/internet/tlsmirror/tlstrafficgen/trafficgen.go
@@ -192,6 +192,10 @@ func (generator *TrafficGenerator) GenerateNextTraffic(ctx context.Context) erro
 		endTime := time.Now()
 
 		eclipsedTime := endTime.Sub(startTime)
+		if step.WaitTime == nil {
+			step.WaitTime = &TimeSpec{}
+			newError("no wait time specified for step ", currentStep, ", using default 0 seconds").AtWarning().WriteToLog()
+		}
 		secondToWait := (float64(step.WaitTime.UniformRandomMultiplierNanoseconds)*randFloat64() + float64(step.WaitTime.BaseNanoseconds)) / float64(time.Second)
 		if eclipsedTime < time.Duration(secondToWait*float64(time.Second)) {
 			waitTime := time.Duration(secondToWait*float64(time.Second)) - eclipsedTime


### PR DESCRIPTION
This pull request adds the follow new features to TLSMirror

- TLS1.2 AEAD support
- defer_instance_derived_write_time
-  transport_layer_padding
- h2_do_not_wait_for_download_finish
- connection invalidation for generated traffic 

Fix following bugs:
- not using tags in encryption key derivation

With a few option rename