### PR TITLE
TLSMirror Connection Enrollment System

### DIFF
--- a/.github/linters/.golangci.yml
+++ b/.github/linters/.golangci.yml
@@ -50,7 +50,7 @@ linters:
       - builtin$
       - examples$
 issues:
-  new: false
+  new: true
 formatters:
   enable:
     - gofmt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,70 @@
+version: "2"
+linters:
+  enable:
+    - asciicheck
+    - bodyclose
+    - depguard
+    - gocritic
+    - goprintffuncname
+    - misspell
+    - nakedret
+    - revive
+    - rowserrcheck
+    - staticcheck
+    - unconvert
+    - unparam
+    - whitespace
+  disable:
+    - errcheck
+    - unused
+  settings:
+    depguard:
+      rules:
+        Main:
+          deny:
+            - pkg: github.com/pkg/errors
+              desc: Should be replaced by standard lib errors package
+    revive:
+      rules:
+        - name: blank-imports
+          severity: warning
+          disabled: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - staticcheck
+        text: 'SA1019:'
+      - linters:
+          - staticcheck
+        text: 'ST1016:'
+    paths:
+      - generated.*
+      - .pb.go
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  new: true
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/v2fly/v2ray-core
+  exclusions:
+    generated: lax
+    paths:
+      - generated.*
+      - .pb.go
+      - third_party$
+      - builtin$
+      - examples$

