### PR TITLE
Add support for enrollment links in tlsmirror

### DIFF
--- a/main/distro/all/all.go
+++ b/main/distro/all/all.go
@@ -92,6 +92,8 @@ import (
 	_ "github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/mirrorenrollment/roundtripperenrollmentconfirmation"
 	_ "github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/server"
 
+	_ "github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/mirrorenrollment/clicommand"
+
 	// Transport headers
 	_ "github.com/v2fly/v2ray-core/v5/transport/internet/headers/http"
 	_ "github.com/v2fly/v2ray-core/v5/transport/internet/headers/noop"

--- a/transport/internet/tlsmirror/mirrorenrollment/clicommand/enrollmentlink_cli.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/clicommand/enrollmentlink_cli.go
@@ -1,0 +1,103 @@
+package clicommand
+
+import (
+	"flag"
+	"io"
+	"os"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	anypb "google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/v2fly/v2ray-core/v5/main/commands/all/engineering"
+	"github.com/v2fly/v2ray-core/v5/main/commands/base"
+	mirrorenrollment "github.com/v2fly/v2ray-core/v5/transport/internet/tlsmirror/mirrorenrollment"
+)
+
+var (
+	inputPath  *string
+	outputPath *string
+	mode       *string
+)
+
+var cmdEnrollmentLink = &base.Command{
+	UsageLine: "{{.Exec}} engineering tlsmirror-enrollment-link",
+	Flag: func() flag.FlagSet {
+		fs := flag.NewFlagSet("tlsmirror-enrollment-link", flag.ExitOnError)
+		inputPath = fs.String("c", "", "input file path (optional, defaults to stdin)")
+		outputPath = fs.String("o", "", "output file path (default stdout)")
+		mode = fs.String("mode", "link", "conversion mode: 'link' to convert JSON -> link, 'json' to convert link -> JSON")
+		return *fs
+	}(),
+	Run: func(cmd *base.Command, args []string) {
+		if err := cmd.Flag.Parse(args); err != nil {
+			base.Fatalf("failed to parse flags: %v", err)
+		}
+
+		var content []byte
+		var err error
+		if *inputPath == "" {
+			// Read from stdin when -c is omitted.
+			content, err = io.ReadAll(os.Stdin)
+			if err != nil {
+				base.Fatalf("failed to read from stdin: %v", err)
+			}
+		} else {
+			fd, err := os.Open(*inputPath)
+			if err != nil {
+				base.Fatalf("failed to open input file %q: %v", *inputPath, err)
+			}
+			defer fd.Close()
+
+			content, err = io.ReadAll(fd)
+			if err != nil {
+				base.Fatalf("failed to read input file %q: %v", *inputPath, err)
+			}
+		}
+
+		var outBytes []byte
+		switch *mode {
+		case "link":
+			// Expect protobuf JSON for google.protobuf.Any, convert to a data URL link.
+			var any anypb.Any
+			if err := protojson.Unmarshal(content, &any); err != nil {
+				base.Fatalf("failed to unmarshal JSON into google.protobuf.Any: %v", err)
+			}
+			link, err := mirrorenrollment.LinkFromAny(&any)
+			if err != nil {
+				base.Fatalf("failed to create link from Any: %v", err)
+			}
+			outBytes = []byte(link)
+
+		case "json":
+			// Expect link (data URL or other supported forms), convert to protobuf JSON.
+			link := string(content)
+			any, err := mirrorenrollment.AnyFromLink(link)
+			if err != nil {
+				base.Fatalf("failed to parse link into Any: %v", err)
+			}
+			b, err := protojson.Marshal(any)
+			if err != nil {
+				base.Fatalf("failed to marshal Any to JSON: %v", err)
+			}
+			outBytes = b
+
+		default:
+			base.Fatalf("unknown mode: %s", *mode)
+		}
+
+		if *outputPath == "" {
+			if _, err := os.Stdout.Write(outBytes); err != nil {
+				base.Fatalf("failed to write output to stdout: %v", err)
+			}
+			return
+		}
+
+		if err := os.WriteFile(*outputPath, outBytes, 0o644); err != nil {
+			base.Fatalf("failed to write output file %q: %v", *outputPath, err)
+		}
+	},
+}
+
+func init() {
+	engineering.AddCommand(cmdEnrollmentLink)
+}

--- a/transport/internet/tlsmirror/mirrorenrollment/client.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/client.go
@@ -27,6 +27,20 @@ func NewEnrollmentConfirmationClient(
 		return nil, newError("config cannot be nil")
 	}
 
+	for _, handler := range config.BootstrapEgressUrl {
+		if handler == "" {
+			return nil, newError("bootstrap ingress URL cannot be empty")
+		}
+		anyPb, err := AnyFromLink(handler)
+		if err != nil {
+			return nil, newError("invalid bootstrap ingress URL").Base(err).AtError()
+		}
+		if anyPb == nil {
+			return nil, newError("bootstrap ingress URL did not produce valid Any")
+		}
+		config.BootstrapEgressConfig = append(config.BootstrapEgressConfig, anyPb)
+	}
+
 	ecc := &EnrollmentConfirmationClient{
 		ctx:            ctx,
 		config:         config,

--- a/transport/internet/tlsmirror/mirrorenrollment/enrollmentlink.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/enrollmentlink.go
@@ -1,0 +1,94 @@
+package mirrorenrollment
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+	anypb "google.golang.org/protobuf/types/known/anypb"
+)
+
+const (
+	// MIME type used for enrollment data URLs.
+	enrollmentDataMIME = "application/vnd.v2ray.tlsmirror-enrollment"
+)
+
+// LinkFromAny converts a protobuf Any into a data URL string.
+// The produced link has form:
+// data:application/vnd.v2ray.tlsmirror-enrollment;base64,<base64(payload)>
+// where payload is the marshaled Any message encoded with standard base64 (with padding).
+func LinkFromAny(a *anypb.Any) (string, error) {
+	if a == nil {
+		return "", newError("nil Any")
+	}
+	b, err := proto.Marshal(a)
+	if err != nil {
+		return "", newError("failed to marshal Any").Base(err)
+	}
+	enc := base64.StdEncoding.EncodeToString(b)
+	dataURL := "data:" + enrollmentDataMIME + ";base64," + enc
+	return dataURL, nil
+}
+
+// AnyFromLink converts a string link (now primarily a data URL) back to *anypb.Any.
+// Accepted formats (strict): only data URLs matching the exact MIME type and base64 encoding.
+func AnyFromLink(link string) (*anypb.Any, error) {
+	if link == "" {
+		return nil, newError("empty link")
+	}
+
+	// Must be a data URL.
+	if !strings.HasPrefix(link, "data:") {
+		return nil, newError("input must be a data URL")
+	}
+
+	// Parse and split header and payload at the first comma.
+	comma := strings.Index(link, ",")
+	if comma == -1 || comma+1 >= len(link) {
+		return nil, newError("invalid data URL: missing payload")
+	}
+
+	meta := link[len("data:"):comma]
+	payload := link[comma+1:]
+
+	// Meta should be like "<mime-type>;base64" possibly with additional params.
+	metaParts := strings.Split(meta, ";")
+	if len(metaParts) < 2 {
+		return nil, newError("invalid data URL metadata")
+	}
+
+	// First part must match our expected MIME.
+	if metaParts[0] != enrollmentDataMIME {
+		return nil, newError("unexpected MIME type in data URL: " + metaParts[0])
+	}
+
+	// Ensure "base64" is present in parameters.
+	isBase64 := false
+	for _, p := range metaParts[1:] {
+		if p == "base64" {
+			isBase64 = true
+			break
+		}
+	}
+	if !isBase64 {
+		return nil, newError("data URL must be base64 encoded")
+	}
+
+	// No URL parsing/decoding of payload: payload is raw base64.
+	raw, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		return nil, newError("failed to base64-decode data URL payload").Base(err)
+	}
+
+	var any anypb.Any
+	if err := proto.Unmarshal(raw, &any); err != nil {
+		return nil, newError("failed to unmarshal Any from decoded payload").Base(err)
+	}
+	return &any, nil
+}
+
+// helper to format an error when newError is not available at call site
+func fmtErr(format string, a ...interface{}) error {
+	return fmt.Errorf(format, a...)
+}

