### PR TITLE
Fix custom tls setting for tlsmirror roundtripper enrollment

### DIFF
--- a/transport/internet/request/roundtripper/httprt/httprt.go
+++ b/transport/internet/request/roundtripper/httprt/httprt.go
@@ -77,6 +77,9 @@ func (h *httpTripperClient) RoundTrip(ctx context.Context, req request.Request, 
 		return resp, err
 	}
 	defer httpResp.Body.Close()
+	if httpResp.StatusCode != http.StatusOK {
+		newError("non-200 response: ", httpResp.Status).AtInfo().WriteToLog()
+	}
 	if streamingWriter == nil {
 		result, err := io.ReadAll(httpResp.Body)
 		if err != nil {

--- a/transport/internet/tlsmirror/mirrorenrollment/roundtripperenrollmentconfirmation/client.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/roundtripperenrollmentconfirmation/client.go
@@ -90,7 +90,11 @@ func (c *Client) Dial(ctx context.Context) (net.Conn, error) {
 		return nil, newError("failed to dial to destination").Base(err).AtError()
 	}
 	if c.config.SecurityConfig != nil {
-		securityEngine, err := common.CreateObject(c.ctx, c.config.SecurityConfig)
+		securityConfigSetting, err := serial.GetInstanceOf(c.config.SecurityConfig)
+		if err != nil {
+			return nil, newError("unable to get security config instance").Base(err)
+		}
+		securityEngine, err := common.CreateObject(c.ctx, securityConfigSetting)
 		if err != nil {
 			return nil, newError("unable to create security engine from security settings").Base(err)
 		}

--- a/transport/internet/tlsmirror/mirrorenrollment/roundtripperenrollmentconfirmation/serverinverserole.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/roundtripperenrollmentconfirmation/serverinverserole.go
@@ -99,7 +99,11 @@ func (c *ServerInverseRole) Dial(ctx context.Context) (net.Conn, error) {
 		return nil, newError("failed to dial to destination").Base(err).AtError()
 	}
 	if c.config.SecurityConfig != nil {
-		securityEngine, err := common.CreateObject(ctx, c.config.SecurityConfig)
+		securityConfigSetting, err := serial.GetInstanceOf(c.config.SecurityConfig)
+		if err != nil {
+			return nil, newError("unable to get security config instance").Base(err)
+		}
+		securityEngine, err := common.CreateObject(c.ctx, securityConfigSetting)
 		if err != nil {
 			return nil, newError("unable to create security engine from security settings").Base(err)
 		}


### PR DESCRIPTION
This pull request fix up the custom tls(security) setting for tlsmirror roundtripper enrollment. This allow the use of an public shared tls mirror enrollment server.