### PR TITLE
log the real client ip when using httpupgrade transport

### DIFF
--- a/transport/internet/httpupgrade/connection.go
+++ b/transport/internet/httpupgrade/connection.go
@@ -23,6 +23,13 @@ type connection struct {
 
 type delayedDialer func(earlyData []byte) (conn net.Conn, earlyReply io.Reader, err error)
 
+func newConnection(conn net.Conn, remoteAddr net.Addr) *connection {
+	return &connection{
+		conn:       conn,
+		remoteAddr: remoteAddr,
+	}
+}
+
 func newConnectionWithPendingRead(conn net.Conn, remoteAddr net.Addr, earlyReplyReader io.Reader) *connection {
 	return &connection{
 		conn:       conn,


### PR DESCRIPTION
#3329 
Through testing with Nginx, the real IP address can be obtained, not 127.0.0.1.