### PR TITLE
Fix HTTP/1.1 CONNECT response close

### DIFF
--- a/proxy/http/client.go
+++ b/proxy/http/client.go
@@ -213,7 +213,6 @@ func setUpHTTPTunnel(ctx context.Context, dest net.Destination, target string, u
 			rawConn.Close()
 			return nil, nil, err
 		}
-		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
 			rawConn.Close()


### PR DESCRIPTION
This dates back to 5e99737.

HTTP/1.1 outbound is currently incompatible with Caddy forwardproxy. Example Caddyfile to test:

```
:80 {
	route {
		forward_proxy {
		}
	}
}
```