### PR TITLE
log the real client ip when using grpc transport

### DIFF
--- a/common/protocol/grpc/metadata.go
+++ b/common/protocol/grpc/metadata.go
@@ -1,0 +1,23 @@
+package grpc
+
+import (
+	"strings"
+
+	"google.golang.org/grpc/metadata"
+
+	"github.com/v2fly/v2ray-core/v5/common/net"
+)
+
+// ParseXForwardedFor parses X-Forwarded-For metadata in gRPC metadata, and return the IP list in it.
+func ParseXForwardedFor(md metadata.MD) []net.Address {
+	xff := md.Get("X-Forwarded-For")
+	if len(xff) == 0 {
+		return nil
+	}
+	list := strings.Split(xff[0], ",")
+	addrs := make([]net.Address, 0, len(list))
+	for _, proxy := range list {
+		addrs = append(addrs, net.ParseAddress(proxy))
+	}
+	return addrs
+}

--- a/common/protocol/grpc/metadata_test.go
+++ b/common/protocol/grpc/metadata_test.go
@@ -1,0 +1,19 @@
+package grpc_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/v2fly/v2ray-core/v5/common/net"
+	. "github.com/v2fly/v2ray-core/v5/common/protocol/grpc"
+)
+
+func TestParseXForwardedFor(t *testing.T) {
+	md := metadata.Pairs("X-Forwarded-For", "129.78.138.66, 129.78.64.103")
+	addrs := ParseXForwardedFor(md)
+	if r := cmp.Diff(addrs, []net.Address{net.ParseAddress("129.78.138.66"), net.ParseAddress("129.78.64.103")}); r != "" {
+		t.Error(r)
+	}
+}


### PR DESCRIPTION
resolve: https://github.com/v2fly/v2ray-core/issues/1026
original pr: https://github.com/v2fly/v2ray-core/pull/1032

This PR rebases the original pr on top of the main branch.

Tested with a GRPC server behind NGINX proxy.