--- a/transport/internet/tlsmirror/mirrorenrollment/enrollmentlink_test.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/enrollmentlink_test.go
@@ -1,0 +1,208 @@
+package mirrorenrollment
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+	anypb "google.golang.org/protobuf/types/known/anypb"
+)
+
+func TestLinkRoundTrip(t *testing.T) {
+	orig := &anypb.Any{
+		TypeUrl: "type.test/example",
+		Value:   []byte("sample-payload-bytes"),
+	}
+
+	link, err := LinkFromAny(orig)
+	if err != nil {
+		t.Fatalf("LinkFromAny failed: %v", err)
+	}
+	if !strings.HasPrefix(link, "data:") {
+		t.Fatalf("expected data URL prefix, got: %s", link)
+	}
+
+	decoded, err := AnyFromLink(link)
+	if err != nil {
+		t.Fatalf("AnyFromLink failed: %v", err)
+	}
+	if !proto.Equal(decoded, orig) {
+		t.Fatalf("decoded Any does not match original.\nOriginal: %#v\nDecoded: %#v", orig, decoded)
+	}
+}
+
+func TestLinkFromAnyProducesValidDataURL(t *testing.T) {
+	orig := &anypb.Any{TypeUrl: "type.test/inspect", Value: []byte("inspect-bytes")}
+	link, err := LinkFromAny(orig)
+	if err != nil {
+		t.Fatalf("LinkFromAny failed: %v", err)
+	}
+	if !strings.HasPrefix(link, "data:") {
+		t.Fatalf("expected data URL prefix, got: %s", link)
+	}
+	comma := strings.Index(link, ",")
+	if comma == -1 {
+		t.Fatalf("no comma in data URL: %s", link)
+	}
+	meta := link[len("data:"):comma]
+	payload := link[comma+1:]
+	if !strings.HasPrefix(meta, enrollmentDataMIME) {
+		t.Fatalf("unexpected MIME in meta: %s", meta)
+	}
+	if !strings.Contains(meta, "base64") {
+		t.Fatalf("expected base64 param in meta: %s", meta)
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		t.Fatalf("failed to decode payload with std encoding: %v", err)
+	}
+	var any anypb.Any
+	if err := proto.Unmarshal(raw, &any); err != nil {
+		t.Fatalf("unmarshal payload failed: %v", err)
+	}
+	if !proto.Equal(&any, orig) {
+		t.Fatalf("unmarshaled Any does not equal original\nwant=%v\ngot=%v", orig, &any)
+	}
+}
+
+func TestLegacyTLSMirrorScheme(t *testing.T) {
+	orig := &anypb.Any{
+		TypeUrl: "type.test/legacy",
+		Value:   []byte("legacy-bytes"),
+	}
+	marshaled, err := proto.Marshal(orig)
+	if err != nil {
+		t.Fatalf("failed to marshal orig Any: %v", err)
+	}
+	enc := base64.RawURLEncoding.EncodeToString(marshaled)
+	legacyLink := "tlsmirror-enrollment:" + enc
+
+	if _, err := AnyFromLink(legacyLink); err == nil {
+		t.Fatalf("expected AnyFromLink to reject legacy link format, but it succeeded")
+	}
+}
+
+func TestPlainBase64Input(t *testing.T) {
+	orig := &anypb.Any{
+		TypeUrl: "type.test/plain",
+		Value:   []byte("plain-bytes"),
+	}
+	marshaled, err := proto.Marshal(orig)
+	if err != nil {
+		t.Fatalf("failed to marshal orig Any: %v", err)
+	}
+	enc := base64.StdEncoding.EncodeToString(marshaled)
+	// Pass plain base64 (no scheme) - should be rejected in strict mode
+	if _, err := AnyFromLink(enc); err == nil {
+		t.Fatalf("expected AnyFromLink to reject plain base64 input, but it succeeded")
+	}
+}
+
+func TestInvalidInput(t *testing.T) {
+	if _, err := AnyFromLink("not-a-valid-base64@@"); err == nil {
+		t.Fatalf("expected error for invalid input, got nil")
+	}
+
+	if _, err := LinkFromAny(nil); err == nil {
+		t.Fatalf("expected error for LinkFromAny(nil), got nil")
+	}
+}
+
+func TestRejectWrongMIME(t *testing.T) {
+	orig := &anypb.Any{TypeUrl: "type.test/wrongmime", Value: []byte("x")}
+	b, _ := proto.Marshal(orig)
+	enc := base64.StdEncoding.EncodeToString(b)
+	link := fmt.Sprintf("data:application/octet-stream;base64,%s", enc)
+	if _, err := AnyFromLink(link); err == nil {
+		t.Fatalf("expected rejection for wrong MIME type, but got success")
+	}
+}
+
+func TestRejectMissingBase64Param(t *testing.T) {
+	orig := &anypb.Any{TypeUrl: "type.test/nobase64", Value: []byte("x")}
+	b, _ := proto.Marshal(orig)
+	enc := base64.StdEncoding.EncodeToString(b)
+	link := fmt.Sprintf("data:%s,%s", enrollmentDataMIME, enc) // no ;base64
+	if _, err := AnyFromLink(link); err == nil {
+		t.Fatalf("expected rejection for missing base64 param, but got success")
+	}
+}
+
+func TestAcceptExtraParams(t *testing.T) {
+	orig := &anypb.Any{TypeUrl: "type.test/params", Value: []byte("p")}
+	b, _ := proto.Marshal(orig)
+	enc := base64.StdEncoding.EncodeToString(b)
+	link := fmt.Sprintf("data:%s;v=1;base64;foo=bar,%s", enrollmentDataMIME, enc)
+	any, err := AnyFromLink(link)
+	if err != nil {
+		t.Fatalf("expected success for extra params, got error: %v", err)
+	}
+	if !proto.Equal(any, orig) {
+		t.Fatalf("decoded Any mismatch; want %v got %v", orig, any)
+	}
+}
+
+func TestRejectNonBase64Payload(t *testing.T) {
+	link := "data:" + enrollmentDataMIME + ";base64,not-base64-@@@"
+	if _, err := AnyFromLink(link); err == nil {
+		t.Fatalf("expected error for non-base64 payload, got nil")
+	}
+}
+
+func TestRejectURLEncodedPayload(t *testing.T) {
+	// percent-encoded payload
+	orig := &anypb.Any{TypeUrl: "type.test/urlenc", Value: []byte("url-bytes")}
+	b, _ := proto.Marshal(orig)
+	enc := base64.StdEncoding.EncodeToString(b)
+	// percent-encode first few chars
+	pct := "%" + enc[:2] + enc[2:]
+	link := fmt.Sprintf("data:%s;base64,%s", enrollmentDataMIME, pct)
+	if _, err := AnyFromLink(link); err == nil {
+		t.Fatalf("expected rejection for percent-encoded payload, got success")
+	}
+}
+
+func TestCaseSensitiveMIME(t *testing.T) {
+	orig := &anypb.Any{TypeUrl: "type.test/case", Value: []byte("c")}
+	b, _ := proto.Marshal(orig)
+	enc := base64.StdEncoding.EncodeToString(b)
+	link := fmt.Sprintf("data:%s;base64,%s", strings.ToUpper(enrollmentDataMIME), enc)
+	if _, err := AnyFromLink(link); err == nil {
+		t.Fatalf("expected rejection for case mismatch MIME, got success")
+	}
+}
+
+func TestLargePayloadRoundTrip(t *testing.T) {
+	// create a ~100KB payload
+	size := 100 * 1024
+	p := make([]byte, size)
+	if _, err := rand.Read(p); err != nil {
+		t.Fatalf("failed to generate random payload: %v", err)
+	}
+	orig := &anypb.Any{TypeUrl: "type.test/large", Value: p}
+	link, err := LinkFromAny(orig)
+	if err != nil {
+		t.Fatalf("LinkFromAny failed: %v", err)
+	}
+	any, err := AnyFromLink(link)
+	if err != nil {
+		t.Fatalf("AnyFromLink failed for large payload: %v", err)
+	}
+	if !proto.Equal(any, orig) {
+		t.Fatalf("large payload mismatch after roundtrip")
+	}
+}
+
+func TestRejectRawURLEncodingInDataURL(t *testing.T) {
+	orig := &anypb.Any{TypeUrl: "type.test/rawurl", Value: []byte("raw")}
+	b, _ := proto.Marshal(orig)
+	enc := base64.RawURLEncoding.EncodeToString(b)
+	link := fmt.Sprintf("data:%s;base64,%s", enrollmentDataMIME, enc)
+	if _, err := AnyFromLink(link); err == nil {
+		t.Fatalf("expected rejection for raw URL base64 payload, got success")
+	}
+}

