### PR TITLE
Add transient storage lifecycle receiver framework

### DIFF
--- a/common/environment/rootcap_impl.go
+++ b/common/environment/rootcap_impl.go
@@ -74,7 +74,8 @@ func (r *rootEnvImpl) DropProxyEnvironment(tag string) error {
 	if err != nil {
 		return err
 	}
-	return transientStorage.DropScope(r.ctx, tag)
+	transientStorage.Clear(r.ctx)
+	return r.transientStorage.DropScope(r.ctx, tag)
 }
 
 type appEnvImpl struct {

--- a/features/extension/storage/storage.go
+++ b/features/extension/storage/storage.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 
+	"github.com/v2fly/v2ray-core/v5/common"
 	"github.com/v2fly/v2ray-core/v5/features"
 )
 
@@ -32,3 +33,8 @@ type ScopedPersistentStorageService interface {
 }
 
 var ScopedPersistentStorageServiceType = (*ScopedPersistentStorageService)(nil)
+
+type TransientStorageLifecycleReceiver interface {
+	IsTransientStorageLifecycleReceiver()
+	common.Closable
+}


### PR DESCRIPTION
This framework adds support for clearing up residual resources allocated by a transport when its associated proxy is removed.

This is designed to help with long running proxies with subscription managed outbounds to avoid consuming unnecessary resources.  