### PR TITLE
Generalize IP address parsing in TUN stack options

### DIFF
--- a/app/tun/option.go
+++ b/app/tun/option.go
@@ -44,7 +44,7 @@ func SetSpoofing(id tcpip.NICID, enable bool) StackOption {
 func AddProtocolAddress(id tcpip.NICID, ips []*routercommon.CIDR) StackOption {
 	return func(s *stack.Stack) error {
 		for _, ip := range ips {
-			tcpIPAddr := tcpip.AddrFrom4Slice(ip.Ip)
+			tcpIPAddr := tcpip.AddrFromSlice(ip.Ip)
 			protocolAddress := tcpip.ProtocolAddress{
 				AddressWithPrefix: tcpip.AddressWithPrefix{
 					Address:   tcpIPAddr,
@@ -75,7 +75,7 @@ func SetRouteTable(id tcpip.NICID, routes []*routercommon.CIDR) StackOption {
 		s.SetRouteTable(func() (table []tcpip.Route) {
 			for _, cidrs := range routes {
 				subnet := tcpip.AddressWithPrefix{
-					Address:   tcpip.AddrFrom4Slice(cidrs.Ip),
+					Address:   tcpip.AddrFromSlice(cidrs.Ip),
 					PrefixLen: int(cidrs.Prefix),
 				}.Subnet()
 				route := tcpip.Route{


### PR DESCRIPTION
- Replaced `tcpip.AddrFrom4Slice` with `tcpip.AddrFromSlice` in `AddProtocolAddress` to support generic IP versions.
- Updated `SetRouteTable` to use `tcpip.AddrFromSlice` for subnet address calculations.