--- a/transport/internet/tlsmirror/mirrorenrollment/server.go
+++ b/transport/internet/tlsmirror/mirrorenrollment/server.go
@@ -19,6 +19,20 @@ func NewEnrollmentConfirmationServer(ctx context.Context, config *Config, enroll
 		return nil, newError("config cannot be nil")
 	}
 
+	for _, handler := range config.BootstrapIngressUrl {
+		if handler == "" {
+			return nil, newError("bootstrap ingress URL cannot be empty")
+		}
+		anyPb, err := AnyFromLink(handler)
+		if err != nil {
+			return nil, newError("invalid bootstrap ingress URL").Base(err).AtError()
+		}
+		if anyPb == nil {
+			return nil, newError("bootstrap ingress URL did not produce valid Any")
+		}
+		config.BootstrapIngressConfig = append(config.BootstrapIngressConfig, anyPb)
+	}
+
 	if enrollmentProcessor == nil {
 		return nil, newError("enrollment processor cannot be nil")
 	}


### PR DESCRIPTION
(Machine Generated Summary:)

This pull request introduces support for strict, MIME-typed data URL encoding and decoding of TLS mirror enrollment links, along with a CLI tool and comprehensive tests. The changes ensure that enrollment links are handled in a robust, well-defined way, and integrate this handling into both client and server configuration paths.

