### PR TITLE
Add TLSMirror Sequence Watermarking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ errorgen
 *.dat
 *~
 [._]*.un~
+
+.golangci.yml

--- a/transport/internet/tlsmirror/interface.go
+++ b/transport/internet/tlsmirror/interface.go
@@ -11,6 +11,9 @@ type TLSRecord struct {
 	LegacyProtocolVersion [2]byte
 	RecordLength          uint16
 	Fragment              []byte
+
+	// Annotations are used to store additional information about the record. Never sent over the wire.
+	InsertedMessage bool
 }
 
 type RecordReader interface {

--- a/transport/internet/tlsmirror/mirrorbase/conn.go
+++ b/transport/internet/tlsmirror/mirrorbase/conn.go
@@ -15,7 +15,11 @@ import (
 
 // NewMirroredTLSConn creates a new mirrored TLS connection.
 // No stable interface
-func NewMirroredTLSConn(ctx context.Context, clientConn net.Conn, serverConn net.Conn, onC2SMessage, onS2CMessage tlsmirror.MessageHook, closable common.Closable, explicitNonceDetection tlsmirror.ExplicitNonceDetection) tlsmirror.InsertableTLSConn {
+func NewMirroredTLSConn(ctx context.Context, clientConn net.Conn,
+	serverConn net.Conn, onC2SMessage, onS2CMessage tlsmirror.MessageHook,
+	closable common.Closable, explicitNonceDetection tlsmirror.ExplicitNonceDetection,
+	onC2SMessageTx, onS2CMessageTx tlsmirror.MessageHook,
+) tlsmirror.InsertableTLSConn {
 	explicitNonceDetectionReady, explicitNonceDetectionOver := context.WithCancel(ctx)
 	c := &conn{
 		ctx:                         ctx,
@@ -28,6 +32,8 @@ func NewMirroredTLSConn(ctx context.Context, clientConn net.Conn, serverConn net
 		explicitNonceDetection:      explicitNonceDetection,
 		explicitNonceDetectionReady: explicitNonceDetectionReady,
 		explicitNonceDetectionOver:  explicitNonceDetectionOver,
+		OnC2SMessageTx:              onC2SMessageTx,
+		OnS2CMessageTx:              onS2CMessageTx,
 	}
 	c.ctx, c.done = context.WithCancel(ctx)
 	go c.c2sWorker()
@@ -53,6 +59,9 @@ type conn struct {
 	OnC2SMessage           tlsmirror.MessageHook
 	OnS2CMessage           tlsmirror.MessageHook
 	explicitNonceDetection tlsmirror.ExplicitNonceDetection
+
+	OnC2SMessageTx tlsmirror.MessageHook
+	OnS2CMessageTx tlsmirror.MessageHook
 
 	c2sInsert chan *tlsmirror.TLSRecord
 	s2cInsert chan *tlsmirror.TLSRecord
@@ -180,6 +189,17 @@ func (c *conn) c2sWorker() {
 						nonce := c.c2sExplicitNonceCounterGenerator()
 						copy(record.Fragment, nonce)
 					}
+				}
+			}
+			if c.OnC2SMessageTx != nil {
+				drop, err := c.OnC2SMessageTx(record)
+				if err != nil {
+					c.done()
+					newError("failed to process C2S message").Base(err).AtWarning().WriteToLog()
+					return
+				}
+				if drop {
+					continue
 				}
 			}
 			err := recordWriter.WriteRecord(record, false)
@@ -325,6 +345,17 @@ func (c *conn) s2cWorker() {
 						nonce := c.s2cExplicitNonceCounterGenerator()
 						copy(record.Fragment, nonce)
 					}
+				}
+			}
+			if c.OnS2CMessageTx != nil {
+				drop, err := c.OnS2CMessageTx(record)
+				if err != nil {
+					c.done()
+					newError("failed to process S2C message").Base(err).AtWarning().WriteToLog()
+					return
+				}
+				if drop {
+					continue
 				}
 			}
 			err := recordWriter.WriteRecord(record, false)

--- a/transport/internet/tlsmirror/mirrorcrypto/derive_key.go
+++ b/transport/internet/tlsmirror/mirrorcrypto/derive_key.go
@@ -46,3 +46,31 @@ func DeriveSecondaryKey(primaryKey []byte, tag string) ([]byte, error) {
 
 	return secondaryKey, nil
 }
+
+func DeriveSequenceWatermarkingKey(primaryKey, clientRandom, serverRandom []byte, tag string) ([]byte, []byte, error) {
+	if len(primaryKey) != 32 {
+		return nil, nil, newError("invalid primary key size: ", len(primaryKey))
+	}
+	if len(clientRandom) != 32 {
+		return nil, nil, newError("invalid client random size: ", len(clientRandom))
+	}
+	if len(serverRandom) != 32 {
+		return nil, nil, newError("invalid server random size: ", len(serverRandom))
+	}
+
+	// Concatenate the primary key, client random, and server random
+	combined := append(primaryKey, clientRandom...) // nolint: gocritic
+	combined = append(combined, serverRandom...)
+
+	encryptionKey, err := hkdf.Expand(sha256.New, combined, "v2ray-xv64FXUU-GxMn8UYz-bTy6UDeE:tlsmirror-sequence-watermark"+tag, 32)
+	if err != nil {
+		return nil, nil, newError("unable to derive encryption key").Base(err)
+	}
+
+	nonceMask, err := hkdf.Expand(sha256.New, combined, "v2ray-xv64FXUU-GxMn8UYz-bTy6UDeE:tlsmirror-sequence-watermark"+tag, 24)
+	if err != nil {
+		return nil, nil, newError("unable to derive nonce mask").Base(err)
+	}
+
+	return encryptionKey, nonceMask, nil
+}

--- a/transport/internet/tlsmirror/server/client.go
+++ b/transport/internet/tlsmirror/server/client.go
@@ -183,20 +183,21 @@ func (d *persistentMirrorTLSDialer) handleIncomingCarrierConnection(ctx context.
 
 	ctx, cancel := context.WithCancel(ctx)
 	cconnState := &clientConnState{
-		ctx:                   ctx,
-		done:                  cancel,
-		localAddr:             conn.LocalAddr(),
-		remoteAddr:            conn.RemoteAddr(),
-		handler:               d.handleIncomingReadyConnection,
-		primaryKey:            d.config.PrimaryKey,
-		readPipe:              make(chan []byte, 1),
-		firstWrite:            true,
-		firstWriteDelay:       firstWriteDelay,
-		transportLayerPadding: d.config.TransportLayerPadding,
+		ctx:                      ctx,
+		done:                     cancel,
+		localAddr:                conn.LocalAddr(),
+		remoteAddr:               conn.RemoteAddr(),
+		handler:                  d.handleIncomingReadyConnection,
+		primaryKey:               d.config.PrimaryKey,
+		readPipe:                 make(chan []byte, 1),
+		firstWrite:               true,
+		firstWriteDelay:          firstWriteDelay,
+		transportLayerPadding:    d.config.TransportLayerPadding,
+		sequenceWatermarkEnabled: d.config.SequenceWatermarkingEnabled,
 	}
 
 	cconnState.mirrorConn = mirrorbase.NewMirroredTLSConn(ctx, conn, forwardConn, cconnState.onC2SMessage, cconnState.onS2CMessage, conn,
-		d.explicitNonceCiphersuiteLookup.Lookup)
+		d.explicitNonceCiphersuiteLookup.Lookup, cconnState.onC2SMessageTx, cconnState.onS2CMessageTx)
 }
 
 type connectionContextGetter interface {

--- a/transport/internet/tlsmirror/server/config.pb.go
+++ b/transport/internet/tlsmirror/server/config.pb.go
@@ -126,6 +126,7 @@ type Config struct {
 	DeferInstanceDerivedWriteTime *TimeSpec                `protobuf:"bytes,8,opt,name=defer_instance_derived_write_time,json=deferInstanceDerivedWriteTime,proto3" json:"defer_instance_derived_write_time,omitempty"`
 	TransportLayerPadding         *TransportLayerPadding   `protobuf:"bytes,9,opt,name=transport_layer_padding,json=transportLayerPadding,proto3" json:"transport_layer_padding,omitempty"`
 	ConnectionEnrollment          *mirrorenrollment.Config `protobuf:"bytes,10,opt,name=connection_enrollment,json=connectionEnrollment,proto3" json:"connection_enrollment,omitempty"`
+	SequenceWatermarkingEnabled   bool                     `protobuf:"varint,11,opt,name=sequence_watermarking_enabled,json=sequenceWatermarkingEnabled,proto3" json:"sequence_watermarking_enabled,omitempty"`
 	unknownFields                 protoimpl.UnknownFields
 	sizeCache                     protoimpl.SizeCache
 }
@@ -230,6 +231,13 @@ func (x *Config) GetConnectionEnrollment() *mirrorenrollment.Config {
 	return nil
 }
 
+func (x *Config) GetSequenceWatermarkingEnabled() bool {
+	if x != nil {
+		return x.SequenceWatermarkingEnabled
+	}
+	return false
+}
+
 var File_transport_internet_tlsmirror_server_config_proto protoreflect.FileDescriptor
 
 const file_transport_internet_tlsmirror_server_config_proto_rawDesc = "" +
@@ -239,7 +247,7 @@ const file_transport_internet_tlsmirror_server_config_proto_rawDesc = "" +
 	"\x10base_nanoseconds\x18\x01 \x01(\x04R\x0fbaseNanoseconds\x12Q\n" +
 	"%uniform_random_multiplier_nanoseconds\x18\x02 \x01(\x04R\"uniformRandomMultiplierNanoseconds\"1\n" +
 	"\x15TransportLayerPadding\x12\x18\n" +
-	"\aenabled\x18\x01 \x01(\bR\aenabled\"\xad\x06\n" +
+	"\aenabled\x18\x01 \x01(\bR\aenabled\"\xf1\x06\n" +
 	"\x06Config\x12'\n" +
 	"\x0fforward_address\x18\x01 \x01(\tR\x0eforwardAddress\x12!\n" +
 	"\fforward_port\x18\x02 \x01(\rR\vforwardPort\x12\x1f\n" +
@@ -253,7 +261,8 @@ const file_transport_internet_tlsmirror_server_config_proto_rawDesc = "" +
 	"!defer_instance_derived_write_time\x18\b \x01(\v28.v2ray.core.transport.internet.tlsmirror.server.TimeSpecR\x1ddeferInstanceDerivedWriteTime\x12}\n" +
 	"\x17transport_layer_padding\x18\t \x01(\v2E.v2ray.core.transport.internet.tlsmirror.server.TransportLayerPaddingR\x15transportLayerPadding\x12u\n" +
 	"\x15connection_enrollment\x18\n" +
-	" \x01(\v2@.v2ray.core.transport.internet.tlsmirror.mirrorenrollment.ConfigR\x14connectionEnrollment:'\x82\xb5\x18#\n" +
+	" \x01(\v2@.v2ray.core.transport.internet.tlsmirror.mirrorenrollment.ConfigR\x14connectionEnrollment\x12B\n" +
+	"\x1dsequence_watermarking_enabled\x18\v \x01(\bR\x1bsequenceWatermarkingEnabled:'\x82\xb5\x18#\n" +
 	"\ttransport\x12\ttlsmirror\x8a\xff)\ttlsmirrorB\xab\x01\n" +
 	"2com.v2ray.core.transport.internet.tlsmirror.serverP\x01ZBgithub.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/server\xaa\x02.V2Ray.Core.Transport.Internet.Tlsmirror.Serverb\x06proto3"
 

--- a/transport/internet/tlsmirror/server/config.proto
+++ b/transport/internet/tlsmirror/server/config.proto
@@ -44,4 +44,6 @@ message Config {
 
   v2ray.core.transport.internet.tlsmirror.mirrorenrollment.Config connection_enrollment = 10;
 
+  bool sequence_watermarking_enabled = 11;
+
 }

--- a/transport/internet/tlsmirror/server/server.go
+++ b/transport/internet/tlsmirror/server/server.go
@@ -113,16 +113,17 @@ func (s *Server) accept(clientConn net.Conn, serverConn net.Conn) {
 	}
 
 	conn := &connState{
-		ctx:                   ctx,
-		done:                  cancel,
-		localAddr:             clientConn.LocalAddr(),
-		remoteAddr:            clientConn.RemoteAddr(),
-		primaryKey:            s.config.PrimaryKey,
-		handler:               s.onIncomingReadyConnection,
-		readPipe:              make(chan []byte, 1),
-		firstWrite:            true,
-		firstWriteDelay:       firstWriteDelay,
-		transportLayerPadding: s.config.TransportLayerPadding,
+		ctx:                      ctx,
+		done:                     cancel,
+		localAddr:                clientConn.LocalAddr(),
+		remoteAddr:               clientConn.RemoteAddr(),
+		primaryKey:               s.config.PrimaryKey,
+		handler:                  s.onIncomingReadyConnection,
+		readPipe:                 make(chan []byte, 1),
+		firstWrite:               true,
+		firstWriteDelay:          firstWriteDelay,
+		transportLayerPadding:    s.config.TransportLayerPadding,
+		sequenceWatermarkEnabled: s.config.SequenceWatermarkingEnabled,
 	}
 
 	if s.config.ConnectionEnrollment != nil {
@@ -131,7 +132,7 @@ func (s *Server) accept(clientConn net.Conn, serverConn net.Conn) {
 	}
 
 	conn.mirrorConn = mirrorbase.NewMirroredTLSConn(ctx, clientConn, serverConn, conn.onC2SMessage, conn.onS2CMessage, conn,
-		s.explicitNonceCiphersuiteLookup.Lookup)
+		s.explicitNonceCiphersuiteLookup.Lookup, conn.onC2SMessageTx, conn.onS2CMessageTx)
 }
 
 func (s *Server) onIncomingReadyConnection(conn internet.Connection) {


### PR DESCRIPTION
This pull request adds sequence watermarking support to TLSMirror.

Following some discussion with Fangliding(https://t.me/v2fly_chat/366660), I begin working on adding sequence watermarking on TLSMirror. 

I already explained how it works, which I [quote](https://github.com/net4people/bbs/issues/496#issuecomment-3042002780):

After the first encrypted frame is inserted, the last 16 bytes of encrypted data in each subsequent encrypted TLS frame will be re-encrypted in place based on the sender's sequence number. On the receiving end, the data will first be decrypted in place using the receiver's sequence number before attempting to decrypt or forward it to the original connection. If the sequence number is incorrect, decryption will fail both at the TLSMirror end and at the remote end, and then the remote end will handle it according to the normal TLS error handling process (this error cannot be detected at the TLSMirror, but that's fine because letting the forwarding end handle the error actually makes more senses when it comes to anti-censorship purpose).

If a packet get delivered out of order(no matter it is produced by an real tls implementation (real client or forwarded site) or TLSMirror, then its authentication tag would be invalided by sequence watermarking, by XOR it will 2 different watermark key material, thus can't be decrypted by either TLSMirror (at which point get forwarded to forwarded site) or the forwarded site, and get a error response from forwarded site.

If a packet is delivered in order, then it get XORed with the same watermarking key material twice, and restoring it to the original state.