--- a/infra/conf/v5cfg/root.go
+++ b/infra/conf/v5cfg/root.go
@@ -1,6 +1,7 @@
 package v5cfg
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -86,7 +87,9 @@ func (c RootConfig) BuildV5(ctx context.Context) (proto.Message, error) {
 func loadJSONConfig(data []byte) (*core.Config, error) {
 	rootConfig := &RootConfig{}
 
-	err := json.Unmarshal(data, rootConfig)
+	rootConfDecoder := json.NewDecoder(bytes.NewReader(data))
+	rootConfDecoder.DisallowUnknownFields()
+	err := rootConfDecoder.Decode(rootConfig)
 	if err != nil {
 		return nil, newError("unable to load json").Base(err)
 	}

--- a/transport/internet/tlsmirror/data.pb.go
+++ b/transport/internet/tlsmirror/data.pb.go
@@ -1,0 +1,182 @@
+package tlsmirror
+
+import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+)
+
+const (
+	// Verify that this generated code is sufficiently up-to-date.
+	_ = protoimpl.EnforceVersion(20 - protoimpl.MinVersion)
+	// Verify that runtime/protoimpl is sufficiently up-to-date.
+	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
+)
+
+type EnrollmentConfirmationReq struct {
+	state                            protoimpl.MessageState `protogen:"open.v1"`
+	ServerIdentifier                 []byte                 `protobuf:"bytes,1,opt,name=server_identifier,json=serverIdentifier,proto3" json:"server_identifier,omitempty"`
+	CarrierTlsConnectionClientRandom []byte                 `protobuf:"bytes,2,opt,name=carrier_tls_connection_client_random,json=carrierTlsConnectionClientRandom,proto3" json:"carrier_tls_connection_client_random,omitempty"`
+	CarrierTlsConnectionServerRandom []byte                 `protobuf:"bytes,3,opt,name=carrier_tls_connection_server_random,json=carrierTlsConnectionServerRandom,proto3" json:"carrier_tls_connection_server_random,omitempty"`
+	unknownFields                    protoimpl.UnknownFields
+	sizeCache                        protoimpl.SizeCache
+}
+
+func (x *EnrollmentConfirmationReq) Reset() {
+	*x = EnrollmentConfirmationReq{}
+	mi := &file_transport_internet_tlsmirror_data_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnrollmentConfirmationReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnrollmentConfirmationReq) ProtoMessage() {}
+
+func (x *EnrollmentConfirmationReq) ProtoReflect() protoreflect.Message {
+	mi := &file_transport_internet_tlsmirror_data_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EnrollmentConfirmationReq.ProtoReflect.Descriptor instead.
+func (*EnrollmentConfirmationReq) Descriptor() ([]byte, []int) {
+	return file_transport_internet_tlsmirror_data_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *EnrollmentConfirmationReq) GetServerIdentifier() []byte {
+	if x != nil {
+		return x.ServerIdentifier
+	}
+	return nil
+}
+
+func (x *EnrollmentConfirmationReq) GetCarrierTlsConnectionClientRandom() []byte {
+	if x != nil {
+		return x.CarrierTlsConnectionClientRandom
+	}
+	return nil
+}
+
+func (x *EnrollmentConfirmationReq) GetCarrierTlsConnectionServerRandom() []byte {
+	if x != nil {
+		return x.CarrierTlsConnectionServerRandom
+	}
+	return nil
+}
+
+type EnrollmentConfirmationResp struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Enrolled      bool                   `protobuf:"varint,1,opt,name=enrolled,proto3" json:"enrolled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EnrollmentConfirmationResp) Reset() {
+	*x = EnrollmentConfirmationResp{}
+	mi := &file_transport_internet_tlsmirror_data_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnrollmentConfirmationResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnrollmentConfirmationResp) ProtoMessage() {}
+
+func (x *EnrollmentConfirmationResp) ProtoReflect() protoreflect.Message {
+	mi := &file_transport_internet_tlsmirror_data_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EnrollmentConfirmationResp.ProtoReflect.Descriptor instead.
+func (*EnrollmentConfirmationResp) Descriptor() ([]byte, []int) {
+	return file_transport_internet_tlsmirror_data_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *EnrollmentConfirmationResp) GetEnrolled() bool {
+	if x != nil {
+		return x.Enrolled
+	}
+	return false
+}
+
+var File_transport_internet_tlsmirror_data_proto protoreflect.FileDescriptor
+
+const file_transport_internet_tlsmirror_data_proto_rawDesc = "" +
+	"\n" +
+	"'transport/internet/tlsmirror/data.proto\x12'v2ray.core.transport.internet.tlsmirror\"\xe8\x01\n" +
+	"\x19EnrollmentConfirmationReq\x12+\n" +
+	"\x11server_identifier\x18\x01 \x01(\fR\x10serverIdentifier\x12N\n" +
+	"$carrier_tls_connection_client_random\x18\x02 \x01(\fR carrierTlsConnectionClientRandom\x12N\n" +
+	"$carrier_tls_connection_server_random\x18\x03 \x01(\fR carrierTlsConnectionServerRandom\"8\n" +
+	"\x1aEnrollmentConfirmationResp\x12\x1a\n" +
+	"\benrolled\x18\x01 \x01(\bR\benrolledB\x96\x01\n" +
+	"+com.v2ray.core.transport.internet.tlsmirrorP\x01Z;github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror\xaa\x02'V2Ray.Core.Transport.Internet.Tlsmirrorb\x06proto3"
+
+var (
+	file_transport_internet_tlsmirror_data_proto_rawDescOnce sync.Once
+	file_transport_internet_tlsmirror_data_proto_rawDescData []byte
+)
+
+func file_transport_internet_tlsmirror_data_proto_rawDescGZIP() []byte {
+	file_transport_internet_tlsmirror_data_proto_rawDescOnce.Do(func() {
+		file_transport_internet_tlsmirror_data_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_transport_internet_tlsmirror_data_proto_rawDesc), len(file_transport_internet_tlsmirror_data_proto_rawDesc)))
+	})
+	return file_transport_internet_tlsmirror_data_proto_rawDescData
+}
+
+var file_transport_internet_tlsmirror_data_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_transport_internet_tlsmirror_data_proto_goTypes = []any{
+	(*EnrollmentConfirmationReq)(nil),  // 0: v2ray.core.transport.internet.tlsmirror.EnrollmentConfirmationReq
+	(*EnrollmentConfirmationResp)(nil), // 1: v2ray.core.transport.internet.tlsmirror.EnrollmentConfirmationResp
+}
+var file_transport_internet_tlsmirror_data_proto_depIdxs = []int32{
+	0, // [0:0] is the sub-list for method output_type
+	0, // [0:0] is the sub-list for method input_type
+	0, // [0:0] is the sub-list for extension type_name
+	0, // [0:0] is the sub-list for extension extendee
+	0, // [0:0] is the sub-list for field type_name
+}
+
+func init() { file_transport_internet_tlsmirror_data_proto_init() }
+func file_transport_internet_tlsmirror_data_proto_init() {
+	if File_transport_internet_tlsmirror_data_proto != nil {
+		return
+	}
+	type x struct{}
+	out := protoimpl.TypeBuilder{
+		File: protoimpl.DescBuilder{
+			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_transport_internet_tlsmirror_data_proto_rawDesc), len(file_transport_internet_tlsmirror_data_proto_rawDesc)),
+			NumEnums:      0,
+			NumMessages:   2,
+			NumExtensions: 0,
+			NumServices:   0,
+		},
+		GoTypes:           file_transport_internet_tlsmirror_data_proto_goTypes,
+		DependencyIndexes: file_transport_internet_tlsmirror_data_proto_depIdxs,
+		MessageInfos:      file_transport_internet_tlsmirror_data_proto_msgTypes,
+	}.Build()
+	File_transport_internet_tlsmirror_data_proto = out.File
+	file_transport_internet_tlsmirror_data_proto_goTypes = nil
+	file_transport_internet_tlsmirror_data_proto_depIdxs = nil
+}

--- a/transport/internet/tlsmirror/data.proto
+++ b/transport/internet/tlsmirror/data.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package v2ray.core.transport.internet.tlsmirror;
+option csharp_namespace = "V2Ray.Core.Transport.Internet.Tlsmirror";
+option go_package = "github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror";
+option java_package = "com.v2ray.core.transport.internet.tlsmirror";
+option java_multiple_files = true;
+
+
+message EnrollmentConfirmationReq{
+  bytes server_identifier = 1;
+  bytes carrier_tls_connection_client_random = 2;
+  bytes carrier_tls_connection_server_random = 3;
+}
+message EnrollmentConfirmationResp{
+  bool enrolled = 1;
+}

--- a/transport/internet/tlsmirror/interface.go
+++ b/transport/internet/tlsmirror/interface.go
@@ -56,7 +56,6 @@ type ConnectionEnrollmentConfirmation interface {
 const EnrollmentVerificationControlConnectionPostfix = ".tlsmirror-controlconnection.v2fly.arpa"
 
 type InsertableTLSConnForEnrollment interface {
-	InsertableTLSConn
 	InsertableTLSConnEnrollmentEventReceiver
 }
 
@@ -68,5 +67,5 @@ type RemoveConnectionFunc func() error
 
 type ConnectionEnrollmentConfirmationProcessor interface {
 	ConnectionEnrollmentConfirmation
-	AddConnection(ctx context.Context, conn InsertableTLSConnForEnrollment) (RemoveConnectionFunc, error)
+	AddConnection(ctx context.Context, clientRandom, ServerRandom []byte, conn InsertableTLSConnForEnrollment) (RemoveConnectionFunc, error)
 }

--- a/transport/internet/tlsmirror/interface.go
+++ b/transport/internet/tlsmirror/interface.go
@@ -48,3 +48,25 @@ type TrafficGeneratorManagedConnection interface {
 	WaitConnectionReady() context.Context
 	IsConnectionInvalidated() bool
 }
+
+type ConnectionEnrollmentConfirmation interface {
+	VerifyConnectionEnrollment(req *EnrollmentConfirmationReq) (*EnrollmentConfirmationResp, error)
+}
+
+const EnrollmentVerificationControlConnectionPostfix = ".tlsmirror-controlconnection.v2fly.arpa"
+
+type InsertableTLSConnForEnrollment interface {
+	InsertableTLSConn
+	InsertableTLSConnEnrollmentEventReceiver
+}
+
+type InsertableTLSConnEnrollmentEventReceiver interface {
+	ConnectionEnrollmentConfirmation
+}
+
+type RemoveConnectionFunc func() error
+
+type ConnectionEnrollmentConfirmationProcessor interface {
+	ConnectionEnrollmentConfirmation
+	AddConnection(ctx context.Context, conn InsertableTLSConnForEnrollment) (RemoveConnectionFunc, error)
+}

--- a/transport/internet/tlsmirror/mirrorcrypto/derive_key.go
+++ b/transport/internet/tlsmirror/mirrorcrypto/derive_key.go
@@ -32,3 +32,17 @@ func DeriveEncryptionKey(primaryKey, clientRandom, serverRandom []byte, tag stri
 
 	return encryptionKey, nonceMask, nil
 }
+
+func DeriveSecondaryKey(primaryKey []byte, tag string) ([]byte, error) {
+	if len(primaryKey) != 32 {
+		return nil, newError("invalid primary key size: ", len(primaryKey))
+	}
+
+	// Use HKDF to derive a secondary key
+	secondaryKey, err := hkdf.Expand(sha256.New, primaryKey, "v2ray-sv77RCEY-e8AhYsbD-BmFC7XRK:tlsmirror-secondary"+tag, 16)
+	if err != nil {
+		return nil, newError("unable to derive secondary key").Base(err)
+	}
+
+	return secondaryKey, nil
+}

--- a/transport/internet/tlsmirror/mirrorenrollment/client.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/client.go
@@ -1,0 +1,77 @@
+package mirrorenrollment
+
+import (
+	"context"
+	"net"
+
+	"github.com/v2fly/v2ray-core/v5/common/environment"
+	"github.com/v2fly/v2ray-core/v5/common/environment/envctx"
+	v2net "github.com/v2fly/v2ray-core/v5/common/net"
+	"github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror"
+	"github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/mirrorenrollment/httpenrollmentconfirmation"
+)
+
+func NewEnrollmentConfirmationClient(
+	ctx context.Context,
+	config *Config,
+	serverIdentity []byte,
+) (*EnrollmentConfirmationClient, error) {
+	if ctx == nil {
+		return nil, newError("context cannot be nil")
+	}
+
+	if config == nil {
+		return nil, newError("config cannot be nil")
+	}
+
+	ecc := &EnrollmentConfirmationClient{
+		ctx:            ctx,
+		config:         config,
+		serverIdentity: serverIdentity,
+	}
+
+	if err := ecc.init(); err != nil {
+		return nil, newError("failed to initialize enrollment confirmation client").Base(err).AtError()
+	}
+
+	return ecc, nil
+}
+
+type EnrollmentConfirmationClient struct {
+	ctx context.Context
+
+	config *Config
+
+	serverIdentity []byte
+
+	primaryEnrollmentConfirmationClient tlsmirror.ConnectionEnrollmentConfirmation
+}
+
+func (c *EnrollmentConfirmationClient) VerifyConnectionEnrollment(req *tlsmirror.EnrollmentConfirmationReq) (*tlsmirror.EnrollmentConfirmationResp, error) {
+	return c.primaryEnrollmentConfirmationClient.VerifyConnectionEnrollment(req)
+}
+
+func (c *EnrollmentConfirmationClient) init() error {
+	rtt, err := httpenrollmentconfirmation.NewClientRoundTripperForEnrollmentConfirmation(
+		func(network, addr string) (net.Conn, error) {
+			transportEnvironment := envctx.EnvironmentFromContext(c.ctx).(environment.TransportEnvironment)
+			dialer := transportEnvironment.OutboundDialer()
+			if dialer == nil {
+				return nil, newError("no outbound dialer available in transport environment")
+			}
+			dest, err := v2net.ParseDestination(addr)
+			if err != nil {
+				return nil, newError("failed to parse destination address").Base(err).AtError()
+			}
+			dest.Network = v2net.Network_TCP
+			return dialer(c.ctx, dest, c.config.PrimaryEgressOutbound)
+		}, c.serverIdentity)
+	if err != nil {
+		return newError("failed to create HTTP round tripper for enrollment confirmation").Base(err).AtError()
+	}
+	c.primaryEnrollmentConfirmationClient, err = httpenrollmentconfirmation.NewHTTPEnrollmentConfirmationClientFromHTTPRoundTripper(rtt)
+	if err != nil {
+		return newError("failed to create HTTP enrollment confirmation client").Base(err).AtError()
+	}
+	return nil
+}

--- a/transport/internet/tlsmirror/mirrorenrollment/config.pb.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/config.pb.go
@@ -1,0 +1,167 @@
+package mirrorenrollment
+
+import (
+	_ "github.com/v2fly/v2ray-core/v5/common/protoext"
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	anypb "google.golang.org/protobuf/types/known/anypb"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+)
+
+const (
+	// Verify that this generated code is sufficiently up-to-date.
+	_ = protoimpl.EnforceVersion(20 - protoimpl.MinVersion)
+	// Verify that runtime/protoimpl is sufficiently up-to-date.
+	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
+)
+
+type Config struct {
+	state                  protoimpl.MessageState `protogen:"open.v1"`
+	PrimaryIngressOutbound string                 `protobuf:"bytes,1,opt,name=primary_ingress_outbound,json=primaryIngressOutbound,proto3" json:"primary_ingress_outbound,omitempty"`
+	PrimaryEgressOutbound  string                 `protobuf:"bytes,2,opt,name=primary_egress_outbound,json=primaryEgressOutbound,proto3" json:"primary_egress_outbound,omitempty"`
+	BootstrapIngressUrl    []string               `protobuf:"bytes,3,rep,name=bootstrap_ingress_url,json=bootstrapIngressUrl,proto3" json:"bootstrap_ingress_url,omitempty"`
+	BootstrapEgressUrl     []string               `protobuf:"bytes,4,rep,name=bootstrap_egress_url,json=bootstrapEgressUrl,proto3" json:"bootstrap_egress_url,omitempty"`
+	BootstrapIngressConfig []*anypb.Any           `protobuf:"bytes,5,rep,name=bootstrap_ingress_config,json=bootstrapIngressConfig,proto3" json:"bootstrap_ingress_config,omitempty"`
+	BootstrapEgressConfig  []*anypb.Any           `protobuf:"bytes,6,rep,name=bootstrap_egress_config,json=bootstrapEgressConfig,proto3" json:"bootstrap_egress_config,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *Config) Reset() {
+	*x = Config{}
+	mi := &file_transport_internet_tlsmirror_mirrorenrollment_config_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Config) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Config) ProtoMessage() {}
+
+func (x *Config) ProtoReflect() protoreflect.Message {
+	mi := &file_transport_internet_tlsmirror_mirrorenrollment_config_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Config.ProtoReflect.Descriptor instead.
+func (*Config) Descriptor() ([]byte, []int) {
+	return file_transport_internet_tlsmirror_mirrorenrollment_config_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *Config) GetPrimaryIngressOutbound() string {
+	if x != nil {
+		return x.PrimaryIngressOutbound
+	}
+	return ""
+}
+
+func (x *Config) GetPrimaryEgressOutbound() string {
+	if x != nil {
+		return x.PrimaryEgressOutbound
+	}
+	return ""
+}
+
+func (x *Config) GetBootstrapIngressUrl() []string {
+	if x != nil {
+		return x.BootstrapIngressUrl
+	}
+	return nil
+}
+
+func (x *Config) GetBootstrapEgressUrl() []string {
+	if x != nil {
+		return x.BootstrapEgressUrl
+	}
+	return nil
+}
+
+func (x *Config) GetBootstrapIngressConfig() []*anypb.Any {
+	if x != nil {
+		return x.BootstrapIngressConfig
+	}
+	return nil
+}
+
+func (x *Config) GetBootstrapEgressConfig() []*anypb.Any {
+	if x != nil {
+		return x.BootstrapEgressConfig
+	}
+	return nil
+}
+
+var File_transport_internet_tlsmirror_mirrorenrollment_config_proto protoreflect.FileDescriptor
+
+const file_transport_internet_tlsmirror_mirrorenrollment_config_proto_rawDesc = "" +
+	"\n" +
+	":transport/internet/tlsmirror/mirrorenrollment/config.proto\x128v2ray.core.transport.internet.tlsmirror.mirrorenrollment\x1a common/protoext/extensions.proto\x1a\x19google/protobuf/any.proto\"\xfe\x02\n" +
+	"\x06Config\x128\n" +
+	"\x18primary_ingress_outbound\x18\x01 \x01(\tR\x16primaryIngressOutbound\x126\n" +
+	"\x17primary_egress_outbound\x18\x02 \x01(\tR\x15primaryEgressOutbound\x122\n" +
+	"\x15bootstrap_ingress_url\x18\x03 \x03(\tR\x13bootstrapIngressUrl\x120\n" +
+	"\x14bootstrap_egress_url\x18\x04 \x03(\tR\x12bootstrapEgressUrl\x12N\n" +
+	"\x18bootstrap_ingress_config\x18\x05 \x03(\v2\x14.google.protobuf.AnyR\x16bootstrapIngressConfig\x12L\n" +
+	"\x17bootstrap_egress_config\x18\x06 \x03(\v2\x14.google.protobuf.AnyR\x15bootstrapEgressConfigB\xc9\x01\n" +
+	"<com.v2ray.core.transport.internet.tlsmirror.mirrorenrollmentP\x01ZLgithub.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/mirrorenrollment\xaa\x028V2Ray.Core.Transport.Internet.Tlsmirror.MirrorEnrollmentb\x06proto3"
+
+var (
+	file_transport_internet_tlsmirror_mirrorenrollment_config_proto_rawDescOnce sync.Once
+	file_transport_internet_tlsmirror_mirrorenrollment_config_proto_rawDescData []byte
+)
+
+func file_transport_internet_tlsmirror_mirrorenrollment_config_proto_rawDescGZIP() []byte {
+	file_transport_internet_tlsmirror_mirrorenrollment_config_proto_rawDescOnce.Do(func() {
+		file_transport_internet_tlsmirror_mirrorenrollment_config_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_transport_internet_tlsmirror_mirrorenrollment_config_proto_rawDesc), len(file_transport_internet_tlsmirror_mirrorenrollment_config_proto_rawDesc)))
+	})
+	return file_transport_internet_tlsmirror_mirrorenrollment_config_proto_rawDescData
+}
+
+var file_transport_internet_tlsmirror_mirrorenrollment_config_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_transport_internet_tlsmirror_mirrorenrollment_config_proto_goTypes = []any{
+	(*Config)(nil),    // 0: v2ray.core.transport.internet.tlsmirror.mirrorenrollment.Config
+	(*anypb.Any)(nil), // 1: google.protobuf.Any
+}
+var file_transport_internet_tlsmirror_mirrorenrollment_config_proto_depIdxs = []int32{
+	1, // 0: v2ray.core.transport.internet.tlsmirror.mirrorenrollment.Config.bootstrap_ingress_config:type_name -> google.protobuf.Any
+	1, // 1: v2ray.core.transport.internet.tlsmirror.mirrorenrollment.Config.bootstrap_egress_config:type_name -> google.protobuf.Any
+	2, // [2:2] is the sub-list for method output_type
+	2, // [2:2] is the sub-list for method input_type
+	2, // [2:2] is the sub-list for extension type_name
+	2, // [2:2] is the sub-list for extension extendee
+	0, // [0:2] is the sub-list for field type_name
+}
+
+func init() { file_transport_internet_tlsmirror_mirrorenrollment_config_proto_init() }
+func file_transport_internet_tlsmirror_mirrorenrollment_config_proto_init() {
+	if File_transport_internet_tlsmirror_mirrorenrollment_config_proto != nil {
+		return
+	}
+	type x struct{}
+	out := protoimpl.TypeBuilder{
+		File: protoimpl.DescBuilder{
+			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_transport_internet_tlsmirror_mirrorenrollment_config_proto_rawDesc), len(file_transport_internet_tlsmirror_mirrorenrollment_config_proto_rawDesc)),
+			NumEnums:      0,
+			NumMessages:   1,
+			NumExtensions: 0,
+			NumServices:   0,
+		},
+		GoTypes:           file_transport_internet_tlsmirror_mirrorenrollment_config_proto_goTypes,
+		DependencyIndexes: file_transport_internet_tlsmirror_mirrorenrollment_config_proto_depIdxs,
+		MessageInfos:      file_transport_internet_tlsmirror_mirrorenrollment_config_proto_msgTypes,
+	}.Build()
+	File_transport_internet_tlsmirror_mirrorenrollment_config_proto = out.File
+	file_transport_internet_tlsmirror_mirrorenrollment_config_proto_goTypes = nil
+	file_transport_internet_tlsmirror_mirrorenrollment_config_proto_depIdxs = nil
+}

