### PR TITLE
Better server failure detection and PreserveSourceIPPortWhenDestNATMa…

### DIFF
--- a/common/natTraversal/stun/natTypeTest.go
+++ b/common/natTraversal/stun/natTypeTest.go
@@ -641,6 +641,10 @@ func (t *NATTypeTest) CalcReminderValues() error {
 			if tc.Resp == nil || tc.RespFrom == nil || tc.ReqSentTo == nil {
 				continue
 			}
+			// Only count hairpin packets: responses that are binding requests (not binding responses)
+			if tc.Resp.Type != stun.BindingRequest {
+				continue
+			}
 			respPairCount++
 			if tc.RespFrom.String() != tc.ReqSentTo.String() {
 				allSendToMatchRespFrom = false


### PR DESCRIPTION
(Machine Generated)
This pull request introduces improvements to the NAT mapping behavior tests in `common/natTraversal/stun/natTypeTest.go`. The main focus is on increasing the reliability of the mapping behavior test by validating the distinctness of test endpoints and refining the logic for determining whether source IP and port are preserved during NAT traversal.

Validation improvements for mapping behavior:

* Added a check to ensure that `OTHER-ADDRESS` from the STUN server differs from the primary server in both IP and port, preventing false positives in mapping behavior tests.

Refined NAT mapping detection logic:

* Updated the `CalcReminderValues` method to prioritize using the `RESPONSE-ORIGIN` attribute for detecting preservation of source IP and port, falling back to hairpin detection only if `RESPONSE-ORIGIN` is unavailable. This improves accuracy in determining NAT mapping characteristics.
* Improved fallback logic to more reliably detect whether source address rewriting occurs when `RESPONSE-ORIGIN` is not present, ensuring the NAT mapping result is set appropriately.…