### PR TITLE
 limit TTL value range and add Dns response ttl Configuration v4 

### DIFF
--- a/infra/conf/v4/dns_proxy.go
+++ b/infra/conf/v4/dns_proxy.go
@@ -9,22 +9,26 @@ import (
 )
 
 type DNSOutboundConfig struct {
-	Network   cfgcommon.Network  `json:"network"`
-	Address   *cfgcommon.Address `json:"address"`
-	Port      uint16             `json:"port"`
-	UserLevel uint32             `json:"userLevel"`
+   Network             cfgcommon.Network  `json:"network"`
+   Address             *cfgcommon.Address `json:"address"`
+   Port                uint16             `json:"port"`
+   UserLevel           uint32             `json:"userLevel"`
+   OverrideResponseTtl bool               `json:"overrideresponseTtl"`
+   ResponseTtl         uint32             `json:"responseTtl"`
 }
 
 func (c *DNSOutboundConfig) Build() (proto.Message, error) {
-	config := &dns.Config{
-		Server: &net.Endpoint{
-			Network: c.Network.Build(),
-			Port:    uint32(c.Port),
-		},
-		UserLevel: c.UserLevel,
-	}
-	if c.Address != nil {
-		config.Server.Address = c.Address.Build()
-	}
-	return config, nil
+   config := &dns.Config{
+	   Server: &net.Endpoint{
+		   Network: c.Network.Build(),
+		   Port:    uint32(c.Port),
+	   },
+	   UserLevel: c.UserLevel,
+	   OverrideResponseTtl: c.OverrideResponseTtl,
+	   ResponseTtl:         c.ResponseTtl,
+   }
+   if c.Address != nil {
+	   config.Server.Address = c.Address.Build()
+   }
+   return config, nil
 }

--- a/proxy/dns/dns.go
+++ b/proxy/dns/dns.go
@@ -251,7 +251,16 @@ func (h *Handler) handleIPQuery(id uint16, qType dnsmessage.Type, domain string,
 
 	var ttl uint32 = 600
 	if h.config.OverrideResponseTtl {
-		ttl = h.config.ResponseTtl
+		// RFC 1035: TTL 32-Bit unsigned Integer, 0 .. 4294967295
+		const maxTTL uint32 = 4294967295
+		const minTTL uint32 = 0
+		if h.config.ResponseTtl > maxTTL {
+			ttl = maxTTL
+		} else if h.config.ResponseTtl < minTTL {
+			ttl = minTTL
+		} else {
+			ttl = h.config.ResponseTtl
+		}
 	}
 
 	switch qType {


### PR DESCRIPTION
1.  Backporting Response TTL Configuration from v5 to v4 fixes: 

- #3381 

2. limit TTL value range in `handleIPQuery `according RFC 1035

- https://github.com/v2fly/v2ray-core/pull/3323#issuecomment-2806775227