### PR TITLE
avoid DNS leakage with gRPC transports

### DIFF
--- a/transport/internet/grpc/dial.go
+++ b/transport/internet/grpc/dial.go
@@ -142,6 +142,7 @@ func getGrpcClient(ctx context.Context, dest net.Destination, dialOption grpc.Di
 			detachedContext := core.ToBackgroundDetachedContext(ctx)
 			return internet.DialSystem(detachedContext, net.TCPDestination(address, port), streamSettings.SocketSettings)
 		}),
+		grpc.WithDisableServiceConfig(),
 	)
 	canceller = func() {
 		stateTyped.scopedDialerAccess.Lock()


### PR DESCRIPTION
currently, v2ray queries TXT record for domain formats in `_grpc_config.<invalid.test>` when gRPC transport is used, this could potentially being exploited by censorships as an indicator.

despite this behaviour is a part of standard and is the current best practice mandated by grpc developers, according to https://github.com/grpc/proposal/blob/master/A2-service-configs-in-dns.md#encoding-in-dns-txt-records, while considering its potential degradation to protocol "stealthiness", this patch disables this behaviour by appending a `DialOption` returned by `grpc.WithDisableServiceConfig()`.