--- a/transport/internet/tlsmirror/mirrorenrollment/config.pb.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/config.pb.go
@@ -18,15 +18,17 @@ const (
 )
 
 type Config struct {
-	state                  protoimpl.MessageState `protogen:"open.v1"`
-	PrimaryIngressOutbound string                 `protobuf:"bytes,1,opt,name=primary_ingress_outbound,json=primaryIngressOutbound,proto3" json:"primary_ingress_outbound,omitempty"`
-	PrimaryEgressOutbound  string                 `protobuf:"bytes,2,opt,name=primary_egress_outbound,json=primaryEgressOutbound,proto3" json:"primary_egress_outbound,omitempty"`
-	BootstrapIngressUrl    []string               `protobuf:"bytes,3,rep,name=bootstrap_ingress_url,json=bootstrapIngressUrl,proto3" json:"bootstrap_ingress_url,omitempty"`
-	BootstrapEgressUrl     []string               `protobuf:"bytes,4,rep,name=bootstrap_egress_url,json=bootstrapEgressUrl,proto3" json:"bootstrap_egress_url,omitempty"`
-	BootstrapIngressConfig []*anypb.Any           `protobuf:"bytes,5,rep,name=bootstrap_ingress_config,json=bootstrapIngressConfig,proto3" json:"bootstrap_ingress_config,omitempty"`
-	BootstrapEgressConfig  []*anypb.Any           `protobuf:"bytes,6,rep,name=bootstrap_egress_config,json=bootstrapEgressConfig,proto3" json:"bootstrap_egress_config,omitempty"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// This will be handled by the TLS Mirror server, the enrollment part only accepts existing connections.
+	PrimaryIngressOutbound  string       `protobuf:"bytes,1,opt,name=primary_ingress_outbound,json=primaryIngressOutbound,proto3" json:"primary_ingress_outbound,omitempty"`
+	PrimaryEgressOutbound   string       `protobuf:"bytes,2,opt,name=primary_egress_outbound,json=primaryEgressOutbound,proto3" json:"primary_egress_outbound,omitempty"`
+	BootstrapIngressUrl     []string     `protobuf:"bytes,3,rep,name=bootstrap_ingress_url,json=bootstrapIngressUrl,proto3" json:"bootstrap_ingress_url,omitempty"`
+	BootstrapEgressUrl      []string     `protobuf:"bytes,4,rep,name=bootstrap_egress_url,json=bootstrapEgressUrl,proto3" json:"bootstrap_egress_url,omitempty"`
+	BootstrapIngressConfig  []*anypb.Any `protobuf:"bytes,5,rep,name=bootstrap_ingress_config,json=bootstrapIngressConfig,proto3" json:"bootstrap_ingress_config,omitempty"`
+	BootstrapEgressConfig   []*anypb.Any `protobuf:"bytes,6,rep,name=bootstrap_egress_config,json=bootstrapEgressConfig,proto3" json:"bootstrap_egress_config,omitempty"`
+	BootstrapEgressOutbound string       `protobuf:"bytes,7,opt,name=bootstrap_egress_outbound,json=bootstrapEgressOutbound,proto3" json:"bootstrap_egress_outbound,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
 }
 
 func (x *Config) Reset() {
@@ -101,18 +103,26 @@ func (x *Config) GetBootstrapEgressConfig() []*anypb.Any {
 	return nil
 }
 
+func (x *Config) GetBootstrapEgressOutbound() string {
+	if x != nil {
+		return x.BootstrapEgressOutbound
+	}
+	return ""
+}
+
 var File_transport_internet_tlsmirror_mirrorenrollment_config_proto protoreflect.FileDescriptor
 
 const file_transport_internet_tlsmirror_mirrorenrollment_config_proto_rawDesc = "" +
 	"\n" +
-	":transport/internet/tlsmirror/mirrorenrollment/config.proto\x128v2ray.core.transport.internet.tlsmirror.mirrorenrollment\x1a common/protoext/extensions.proto\x1a\x19google/protobuf/any.proto\"\xfe\x02\n" +
+	":transport/internet/tlsmirror/mirrorenrollment/config.proto\x128v2ray.core.transport.internet.tlsmirror.mirrorenrollment\x1a common/protoext/extensions.proto\x1a\x19google/protobuf/any.proto\"\xba\x03\n" +
 	"\x06Config\x128\n" +
 	"\x18primary_ingress_outbound\x18\x01 \x01(\tR\x16primaryIngressOutbound\x126\n" +
 	"\x17primary_egress_outbound\x18\x02 \x01(\tR\x15primaryEgressOutbound\x122\n" +
 	"\x15bootstrap_ingress_url\x18\x03 \x03(\tR\x13bootstrapIngressUrl\x120\n" +
 	"\x14bootstrap_egress_url\x18\x04 \x03(\tR\x12bootstrapEgressUrl\x12N\n" +
 	"\x18bootstrap_ingress_config\x18\x05 \x03(\v2\x14.google.protobuf.AnyR\x16bootstrapIngressConfig\x12L\n" +
-	"\x17bootstrap_egress_config\x18\x06 \x03(\v2\x14.google.protobuf.AnyR\x15bootstrapEgressConfigB\xc9\x01\n" +
+	"\x17bootstrap_egress_config\x18\x06 \x03(\v2\x14.google.protobuf.AnyR\x15bootstrapEgressConfig\x12:\n" +
+	"\x19bootstrap_egress_outbound\x18\a \x01(\tR\x17bootstrapEgressOutboundB\xc9\x01\n" +
 	"<com.v2ray.core.transport.internet.tlsmirror.mirrorenrollmentP\x01ZLgithub.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/mirrorenrollment\xaa\x028V2Ray.Core.Transport.Internet.Tlsmirror.MirrorEnrollmentb\x06proto3"
 
 var (

--- a/transport/internet/tlsmirror/mirrorenrollment/config.proto
+++ b/transport/internet/tlsmirror/mirrorenrollment/config.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package v2ray.core.transport.internet.tlsmirror.mirrorenrollment;
+option csharp_namespace = "V2Ray.Core.Transport.Internet.Tlsmirror.MirrorEnrollment";
+option go_package = "github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/mirrorenrollment";
+option java_package = "com.v2ray.core.transport.internet.tlsmirror.mirrorenrollment";
+option java_multiple_files = true;
+
+import "common/protoext/extensions.proto";
+import "google/protobuf/any.proto";
+
+message Config {
+  // This will be handled by the TLS Mirror server, the enrollment part only accepts existing connections.
+  string primary_ingress_outbound = 1;
+
+  string primary_egress_outbound = 2;
+  repeated string bootstrap_ingress_url = 3;
+  repeated string bootstrap_egress_url = 4;
+  repeated google.protobuf.Any bootstrap_ingress_config = 5;
+  repeated google.protobuf.Any bootstrap_egress_config = 6;
+  string bootstrap_egress_outbound = 7;
+}

--- a/transport/internet/tlsmirror/mirrorenrollment/enrollment.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/enrollment.go
@@ -1,0 +1,3 @@
+package mirrorenrollment
+
+//go:generate go run github.com/v2fly/v2ray-core/v5/common/errors/errorgen

--- a/transport/internet/tlsmirror/mirrorenrollment/errors.generated.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/errors.generated.go
@@ -1,0 +1,9 @@
+package mirrorenrollment
+
+import "github.com/v2fly/v2ray-core/v5/common/errors"
+
+type errPathObjHolder struct{}
+
+func newError(values ...interface{}) *errors.Error {
+	return errors.New(values...).WithPathObj(errPathObjHolder{})
+}

--- a/transport/internet/tlsmirror/mirrorenrollment/httpenrollmentconfirmation/client.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/httpenrollmentconfirmation/client.go
@@ -30,7 +30,7 @@ func (c *client) VerifyConnectionEnrollment(req *tlsmirror.EnrollmentConfirmatio
 		return nil, newError("failed to marshal enrollment confirmation request").Base(err)
 	}
 
-	serverID := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(req.ServerIdentifier)
+	serverID := base32.NewEncoding("0123456789abcdefghijklmnopqrstuv").WithPadding(base32.NoPadding).EncodeToString(req.ServerIdentifier)
 
 	httpReq, err := http.NewRequest("POST", "http://"+serverID+tlsmirror.EnrollmentVerificationControlConnectionPostfix, bytes.NewReader(requestMessage))
 	if err != nil {

--- a/transport/internet/tlsmirror/mirrorenrollment/httpenrollmentconfirmation/client.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/httpenrollmentconfirmation/client.go
@@ -1,0 +1,56 @@
+package httpenrollmentconfirmation
+
+import (
+	"bytes"
+	"encoding/base32"
+	"io"
+	"net/http"
+
+	protov2 "google.golang.org/protobuf/proto"
+
+	"github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror"
+)
+
+func NewHTTPEnrollmentConfirmationClientFromHTTPRoundTripper(tripper http.RoundTripper) (tlsmirror.ConnectionEnrollmentConfirmation, error) {
+	if tripper == nil {
+		return nil, newError("nil tripper")
+	}
+	return &client{
+		httpRoundTripper: tripper,
+	}, nil
+}
+
+type client struct {
+	httpRoundTripper http.RoundTripper
+}
+
+func (c *client) VerifyConnectionEnrollment(req *tlsmirror.EnrollmentConfirmationReq) (*tlsmirror.EnrollmentConfirmationResp, error) {
+	requestMessage, err := protov2.Marshal(req)
+	if err != nil {
+		return nil, newError("failed to marshal enrollment confirmation request").Base(err)
+	}
+
+	serverID := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(req.ServerIdentifier)
+
+	httpReq, err := http.NewRequest("POST", "http://"+serverID+tlsmirror.EnrollmentVerificationControlConnectionPostfix, bytes.NewReader(requestMessage))
+	if err != nil {
+		return nil, newError("failed to create HTTP request").Base(err)
+	}
+	httpResp, err := c.httpRoundTripper.RoundTrip(httpReq)
+	if err != nil {
+		return nil, newError("failed to send HTTP request").Base(err)
+	}
+	defer httpResp.Body.Close()
+	if httpResp.StatusCode != http.StatusOK {
+		return nil, newError("unexpected HTTP response status: ", httpResp.StatusCode)
+	}
+	responseMessage, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, newError("failed to read HTTP response body").Base(err)
+	}
+	resp := &tlsmirror.EnrollmentConfirmationResp{}
+	if err := protov2.Unmarshal(responseMessage, resp); err != nil {
+		return nil, newError("failed to unmarshal enrollment confirmation response").Base(err)
+	}
+	return resp, nil
+}

--- a/transport/internet/tlsmirror/mirrorenrollment/httpenrollmentconfirmation/clientbuilder.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/httpenrollmentconfirmation/clientbuilder.go
@@ -1,0 +1,88 @@
+package httpenrollmentconfirmation
+
+import (
+	"encoding/base32"
+	"net"
+	"net/http"
+	"sync"
+
+	"github.com/v2fly/v2ray-core/v5/common"
+	"github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror"
+	"github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/httponconnection"
+)
+
+func NewClientRoundTripperForEnrollmentConfirmation(
+	dial func(network, addr string) (net.Conn, error),
+	serverIdentity []byte,
+) (http.RoundTripper, error) {
+	if dial == nil {
+		return nil, newError("nil dial function")
+	}
+	if len(serverIdentity) == 0 {
+		return nil, newError("nil or empty server identity")
+	}
+	return &clientRoundtripper{
+		dial:           dial,
+		serverIdentity: serverIdentity,
+	}, nil
+}
+
+type clientRoundtripper struct {
+	dial           func(network, addr string) (net.Conn, error)
+	serverIdentity []byte
+
+	currentConnInnerConn common.Closable
+	currentConn          http.RoundTripper
+	currentConnLock      sync.RWMutex
+}
+
+func (c *clientRoundtripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	c.currentConnLock.RLock()
+
+	if c.currentConn == nil {
+		c.currentConnLock.RUnlock()
+		if err := c.createNewConnection(); err != nil {
+			return nil, err // Failed to create a new connection
+		}
+		return c.RoundTrip(request)
+	}
+	defer c.currentConnLock.RUnlock()
+
+	// Use the current connection to perform the round trip
+	resp, err := c.currentConn.RoundTrip(request)
+	if err != nil {
+		defer func() {
+			c.currentConnLock.Lock()
+			defer c.currentConnLock.Unlock()
+			if c.currentConn != nil {
+				c.currentConnInnerConn.Close()
+				c.currentConnInnerConn = nil
+				c.currentConn = nil
+			}
+		}()
+		return nil, newError("unable to roundtrip for enrollment verification").Base(err)
+	}
+	return resp, err
+}
+
+func (c *clientRoundtripper) createNewConnection() error {
+	c.currentConnLock.Lock()
+	defer c.currentConnLock.Unlock()
+
+	if c.currentConn != nil {
+		return nil // Connection already exists
+	}
+
+	serverID := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(c.serverIdentity)
+	conn, err := c.dial("tcp", serverID+tlsmirror.EnrollmentVerificationControlConnectionPostfix+":80")
+	if err != nil {
+		return newError("failed to dial server: ", err)
+	}
+	c.currentConnInnerConn = conn
+	c.currentConn, err = httponconnection.NewSingleConnectionHTTPTransport(conn, "h2")
+	if err != nil {
+		conn.Close() // Close the connection if transport creation fails
+		return newError("failed to create HTTP transport: ", err)
+	}
+	return nil
+}

--- a/transport/internet/tlsmirror/mirrorenrollment/httpenrollmentconfirmation/clientbuilder.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/httpenrollmentconfirmation/clientbuilder.go
@@ -73,7 +73,7 @@ func (c *clientRoundtripper) createNewConnection() error {
 		return nil // Connection already exists
 	}
 
-	serverID := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(c.serverIdentity)
+	serverID := base32.NewEncoding("0123456789abcdefghijklmnopqrstuv").WithPadding(base32.NoPadding).EncodeToString(c.serverIdentity)
 	conn, err := c.dial("tcp", serverID+tlsmirror.EnrollmentVerificationControlConnectionPostfix+":80")
 	if err != nil {
 		return newError("failed to dial server: ", err)

--- a/transport/internet/tlsmirror/mirrorenrollment/httpenrollmentconfirmation/enrollment.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/httpenrollmentconfirmation/enrollment.go
@@ -1,0 +1,3 @@
+package httpenrollmentconfirmation
+
+//go:generate go run github.com/v2fly/v2ray-core/v5/common/errors/errorgen

--- a/transport/internet/tlsmirror/mirrorenrollment/httpenrollmentconfirmation/errors.generated.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/httpenrollmentconfirmation/errors.generated.go
@@ -1,0 +1,9 @@
+package httpenrollmentconfirmation
+
+import "github.com/v2fly/v2ray-core/v5/common/errors"
+
+type errPathObjHolder struct{}
+
+func newError(values ...interface{}) *errors.Error {
+	return errors.New(values...).WithPathObj(errPathObjHolder{})
+}

--- a/transport/internet/tlsmirror/mirrorenrollment/httpenrollmentconfirmation/hub.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/httpenrollmentconfirmation/hub.go
@@ -1,0 +1,28 @@
+package httpenrollmentconfirmation
+
+import (
+	"context"
+	"net"
+	"net/http"
+
+	"golang.org/x/net/http2"
+)
+
+func NewHTTPConnectionHub(handler http.Handler) *HTTPConnectionHub {
+	return &HTTPConnectionHub{
+		handler:  handler,
+		h2server: &http2.Server{},
+	}
+}
+
+type HTTPConnectionHub struct {
+	handler  http.Handler
+	h2server *http2.Server
+}
+
+func (h *HTTPConnectionHub) ServeConnection(ctx context.Context, conn net.Conn) error {
+	go h.h2server.ServeConn(conn, &http2.ServeConnOpts{
+		Handler: h.handler,
+	})
+	return nil
+}

--- a/transport/internet/tlsmirror/mirrorenrollment/httpenrollmentconfirmation/server.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/httpenrollmentconfirmation/server.go
@@ -1,0 +1,60 @@
+package httpenrollmentconfirmation
+
+import (
+	"io"
+	"net/http"
+	"strconv"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror"
+)
+
+func NewHTTPEnrollmentConfirmationServerFromConnectionEnrollmentConfirmation(confirmation tlsmirror.ConnectionEnrollmentConfirmation) (http.Handler, error) {
+	if confirmation == nil {
+		return nil, newError("nil confirmation")
+	}
+	return &server{
+		ConnectionEnrollmentConfirmation: confirmation,
+	}, nil
+}
+
+type server struct {
+	tlsmirror.ConnectionEnrollmentConfirmation
+}
+
+func (s *server) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	requestBody, err := io.ReadAll(request.Body)
+	if err != nil {
+		http.Error(writer, "failed to read request body: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	req := &tlsmirror.EnrollmentConfirmationReq{}
+	if err := proto.Unmarshal(requestBody, req); err != nil {
+		http.Error(writer, "failed to unmarshal request: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	resp, err := s.VerifyConnectionEnrollment(req)
+	if err != nil {
+		http.Error(writer, "failed to verify connection enrollment: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	responseBody, err := proto.Marshal(resp)
+	if err != nil {
+		http.Error(writer, "failed to marshal response: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writer.Header().Set("Content-Type", "application/octet-stream")
+	writer.Header().Set("Content-Length", strconv.Itoa(len(responseBody)))
+	writer.WriteHeader(http.StatusOK)
+	if _, err := writer.Write(responseBody); err != nil {
+		http.Error(writer, "failed to write response: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if flusher, ok := writer.(http.Flusher); ok {
+		flusher.Flush()
+	} else {
+		http.Error(writer, "response writer does not support flushing", http.StatusInternalServerError)
+		return
+	}
+}

--- a/transport/internet/tlsmirror/mirrorenrollment/keyderivation.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/keyderivation.go
@@ -1,0 +1,46 @@
+package mirrorenrollment
+
+import (
+	"github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror"
+	"github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/mirrorcrypto"
+)
+
+type EnrollmentKey struct {
+	EnrollmentRequestKey  []byte
+	EnrollmentResponseKey []byte
+}
+
+func DeriveEnrollmentKey(primaryKey []byte, conn tlsmirror.InsertableTLSConn) (*EnrollmentKey, error) {
+	clientRandom, serverRandom, err := conn.GetHandshakeRandom()
+	if err != nil {
+		return nil, newError("failed to get handshake random").Base(err).AtError()
+	}
+
+	return DeriveEnrollmentKeyWithClientAndServerRandom(primaryKey, clientRandom, serverRandom)
+}
+
+func DeriveEnrollmentKeyWithClientAndServerRandom(primaryKey []byte, clientRandom []byte, serverRandom []byte) (*EnrollmentKey, error) {
+	requestKey, responseKey, err := mirrorcrypto.DeriveEncryptionKey(primaryKey, clientRandom, serverRandom,
+		":connection-enrollment-re78HQNM-CmpRnPbr-PNJVRMhu")
+	if err != nil {
+		return nil, newError("failed to derive connection enrollment key").Base(err).AtError()
+	}
+	return &EnrollmentKey{
+		EnrollmentRequestKey:  requestKey,
+		EnrollmentResponseKey: responseKey,
+	}, nil
+}
+
+func DeriveEnrollmentServerIdentifier(primaryKey []byte) ([]byte, error) {
+	if len(primaryKey) != 32 {
+		return nil, newError("invalid primary key size: ", len(primaryKey))
+	}
+
+	// Use HKDF to derive a secondary key
+	serverID, err := mirrorcrypto.DeriveSecondaryKey(primaryKey, ":connection-enrollment-server-identifier-av38NNGF-TJvRw7C3-p8KM8yKd")
+	if err != nil {
+		return nil, newError("unable to	server identifier").Base(err)
+	}
+
+	return serverID, nil
+}

--- a/transport/internet/tlsmirror/mirrorenrollment/keyderivation.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/keyderivation.go
@@ -1,22 +1,12 @@
 package mirrorenrollment
 
 import (
-	"github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror"
 	"github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/mirrorcrypto"
 )
 
 type EnrollmentKey struct {
 	EnrollmentRequestKey  []byte
 	EnrollmentResponseKey []byte
-}
-
-func DeriveEnrollmentKey(primaryKey []byte, conn tlsmirror.InsertableTLSConn) (*EnrollmentKey, error) {
-	clientRandom, serverRandom, err := conn.GetHandshakeRandom()
-	if err != nil {
-		return nil, newError("failed to get handshake random").Base(err).AtError()
-	}
-
-	return DeriveEnrollmentKeyWithClientAndServerRandom(primaryKey, clientRandom, serverRandom)
 }
 
 func DeriveEnrollmentKeyWithClientAndServerRandom(primaryKey []byte, clientRandom []byte, serverRandom []byte) (*EnrollmentKey, error) {

--- a/transport/internet/tlsmirror/mirrorenrollment/server.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/server.go
@@ -1,0 +1,55 @@
+package mirrorenrollment
+
+import (
+	"context"
+	"net"
+
+	"github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror"
+	"github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/mirrorenrollment/httpenrollmentconfirmation"
+)
+
+func NewEnrollmentConfirmationServer(ctx context.Context, config *Config, enrollmentProcessor tlsmirror.ConnectionEnrollmentConfirmationProcessor) (*EnrollmentConfirmationServer, error) {
+	if ctx == nil {
+		return nil, newError("context cannot be nil")
+	}
+
+	if config == nil {
+		return nil, newError("config cannot be nil")
+	}
+
+	if enrollmentProcessor == nil {
+		return nil, newError("enrollment processor cannot be nil")
+	}
+
+	enrollmentHandler, err := httpenrollmentconfirmation.NewHTTPEnrollmentConfirmationServerFromConnectionEnrollmentConfirmation(enrollmentProcessor)
+	if err != nil {
+		return nil, newError("failed to create HTTP enrollment confirmation server").Base(err).AtError()
+	}
+
+	primaryIngressConnectionHandler := httpenrollmentconfirmation.NewHTTPConnectionHub(enrollmentHandler)
+
+	return &EnrollmentConfirmationServer{
+		ctx:                             ctx,
+		config:                          config,
+		enrollmentProcessor:             enrollmentProcessor,
+		primaryIngressConnectionHandler: primaryIngressConnectionHandler,
+	}, nil
+}
+
+type EnrollmentConfirmationServer struct {
+	ctx context.Context
+
+	config *Config
+
+	enrollmentProcessor tlsmirror.ConnectionEnrollmentConfirmationProcessor
+
+	primaryIngressConnectionHandler *httpenrollmentconfirmation.HTTPConnectionHub
+}
+
+func (s *EnrollmentConfirmationServer) HandlePrimaryIngressConnection(ctx context.Context, conn net.Conn) error {
+	err := s.primaryIngressConnectionHandler.ServeConnection(ctx, conn)
+	if err != nil {
+		return newError("failed to handle primary ingress connection").Base(err).AtError()
+	}
+	return nil
+}

--- a/transport/internet/tlsmirror/mirrorenrollment/serverenrollmentprocessor.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/serverenrollmentprocessor.go
@@ -1,0 +1,77 @@
+package mirrorenrollment
+
+import (
+	"context"
+	"sync"
+
+	"github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror"
+)
+
+func NewServerEnrollmentProcessor(primaryKey []byte) (tlsmirror.ConnectionEnrollmentConfirmationProcessor, error) {
+	if len(primaryKey) == 0 {
+		return nil, newError("primary key cannot be empty")
+	}
+
+	serverID, err := DeriveEnrollmentServerIdentifier(primaryKey)
+	if err != nil {
+		return nil, newError("failed to derive server identifier").Base(err).AtError()
+	}
+
+	return &serverEnrollmentProcessor{
+		primaryKey: serverID,
+	}, nil
+}
+
+type serverEnrollmentProcessor struct {
+	primaryKey        []byte
+	activeConnections sync.Map
+}
+
+func (p *serverEnrollmentProcessor) AddConnection(ctx context.Context, conn tlsmirror.InsertableTLSConnForEnrollment) (tlsmirror.RemoveConnectionFunc, error) {
+	if conn == nil {
+		return nil, newError("nil InsertableTLSConnForEnrollment")
+	}
+
+	enrollmentKey, err := DeriveEnrollmentKey(p.primaryKey, conn)
+	if err != nil {
+		return nil, newError("failed to derive enrollment key").Base(err).AtError()
+	}
+
+	if _, loaded := p.activeConnections.LoadOrStore(string(enrollmentKey.EnrollmentRequestKey), conn); loaded {
+		return nil, newError("connection with ID ", enrollmentKey.EnrollmentRequestKey, " already exists")
+	}
+
+	return func() error {
+		p.activeConnections.Delete(string(enrollmentKey.EnrollmentRequestKey))
+		return nil
+	}, nil
+}
+
+func (p *serverEnrollmentProcessor) VerifyConnectionEnrollment(req *tlsmirror.EnrollmentConfirmationReq) (*tlsmirror.EnrollmentConfirmationResp, error) {
+	if req == nil {
+		return nil, newError("nil EnrollmentConfirmationReq")
+	}
+
+	if req.CarrierTlsConnectionClientRandom == nil || req.CarrierTlsConnectionServerRandom == nil {
+		return nil, newError("missing client or server random in EnrollmentConfirmationReq")
+	}
+
+	enrollmentKey, err := DeriveEnrollmentKeyWithClientAndServerRandom(p.primaryKey,
+		req.CarrierTlsConnectionClientRandom, req.CarrierTlsConnectionServerRandom)
+	if err != nil {
+		return nil, newError("failed to derive enrollment key").Base(err).AtError()
+	}
+
+	if conn, ok := p.activeConnections.Load(string(enrollmentKey.EnrollmentRequestKey)); ok {
+		insertableConn, ok := conn.(tlsmirror.InsertableTLSConnForEnrollment)
+		if !ok {
+			return nil, newError("connection does not implement InsertableTLSConnForEnrollment")
+		}
+
+		return insertableConn.VerifyConnectionEnrollment(req)
+	}
+
+	return &tlsmirror.EnrollmentConfirmationResp{
+		Enrolled: false,
+	}, nil
+}

--- a/transport/internet/tlsmirror/mirrorenrollment/serverenrollmentprocessor.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/serverenrollmentprocessor.go
@@ -12,13 +12,8 @@ func NewServerEnrollmentProcessor(primaryKey []byte) (tlsmirror.ConnectionEnroll
 		return nil, newError("primary key cannot be empty")
 	}
 
-	serverID, err := DeriveEnrollmentServerIdentifier(primaryKey)
-	if err != nil {
-		return nil, newError("failed to derive server identifier").Base(err).AtError()
-	}
-
 	return &serverEnrollmentProcessor{
-		primaryKey: serverID,
+		primaryKey: primaryKey,
 	}, nil
 }
 

--- a/transport/internet/tlsmirror/mirrorenrollment/serverenrollmentprocessor.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/serverenrollmentprocessor.go
@@ -27,12 +27,12 @@ type serverEnrollmentProcessor struct {
 	activeConnections sync.Map
 }
 
-func (p *serverEnrollmentProcessor) AddConnection(ctx context.Context, conn tlsmirror.InsertableTLSConnForEnrollment) (tlsmirror.RemoveConnectionFunc, error) {
+func (p *serverEnrollmentProcessor) AddConnection(ctx context.Context, clientRandom, serverRandom []byte, conn tlsmirror.InsertableTLSConnForEnrollment) (tlsmirror.RemoveConnectionFunc, error) {
 	if conn == nil {
 		return nil, newError("nil InsertableTLSConnForEnrollment")
 	}
 
-	enrollmentKey, err := DeriveEnrollmentKey(p.primaryKey, conn)
+	enrollmentKey, err := DeriveEnrollmentKeyWithClientAndServerRandom(p.primaryKey, clientRandom, serverRandom)
 	if err != nil {
 		return nil, newError("failed to derive enrollment key").Base(err).AtError()
 	}

--- a/transport/internet/tlsmirror/server/client.go
+++ b/transport/internet/tlsmirror/server/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/v2fly/v2ray-core/v5/transport/internet"
 	"github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror"
 	"github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/mirrorbase"
+	"github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/mirrorenrollment"
 	"github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/tlstrafficgen"
 )
 
@@ -55,6 +56,8 @@ type persistentMirrorTLSDialer struct {
 	obm outbound.Manager
 
 	explicitNonceCiphersuiteLookup *ciphersuiteLookuper
+
+	enrollmentConfirmationClient *mirrorenrollment.EnrollmentConfirmationClient
 }
 
 func (d *persistentMirrorTLSDialer) init(ctx context.Context, config *Config) error {
@@ -97,10 +100,7 @@ func (d *persistentMirrorTLSDialer) init(ctx context.Context, config *Config) er
 			newError("failed to remove existing handler").WriteToLog()
 		}
 
-		err = d.obm.AddHandler(context.Background(), &Outbound{
-			tag:      d.config.CarrierConnectionTag,
-			listener: d.listener,
-		})
+		err = d.obm.AddHandler(context.Background(), d.outbound)
 		if err != nil {
 			newError("failed to add outbound handler").Base(err).AtWarning().WriteToLog()
 			return
@@ -141,6 +141,18 @@ func (d *persistentMirrorTLSDialer) init(ctx context.Context, config *Config) er
 			return nil
 		}
 	}
+
+	if d.config.ConnectionEnrollment != nil {
+		enrollmentServerIdentifier, err := mirrorenrollment.DeriveEnrollmentServerIdentifier(d.config.PrimaryKey)
+		if err != nil {
+			return newError("failed to derive enrollment server identifier").Base(err).AtError()
+		}
+		d.enrollmentConfirmationClient, err = mirrorenrollment.NewEnrollmentConfirmationClient(d.ctx, d.config.ConnectionEnrollment, enrollmentServerIdentifier)
+		if err != nil {
+			return newError("failed to create enrollment confirmation client").Base(err).AtError()
+		}
+	}
+
 	return nil
 }
 
@@ -191,8 +203,29 @@ type connectionContextGetter interface {
 	GetConnectionContext() context.Context
 }
 
+type verifyConnectionEnrollment interface {
+	VerifyConnectionEnrollmentWithProcessor(connectionEnrollmentConfirmationClient tlsmirror.ConnectionEnrollmentConfirmation) error
+}
+
 func (d *persistentMirrorTLSDialer) handleIncomingReadyConnection(conn internet.Connection) {
 	go func() {
+		if d.config.ConnectionEnrollment != nil {
+			if enrollableConn, ok := conn.(verifyConnectionEnrollment); ok {
+				if d.enrollmentConfirmationClient != nil {
+					err := enrollableConn.VerifyConnectionEnrollmentWithProcessor(d.enrollmentConfirmationClient)
+					if err != nil {
+						newError("failed to verify connection enrollment").Base(err).AtWarning().WriteToLog()
+						return
+					}
+				} else {
+					newError("enrollment confirmation client is not set, connection rejected").AtWarning().WriteToLog()
+					return
+				}
+			} else {
+				newError("connection does not implement verifyConnectionEnrollment, connection rejected").AtWarning().WriteToLog()
+				return
+			}
+		}
 		var waitedForReady bool
 		if getter, ok := conn.(connectionContextGetter); ok {
 			ctx := getter.GetConnectionContext()

--- a/transport/internet/tlsmirror/server/config.pb.go
+++ b/transport/internet/tlsmirror/server/config.pb.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	_ "github.com/v2fly/v2ray-core/v5/common/protoext"
+	mirrorenrollment "github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/mirrorenrollment"
 	tlstrafficgen "github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/tlstrafficgen"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -114,16 +115,17 @@ func (x *TransportLayerPadding) GetEnabled() bool {
 }
 
 type Config struct {
-	state                         protoimpl.MessageState `protogen:"open.v1"`
-	ForwardAddress                string                 `protobuf:"bytes,1,opt,name=forward_address,json=forwardAddress,proto3" json:"forward_address,omitempty"`
-	ForwardPort                   uint32                 `protobuf:"varint,2,opt,name=forward_port,json=forwardPort,proto3" json:"forward_port,omitempty"`
-	ForwardTag                    string                 `protobuf:"bytes,3,opt,name=forward_tag,json=forwardTag,proto3" json:"forward_tag,omitempty"`
-	CarrierConnectionTag          string                 `protobuf:"bytes,4,opt,name=carrier_connection_tag,json=carrierConnectionTag,proto3" json:"carrier_connection_tag,omitempty"`
-	EmbeddedTrafficGenerator      *tlstrafficgen.Config  `protobuf:"bytes,5,opt,name=embedded_traffic_generator,json=embeddedTrafficGenerator,proto3" json:"embedded_traffic_generator,omitempty"`
-	PrimaryKey                    []byte                 `protobuf:"bytes,6,opt,name=primary_key,json=primaryKey,proto3" json:"primary_key,omitempty"`
-	ExplicitNonceCiphersuites     []uint32               `protobuf:"varint,7,rep,packed,name=explicit_nonce_ciphersuites,json=explicitNonceCiphersuites,proto3" json:"explicit_nonce_ciphersuites,omitempty"`
-	DeferInstanceDerivedWriteTime *TimeSpec              `protobuf:"bytes,8,opt,name=defer_instance_derived_write_time,json=deferInstanceDerivedWriteTime,proto3" json:"defer_instance_derived_write_time,omitempty"`
-	TransportLayerPadding         *TransportLayerPadding `protobuf:"bytes,9,opt,name=transport_layer_padding,json=transportLayerPadding,proto3" json:"transport_layer_padding,omitempty"`
+	state                         protoimpl.MessageState   `protogen:"open.v1"`
+	ForwardAddress                string                   `protobuf:"bytes,1,opt,name=forward_address,json=forwardAddress,proto3" json:"forward_address,omitempty"`
+	ForwardPort                   uint32                   `protobuf:"varint,2,opt,name=forward_port,json=forwardPort,proto3" json:"forward_port,omitempty"`
+	ForwardTag                    string                   `protobuf:"bytes,3,opt,name=forward_tag,json=forwardTag,proto3" json:"forward_tag,omitempty"`
+	CarrierConnectionTag          string                   `protobuf:"bytes,4,opt,name=carrier_connection_tag,json=carrierConnectionTag,proto3" json:"carrier_connection_tag,omitempty"`
+	EmbeddedTrafficGenerator      *tlstrafficgen.Config    `protobuf:"bytes,5,opt,name=embedded_traffic_generator,json=embeddedTrafficGenerator,proto3" json:"embedded_traffic_generator,omitempty"`
+	PrimaryKey                    []byte                   `protobuf:"bytes,6,opt,name=primary_key,json=primaryKey,proto3" json:"primary_key,omitempty"`
+	ExplicitNonceCiphersuites     []uint32                 `protobuf:"varint,7,rep,packed,name=explicit_nonce_ciphersuites,json=explicitNonceCiphersuites,proto3" json:"explicit_nonce_ciphersuites,omitempty"`
+	DeferInstanceDerivedWriteTime *TimeSpec                `protobuf:"bytes,8,opt,name=defer_instance_derived_write_time,json=deferInstanceDerivedWriteTime,proto3" json:"defer_instance_derived_write_time,omitempty"`
+	TransportLayerPadding         *TransportLayerPadding   `protobuf:"bytes,9,opt,name=transport_layer_padding,json=transportLayerPadding,proto3" json:"transport_layer_padding,omitempty"`
+	ConnectionEnrollment          *mirrorenrollment.Config `protobuf:"bytes,10,opt,name=connection_enrollment,json=connectionEnrollment,proto3" json:"connection_enrollment,omitempty"`
 	unknownFields                 protoimpl.UnknownFields
 	sizeCache                     protoimpl.SizeCache
 }
@@ -221,16 +223,23 @@ func (x *Config) GetTransportLayerPadding() *TransportLayerPadding {
 	return nil
 }
 
+func (x *Config) GetConnectionEnrollment() *mirrorenrollment.Config {
+	if x != nil {
+		return x.ConnectionEnrollment
+	}
+	return nil
+}
+
 var File_transport_internet_tlsmirror_server_config_proto protoreflect.FileDescriptor
 
 const file_transport_internet_tlsmirror_server_config_proto_rawDesc = "" +
 	"\n" +
-	"0transport/internet/tlsmirror/server/config.proto\x12.v2ray.core.transport.internet.tlsmirror.server\x1a common/protoext/extensions.proto\x1a7transport/internet/tlsmirror/tlstrafficgen/config.proto\"\x88\x01\n" +
+	"0transport/internet/tlsmirror/server/config.proto\x12.v2ray.core.transport.internet.tlsmirror.server\x1a common/protoext/extensions.proto\x1a7transport/internet/tlsmirror/tlstrafficgen/config.proto\x1a:transport/internet/tlsmirror/mirrorenrollment/config.proto\"\x88\x01\n" +
 	"\bTimeSpec\x12)\n" +
 	"\x10base_nanoseconds\x18\x01 \x01(\x04R\x0fbaseNanoseconds\x12Q\n" +
 	"%uniform_random_multiplier_nanoseconds\x18\x02 \x01(\x04R\"uniformRandomMultiplierNanoseconds\"1\n" +
 	"\x15TransportLayerPadding\x12\x18\n" +
-	"\aenabled\x18\x01 \x01(\bR\aenabled\"\xb6\x05\n" +
+	"\aenabled\x18\x01 \x01(\bR\aenabled\"\xad\x06\n" +
 	"\x06Config\x12'\n" +
 	"\x0fforward_address\x18\x01 \x01(\tR\x0eforwardAddress\x12!\n" +
 	"\fforward_port\x18\x02 \x01(\rR\vforwardPort\x12\x1f\n" +
@@ -242,7 +251,9 @@ const file_transport_internet_tlsmirror_server_config_proto_rawDesc = "" +
 	"primaryKey\x12>\n" +
 	"\x1bexplicit_nonce_ciphersuites\x18\a \x03(\rR\x19explicitNonceCiphersuites\x12\x82\x01\n" +
 	"!defer_instance_derived_write_time\x18\b \x01(\v28.v2ray.core.transport.internet.tlsmirror.server.TimeSpecR\x1ddeferInstanceDerivedWriteTime\x12}\n" +
-	"\x17transport_layer_padding\x18\t \x01(\v2E.v2ray.core.transport.internet.tlsmirror.server.TransportLayerPaddingR\x15transportLayerPadding:'\x82\xb5\x18#\n" +
+	"\x17transport_layer_padding\x18\t \x01(\v2E.v2ray.core.transport.internet.tlsmirror.server.TransportLayerPaddingR\x15transportLayerPadding\x12u\n" +
+	"\x15connection_enrollment\x18\n" +
+	" \x01(\v2@.v2ray.core.transport.internet.tlsmirror.mirrorenrollment.ConfigR\x14connectionEnrollment:'\x82\xb5\x18#\n" +
 	"\ttransport\x12\ttlsmirror\x8a\xff)\ttlsmirrorB\xab\x01\n" +
 	"2com.v2ray.core.transport.internet.tlsmirror.serverP\x01ZBgithub.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/server\xaa\x02.V2Ray.Core.Transport.Internet.Tlsmirror.Serverb\x06proto3"
 
@@ -260,20 +271,22 @@ func file_transport_internet_tlsmirror_server_config_proto_rawDescGZIP() []byte 
 
 var file_transport_internet_tlsmirror_server_config_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_transport_internet_tlsmirror_server_config_proto_goTypes = []any{
-	(*TimeSpec)(nil),              // 0: v2ray.core.transport.internet.tlsmirror.server.TimeSpec
-	(*TransportLayerPadding)(nil), // 1: v2ray.core.transport.internet.tlsmirror.server.TransportLayerPadding
-	(*Config)(nil),                // 2: v2ray.core.transport.internet.tlsmirror.server.Config
-	(*tlstrafficgen.Config)(nil),  // 3: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Config
+	(*TimeSpec)(nil),                // 0: v2ray.core.transport.internet.tlsmirror.server.TimeSpec
+	(*TransportLayerPadding)(nil),   // 1: v2ray.core.transport.internet.tlsmirror.server.TransportLayerPadding
+	(*Config)(nil),                  // 2: v2ray.core.transport.internet.tlsmirror.server.Config
+	(*tlstrafficgen.Config)(nil),    // 3: v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Config
+	(*mirrorenrollment.Config)(nil), // 4: v2ray.core.transport.internet.tlsmirror.mirrorenrollment.Config
 }
 var file_transport_internet_tlsmirror_server_config_proto_depIdxs = []int32{
 	3, // 0: v2ray.core.transport.internet.tlsmirror.server.Config.embedded_traffic_generator:type_name -> v2ray.core.transport.internet.tlsmirror.tlstrafficgen.Config
 	0, // 1: v2ray.core.transport.internet.tlsmirror.server.Config.defer_instance_derived_write_time:type_name -> v2ray.core.transport.internet.tlsmirror.server.TimeSpec
 	1, // 2: v2ray.core.transport.internet.tlsmirror.server.Config.transport_layer_padding:type_name -> v2ray.core.transport.internet.tlsmirror.server.TransportLayerPadding
-	3, // [3:3] is the sub-list for method output_type
-	3, // [3:3] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	4, // 3: v2ray.core.transport.internet.tlsmirror.server.Config.connection_enrollment:type_name -> v2ray.core.transport.internet.tlsmirror.mirrorenrollment.Config
+	4, // [4:4] is the sub-list for method output_type
+	4, // [4:4] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_transport_internet_tlsmirror_server_config_proto_init() }

--- a/transport/internet/tlsmirror/server/config.proto
+++ b/transport/internet/tlsmirror/server/config.proto
@@ -8,6 +8,7 @@ option java_multiple_files = true;
 
 import "common/protoext/extensions.proto";
 import "transport/internet/tlsmirror/tlstrafficgen/config.proto";
+import "transport/internet/tlsmirror/mirrorenrollment/config.proto";
 
 message TimeSpec {
   uint64 base_nanoseconds = 1;
@@ -40,4 +41,7 @@ message Config {
   TimeSpec defer_instance_derived_write_time = 8;
 
   TransportLayerPadding transport_layer_padding = 9;
+
+  v2ray.core.transport.internet.tlsmirror.mirrorenrollment.Config connection_enrollment = 10;
+
 }

--- a/transport/internet/tlsmirror/server/hub.go
+++ b/transport/internet/tlsmirror/server/hub.go
@@ -18,7 +18,10 @@ func ListenTLSMirror(ctx context.Context, address net.Address, port net.Port,
 		return nil, newError("failed to listen TLS mirror").Base(err)
 	}
 
-	tlsMirrorServer := NewServer(ctx, listener, tlsMirrorSettings, handler)
+	tlsMirrorServer, err := NewServer(ctx, listener, tlsMirrorSettings, handler)
+	if err != nil {
+		return nil, newError("failed to create TLS mirror server").Base(err)
+	}
 
 	go tlsMirrorServer.accepts()
 


### PR DESCRIPTION
This pull request adds a Connection Enrollment verification system to TLSMirror. This system is designed to use a slower connection to verify if the connection to the tlsmirror inbound is being hijacked to the original site to detect if client is sending traffics that could not be processed by the original server. This feature close the hole that would allow an in path attacker to detect the connection. 