### PR TITLE
Add sticky choice option for leastping

### DIFF
--- a/app/router/config.pb.go
+++ b/app/router/config.pb.go
@@ -507,6 +507,7 @@ func (x *StrategyRandomConfig) GetAliveOnly() bool {
 type StrategyLeastPingConfig struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ObserverTag   string                 `protobuf:"bytes,7,opt,name=observer_tag,json=observerTag,proto3" json:"observer_tag,omitempty"`
+	StickyChoice  bool                   `protobuf:"varint,8,opt,name=sticky_choice,json=stickyChoice,proto3" json:"sticky_choice,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -546,6 +547,13 @@ func (x *StrategyLeastPingConfig) GetObserverTag() string {
 		return x.ObserverTag
 	}
 	return ""
+}
+
+func (x *StrategyLeastPingConfig) GetStickyChoice() bool {
+	if x != nil {
+		return x.StickyChoice
+	}
+	return false
 }
 
 type StrategyLeastLoadConfig struct {
@@ -996,9 +1004,10 @@ const file_app_router_config_proto_rawDesc = "" +
 	"\fobserver_tag\x18\a \x01(\tR\vobserverTag\x12\x1d\n" +
 	"\n" +
 	"alive_only\x18\b \x01(\bR\taliveOnly:\x16\x82\xb5\x18\x12\n" +
-	"\bbalancer\x12\x06random\"W\n" +
+	"\bbalancer\x12\x06random\"|\n" +
 	"\x17StrategyLeastPingConfig\x12!\n" +
-	"\fobserver_tag\x18\a \x01(\tR\vobserverTag:\x19\x82\xb5\x18\x15\n" +
+	"\fobserver_tag\x18\a \x01(\tR\vobserverTag\x12#\n" +
+	"\rsticky_choice\x18\b \x01(\bR\fstickyChoice:\x19\x82\xb5\x18\x15\n" +
 	"\bbalancer\x12\tleastping\"\x84\x02\n" +
 	"\x17StrategyLeastLoadConfig\x12;\n" +
 	"\x05costs\x18\x02 \x03(\v2%.v2ray.core.app.router.StrategyWeightR\x05costs\x12\x1c\n" +

--- a/app/router/config.proto
+++ b/app/router/config.proto
@@ -97,6 +97,8 @@ message StrategyLeastPingConfig {
   option (v2ray.core.common.protoext.message_opt).short_name = "leastping";
 
   string observer_tag = 7;
+
+  bool sticky_choice = 8;
 }
 
 message StrategyLeastLoadConfig {

--- a/app/router/strategy_leastping.go
+++ b/app/router/strategy_leastping.go
@@ -5,6 +5,7 @@ package router
 
 import (
 	"context"
+	"sync"
 
 	core "github.com/v2fly/v2ray-core/v5"
 	"github.com/v2fly/v2ray-core/v5/app/observatory"
@@ -18,6 +19,9 @@ type LeastPingStrategy struct {
 	observatory extension.Observatory
 
 	config *StrategyLeastPingConfig
+
+	lock       sync.Mutex
+	lastChoice string
 }
 
 func (l *LeastPingStrategy) GetPrincipleTarget(strings []string) []string {
@@ -60,6 +64,14 @@ func (l *LeastPingStrategy) PickOutbound(strings []string) string {
 				selectedOutboundName = v.OutboundTag
 				leastPing = v.Delay
 			}
+		}
+		{
+			l.lock.Lock()
+			if selectedOutboundName == "" && l.config.StickyChoice {
+				selectedOutboundName = l.lastChoice
+			}
+			l.lastChoice = selectedOutboundName
+			l.lock.Unlock()
 		}
 		return selectedOutboundName
 	}


### PR DESCRIPTION
(AI Generated Summary)
This pull request adds a new "sticky choice" feature to the `StrategyLeastPingConfig` load balancing strategy. This feature allows the strategy to remember and reuse the last selected outbound when enabled, potentially improving connection stability. The implementation introduces a new configuration field, updates the protobuf definitions and generated code, and modifies the strategy logic to support this behavior.

**Sticky choice feature for least ping strategy:**

* Added a new `sticky_choice` boolean field to the `StrategyLeastPingConfig` protobuf message and regenerated the corresponding Go code to include this option. [[1]](diffhunk://#diff-d5f917bb9b54e688185910719ce107b3cd034d724867901fede73fa3f3755458R100-R101) [[2]](diffhunk://#diff-a5b86abc7c9178203fd28ea036435e3178c9187f23a3574e07844f80673a4a67R510) [[3]](diffhunk://#diff-a5b86abc7c9178203fd28ea036435e3178c9187f23a3574e07844f80673a4a67R552-R558) [[4]](diffhunk://#diff-a5b86abc7c9178203fd28ea036435e3178c9187f23a3574e07844f80673a4a67L999-R1010)
* Updated the `LeastPingStrategy` struct in `strategy_leastping.go` to include a mutex and a `lastChoice` field for thread-safe tracking of the last selected outbound. [[1]](diffhunk://#diff-84ee82edbf2c5d67b12bc3e8780a1cd3b902b404809e3a6f8435255d7aa20f2cR8) [[2]](diffhunk://#diff-84ee82edbf2c5d67b12bc3e8780a1cd3b902b404809e3a6f8435255d7aa20f2cR22-R24)
* Modified the `PickOutbound` method to reuse the last selected outbound if `sticky_choice` is enabled and no new outbound is selected, ensuring thread safety with locking.