**Enrollment Link Handling and CLI Integration:**

* Added `LinkFromAny` and `AnyFromLink` functions in `enrollmentlink.go` to convert between protobuf `Any` messages and strict data URLs with the MIME type `application/vnd.v2ray.tlsmirror-enrollment`. Only data URLs with this exact MIME type and base64 encoding are accepted.
* Introduced a new CLI command in `clicommand/enrollmentlink_cli.go` for converting between JSON and link formats, supporting stdin/stdout and file I/O, and registering the command with the engineering CLI.
* Updated both client (`client.go`) and server (`server.go`) initialization to parse bootstrap ingress/egress URLs using the new strict `AnyFromLink` function, rejecting empty or invalid URLs and converting them to protobuf `Any` configs. [[1]](diffhunk://#diff-3259ebc8ba0693803cfb7a3950d17e346a77f61f7e7211a139a78fa3a2ba1d1cR30-R43) [[2]](diffhunk://#diff-7493b489da6d8b623ad89d63c4ea82f2b73113305d62b7919ee4488626c290afR22-R35)

**Testing and Validation:**

* Added extensive tests in `enrollmentlink_test.go` to validate round-trip encoding/decoding, strictness of MIME type and encoding, rejection of legacy/invalid formats, and handling of large payloads and extra parameters.

**Project Integration:**

* Registered the new CLI command in the main build by updating the imports in `main/distro/all/all.go`.