### PR TITLE
Improve API instance support

### DIFF
--- a/main/v2binding/startUp.go
+++ b/main/v2binding/startUp.go
@@ -13,7 +13,7 @@ func (b *bindingInstance) setBaseDir(baseDir string) {
 	b.baseDir = baseDir
 	attentionFile := path.Join(baseDir, "place your config file here.txt")
 	{
-		f, err := os.OpenFile(attentionFile, os.O_RDONLY|os.O_CREATE, 0666)
+		f, err := os.OpenFile(attentionFile, os.O_RDONLY|os.O_CREATE, 0o666)
 		if err != nil {
 			return
 		}

--- a/main/v2binding/v2binding.go
+++ b/main/v2binding/v2binding.go
@@ -101,7 +101,7 @@ func StartAPIInstance(basedir string) {
 		err := binding.loadDefaultConfigIfExists()
 		if err != nil {
 			fmt.Println(err)
-			os.WriteFile("last_err.txt", []byte(err.Error()), 0644)
+			os.WriteFile("last_err.txt", []byte(err.Error()), 0o644)
 		}
 	}
 }


### PR DESCRIPTION
(Machine Generated Summary)
This pull request introduces improvements to the startup process for the `v2binding` package, focusing on better handling of configuration files and instance initialization. The changes add support for setting a base directory, loading a default configuration if present, and improving error reporting. Additionally, the API instance is now bound to the local host for increased security.

Configuration and startup enhancements:

* Added a `baseDir` field to the `bindingInstance` struct and implemented the `setBaseDir` method to set the working directory and create an attention file for configuration placement. [[1]](diffhunk://#diff-794754ad8cc51fcccd65694a3ca1206811e8beda7da8982b981d65b96d37ffa3R26) [[2]](diffhunk://#diff-f2e420e190a67096816cf0e51b5824ed66007d7d64f9d0928aa08fca5ec78a81R1-R49)
* Introduced the `loadDefaultConfigIfExists` method to automatically load and start a default instance from `config.json` if it exists in the base directory. [[1]](diffhunk://#diff-f2e420e190a67096816cf0e51b5824ed66007d7d64f9d0928aa08fca5ec78a81R1-R49) [[2]](diffhunk://#diff-794754ad8cc51fcccd65694a3ca1206811e8beda7da8982b981d65b96d37ffa3R98-R106)
* Updated the startup sequence in `StartAPIInstance` to set the base directory and attempt to load the default configuration, logging errors to `last_err.txt` if loading fails.

Security improvement:

* Changed the API instance listener from `net.AnyIP` to `net.LocalHostIP`, restricting access to localhost only.