### PR TITLE
Add Google Docs Viewer based transport

### DIFF
--- a/main/distro/all/all.go
+++ b/main/distro/all/all.go
@@ -74,10 +74,12 @@ import (
 	_ "github.com/v2fly/v2ray-core/v5/transport/internet/request/assembly"
 
 	_ "github.com/v2fly/v2ray-core/v5/transport/internet/request/assembler/simple"
+	_ "github.com/v2fly/v2ray-core/v5/transport/internet/request/roundtripper/gdocsviewer"
 	_ "github.com/v2fly/v2ray-core/v5/transport/internet/request/roundtripper/httprt"
 
 	_ "github.com/v2fly/v2ray-core/v5/transport/internet/request/assembler/packetconn"
 
+	_ "github.com/v2fly/v2ray-core/v5/transport/internet/request/stereotype/gdocsviewer"
 	_ "github.com/v2fly/v2ray-core/v5/transport/internet/request/stereotype/meek"
 	_ "github.com/v2fly/v2ray-core/v5/transport/internet/request/stereotype/mekya"
 

--- a/transport/internet/request/roundtripper/gdocsviewer/config.pb.go
+++ b/transport/internet/request/roundtripper/gdocsviewer/config.pb.go
@@ -1,0 +1,350 @@
+package gdocsviewer
+
+import (
+	_ "github.com/v2fly/v2ray-core/v5/common/protoext"
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+)
+
+const (
+	// Verify that this generated code is sufficiently up-to-date.
+	_ = protoimpl.EnforceVersion(20 - protoimpl.MinVersion)
+	// Verify that runtime/protoimpl is sufficiently up-to-date.
+	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
+)
+
+type ClientConfig struct {
+	state                     protoimpl.MessageState      `protogen:"open.v1"`
+	ViewerUrl                 string                      `protobuf:"bytes,1,opt,name=viewer_url,json=viewerUrl,proto3" json:"viewer_url,omitempty"`
+	TextUrl                   string                      `protobuf:"bytes,2,opt,name=text_url,json=textUrl,proto3" json:"text_url,omitempty"`
+	OriginUrl                 string                      `protobuf:"bytes,3,opt,name=origin_url,json=originUrl,proto3" json:"origin_url,omitempty"`
+	ViewerHostHeader          string                      `protobuf:"bytes,4,opt,name=viewer_host_header,json=viewerHostHeader,proto3" json:"viewer_host_header,omitempty"`
+	UserAgent                 string                      `protobuf:"bytes,5,opt,name=user_agent,json=userAgent,proto3" json:"user_agent,omitempty"`
+	AllowHttp                 bool                        `protobuf:"varint,6,opt,name=allow_http,json=allowHttp,proto3" json:"allow_http,omitempty"`
+	H2PoolSize                int32                       `protobuf:"varint,7,opt,name=h2_pool_size,json=h2PoolSize,proto3" json:"h2_pool_size,omitempty"`
+	MaxViewerBodyBytes        int32                       `protobuf:"varint,8,opt,name=max_viewer_body_bytes,json=maxViewerBodyBytes,proto3" json:"max_viewer_body_bytes,omitempty"`
+	MinRequestIntervalMs      int32                       `protobuf:"varint,9,opt,name=min_request_interval_ms,json=minRequestIntervalMs,proto3" json:"min_request_interval_ms,omitempty"`
+	SharedKey                 []byte                      `protobuf:"bytes,10,opt,name=shared_key,json=sharedKey,proto3" json:"shared_key,omitempty"`
+	OriginUrlReplacementRules []*OriginUrlReplacementRule `protobuf:"bytes,11,rep,name=origin_url_replacement_rules,json=originUrlReplacementRules,proto3" json:"origin_url_replacement_rules,omitempty"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
+}
+
+func (x *ClientConfig) Reset() {
+	*x = ClientConfig{}
+	mi := &file_transport_internet_request_roundtripper_gdocsviewer_config_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClientConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClientConfig) ProtoMessage() {}
+
+func (x *ClientConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_transport_internet_request_roundtripper_gdocsviewer_config_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClientConfig.ProtoReflect.Descriptor instead.
+func (*ClientConfig) Descriptor() ([]byte, []int) {
+	return file_transport_internet_request_roundtripper_gdocsviewer_config_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *ClientConfig) GetViewerUrl() string {
+	if x != nil {
+		return x.ViewerUrl
+	}
+	return ""
+}
+
+func (x *ClientConfig) GetTextUrl() string {
+	if x != nil {
+		return x.TextUrl
+	}
+	return ""
+}
+
+func (x *ClientConfig) GetOriginUrl() string {
+	if x != nil {
+		return x.OriginUrl
+	}
+	return ""
+}
+
+func (x *ClientConfig) GetViewerHostHeader() string {
+	if x != nil {
+		return x.ViewerHostHeader
+	}
+	return ""
+}
+
+func (x *ClientConfig) GetUserAgent() string {
+	if x != nil {
+		return x.UserAgent
+	}
+	return ""
+}
+
+func (x *ClientConfig) GetAllowHttp() bool {
+	if x != nil {
+		return x.AllowHttp
+	}
+	return false
+}
+
+func (x *ClientConfig) GetH2PoolSize() int32 {
+	if x != nil {
+		return x.H2PoolSize
+	}
+	return 0
+}
+
+func (x *ClientConfig) GetMaxViewerBodyBytes() int32 {
+	if x != nil {
+		return x.MaxViewerBodyBytes
+	}
+	return 0
+}
+
+func (x *ClientConfig) GetMinRequestIntervalMs() int32 {
+	if x != nil {
+		return x.MinRequestIntervalMs
+	}
+	return 0
+}
+
+func (x *ClientConfig) GetSharedKey() []byte {
+	if x != nil {
+		return x.SharedKey
+	}
+	return nil
+}
+
+func (x *ClientConfig) GetOriginUrlReplacementRules() []*OriginUrlReplacementRule {
+	if x != nil {
+		return x.OriginUrlReplacementRules
+	}
+	return nil
+}
+
+type ServerConfig struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	PathPrefix       string                 `protobuf:"bytes,1,opt,name=path_prefix,json=pathPrefix,proto3" json:"path_prefix,omitempty"`
+	MaxRequestBytes  int32                  `protobuf:"varint,2,opt,name=max_request_bytes,json=maxRequestBytes,proto3" json:"max_request_bytes,omitempty"`
+	MaxResponseBytes int32                  `protobuf:"varint,3,opt,name=max_response_bytes,json=maxResponseBytes,proto3" json:"max_response_bytes,omitempty"`
+	SharedKey        []byte                 `protobuf:"bytes,4,opt,name=shared_key,json=sharedKey,proto3" json:"shared_key,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *ServerConfig) Reset() {
+	*x = ServerConfig{}
+	mi := &file_transport_internet_request_roundtripper_gdocsviewer_config_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ServerConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ServerConfig) ProtoMessage() {}
+
+func (x *ServerConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_transport_internet_request_roundtripper_gdocsviewer_config_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ServerConfig.ProtoReflect.Descriptor instead.
+func (*ServerConfig) Descriptor() ([]byte, []int) {
+	return file_transport_internet_request_roundtripper_gdocsviewer_config_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *ServerConfig) GetPathPrefix() string {
+	if x != nil {
+		return x.PathPrefix
+	}
+	return ""
+}
+
+func (x *ServerConfig) GetMaxRequestBytes() int32 {
+	if x != nil {
+		return x.MaxRequestBytes
+	}
+	return 0
+}
+
+func (x *ServerConfig) GetMaxResponseBytes() int32 {
+	if x != nil {
+		return x.MaxResponseBytes
+	}
+	return 0
+}
+
+func (x *ServerConfig) GetSharedKey() []byte {
+	if x != nil {
+		return x.SharedKey
+	}
+	return nil
+}
+
+type OriginUrlReplacementRule struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Pattern       string                 `protobuf:"bytes,2,opt,name=pattern,proto3" json:"pattern,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OriginUrlReplacementRule) Reset() {
+	*x = OriginUrlReplacementRule{}
+	mi := &file_transport_internet_request_roundtripper_gdocsviewer_config_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OriginUrlReplacementRule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OriginUrlReplacementRule) ProtoMessage() {}
+
+func (x *OriginUrlReplacementRule) ProtoReflect() protoreflect.Message {
+	mi := &file_transport_internet_request_roundtripper_gdocsviewer_config_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OriginUrlReplacementRule.ProtoReflect.Descriptor instead.
+func (*OriginUrlReplacementRule) Descriptor() ([]byte, []int) {
+	return file_transport_internet_request_roundtripper_gdocsviewer_config_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *OriginUrlReplacementRule) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *OriginUrlReplacementRule) GetPattern() string {
+	if x != nil {
+		return x.Pattern
+	}
+	return ""
+}
+
+var File_transport_internet_request_roundtripper_gdocsviewer_config_proto protoreflect.FileDescriptor
+
+const file_transport_internet_request_roundtripper_gdocsviewer_config_proto_rawDesc = "" +
+	"\n" +
+	"@transport/internet/request/roundtripper/gdocsviewer/config.proto\x12>v2ray.core.transport.internet.request.roundtripper.gdocsviewer\x1a common/protoext/extensions.proto\"\xd4\x04\n" +
+	"\fClientConfig\x12\x1d\n" +
+	"\n" +
+	"viewer_url\x18\x01 \x01(\tR\tviewerUrl\x12\x19\n" +
+	"\btext_url\x18\x02 \x01(\tR\atextUrl\x12\x1d\n" +
+	"\n" +
+	"origin_url\x18\x03 \x01(\tR\toriginUrl\x12,\n" +
+	"\x12viewer_host_header\x18\x04 \x01(\tR\x10viewerHostHeader\x12\x1d\n" +
+	"\n" +
+	"user_agent\x18\x05 \x01(\tR\tuserAgent\x12\x1d\n" +
+	"\n" +
+	"allow_http\x18\x06 \x01(\bR\tallowHttp\x12 \n" +
+	"\fh2_pool_size\x18\a \x01(\x05R\n" +
+	"h2PoolSize\x121\n" +
+	"\x15max_viewer_body_bytes\x18\b \x01(\x05R\x12maxViewerBodyBytes\x125\n" +
+	"\x17min_request_interval_ms\x18\t \x01(\x05R\x14minRequestIntervalMs\x12\x1d\n" +
+	"\n" +
+	"shared_key\x18\n" +
+	" \x01(\fR\tsharedKey\x12\x99\x01\n" +
+	"\x1corigin_url_replacement_rules\x18\v \x03(\v2X.v2ray.core.transport.internet.request.roundtripper.gdocsviewer.OriginUrlReplacementRuleR\x19originUrlReplacementRules:8\x82\xb5\x184\n" +
+	"%transport.request.roundtripper.client\x12\vgdocsviewer\"\xe2\x01\n" +
+	"\fServerConfig\x12\x1f\n" +
+	"\vpath_prefix\x18\x01 \x01(\tR\n" +
+	"pathPrefix\x12*\n" +
+	"\x11max_request_bytes\x18\x02 \x01(\x05R\x0fmaxRequestBytes\x12,\n" +
+	"\x12max_response_bytes\x18\x03 \x01(\x05R\x10maxResponseBytes\x12\x1d\n" +
+	"\n" +
+	"shared_key\x18\x04 \x01(\fR\tsharedKey:8\x82\xb5\x184\n" +
+	"%transport.request.roundtripper.server\x12\vgdocsviewer\"H\n" +
+	"\x18OriginUrlReplacementRule\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
+	"\apattern\x18\x02 \x01(\tR\apatternB\xdb\x01\n" +
+	"Bcom.v2ray.core.transport.internet.request.roundtripper.gdocsviewerP\x01ZRgithub.com/v2fly/v2ray-core/v5/transport/internet/request/roundtripper/gdocsviewer\xaa\x02>V2Ray.Core.Transport.Internet.Request.Roundtripper.Gdocsviewerb\x06proto3"
+
+var (
+	file_transport_internet_request_roundtripper_gdocsviewer_config_proto_rawDescOnce sync.Once
+	file_transport_internet_request_roundtripper_gdocsviewer_config_proto_rawDescData []byte
+)
+
+func file_transport_internet_request_roundtripper_gdocsviewer_config_proto_rawDescGZIP() []byte {
+	file_transport_internet_request_roundtripper_gdocsviewer_config_proto_rawDescOnce.Do(func() {
+		file_transport_internet_request_roundtripper_gdocsviewer_config_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_transport_internet_request_roundtripper_gdocsviewer_config_proto_rawDesc), len(file_transport_internet_request_roundtripper_gdocsviewer_config_proto_rawDesc)))
+	})
+	return file_transport_internet_request_roundtripper_gdocsviewer_config_proto_rawDescData
+}
+
+var file_transport_internet_request_roundtripper_gdocsviewer_config_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_transport_internet_request_roundtripper_gdocsviewer_config_proto_goTypes = []any{
+	(*ClientConfig)(nil),             // 0: v2ray.core.transport.internet.request.roundtripper.gdocsviewer.ClientConfig
+	(*ServerConfig)(nil),             // 1: v2ray.core.transport.internet.request.roundtripper.gdocsviewer.ServerConfig
+	(*OriginUrlReplacementRule)(nil), // 2: v2ray.core.transport.internet.request.roundtripper.gdocsviewer.OriginUrlReplacementRule
+}
+var file_transport_internet_request_roundtripper_gdocsviewer_config_proto_depIdxs = []int32{
+	2, // 0: v2ray.core.transport.internet.request.roundtripper.gdocsviewer.ClientConfig.origin_url_replacement_rules:type_name -> v2ray.core.transport.internet.request.roundtripper.gdocsviewer.OriginUrlReplacementRule
+	1, // [1:1] is the sub-list for method output_type
+	1, // [1:1] is the sub-list for method input_type
+	1, // [1:1] is the sub-list for extension type_name
+	1, // [1:1] is the sub-list for extension extendee
+	0, // [0:1] is the sub-list for field type_name
+}
+
+func init() { file_transport_internet_request_roundtripper_gdocsviewer_config_proto_init() }
+func file_transport_internet_request_roundtripper_gdocsviewer_config_proto_init() {
+	if File_transport_internet_request_roundtripper_gdocsviewer_config_proto != nil {
+		return
+	}
+	type x struct{}
+	out := protoimpl.TypeBuilder{
+		File: protoimpl.DescBuilder{
+			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_transport_internet_request_roundtripper_gdocsviewer_config_proto_rawDesc), len(file_transport_internet_request_roundtripper_gdocsviewer_config_proto_rawDesc)),
+			NumEnums:      0,
+			NumMessages:   3,
+			NumExtensions: 0,
+			NumServices:   0,
+		},
+		GoTypes:           file_transport_internet_request_roundtripper_gdocsviewer_config_proto_goTypes,
+		DependencyIndexes: file_transport_internet_request_roundtripper_gdocsviewer_config_proto_depIdxs,
+		MessageInfos:      file_transport_internet_request_roundtripper_gdocsviewer_config_proto_msgTypes,
+	}.Build()
+	File_transport_internet_request_roundtripper_gdocsviewer_config_proto = out.File
+	file_transport_internet_request_roundtripper_gdocsviewer_config_proto_goTypes = nil
+	file_transport_internet_request_roundtripper_gdocsviewer_config_proto_depIdxs = nil
+}

--- a/transport/internet/request/roundtripper/gdocsviewer/config.proto
+++ b/transport/internet/request/roundtripper/gdocsviewer/config.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+package v2ray.core.transport.internet.request.roundtripper.gdocsviewer;
+option csharp_namespace = "V2Ray.Core.Transport.Internet.Request.Roundtripper.Gdocsviewer";
+option go_package = "github.com/v2fly/v2ray-core/v5/transport/internet/request/roundtripper/gdocsviewer";
+option java_package = "com.v2ray.core.transport.internet.request.roundtripper.gdocsviewer";
+option java_multiple_files = true;
+
+import "common/protoext/extensions.proto";
+
+message ClientConfig {
+  option (v2ray.core.common.protoext.message_opt).type = "transport.request.roundtripper.client";
+  option (v2ray.core.common.protoext.message_opt).short_name = "gdocsviewer";
+
+  string viewer_url = 1;
+  string text_url = 2;
+  string origin_url = 3;
+  string viewer_host_header = 4;
+  string user_agent = 5;
+  bool allow_http = 6;
+  int32 h2_pool_size = 7;
+  int32 max_viewer_body_bytes = 8;
+  int32 min_request_interval_ms = 9;
+  bytes shared_key = 10;
+  repeated OriginUrlReplacementRule origin_url_replacement_rules = 11;
+}
+
+message ServerConfig {
+  option (v2ray.core.common.protoext.message_opt).type = "transport.request.roundtripper.server";
+  option (v2ray.core.common.protoext.message_opt).short_name = "gdocsviewer";
+
+  string path_prefix = 1;
+  int32 max_request_bytes = 2;
+  int32 max_response_bytes = 3;
+  bytes shared_key = 4;
+}
+
+message OriginUrlReplacementRule {
+  string name = 1;
+  string pattern = 2;
+}

--- a/transport/internet/request/roundtripper/gdocsviewer/errors.generated.go
+++ b/transport/internet/request/roundtripper/gdocsviewer/errors.generated.go
@@ -1,0 +1,9 @@
+package gdocsviewer
+
+import "github.com/v2fly/v2ray-core/v5/common/errors"
+
+type errPathObjHolder struct{}
+
+func newError(values ...interface{}) *errors.Error {
+	return errors.New(values...).WithPathObj(errPathObjHolder{})
+}

--- a/transport/internet/request/roundtripper/gdocsviewer/gdocsviewer.go
+++ b/transport/internet/request/roundtripper/gdocsviewer/gdocsviewer.go
@@ -1,0 +1,781 @@
+package gdocsviewer
+
+//go:generate go run github.com/v2fly/v2ray-core/v5/common/errors/errorgen
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	gonet "net"
+	"net/http"
+	neturl "net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/v2fly/v2ray-core/v5/common"
+	"github.com/v2fly/v2ray-core/v5/common/net"
+	"github.com/v2fly/v2ray-core/v5/transport/internet/request"
+	"github.com/v2fly/v2ray-core/v5/transport/internet/transportcommon"
+)
+
+const (
+	defaultViewerURL            = "https://docs.google.com/viewer"
+	defaultTextURL              = "https://drive.google.com/viewerng/text"
+	defaultPathPrefix           = "/gdocsviewer"
+	defaultMaxViewerBodyBytes   = 32 * 1024 * 1024
+	defaultMinRequestIntervalMs = 100
+	defaultMaxRequestBytes      = 1100
+	defaultMaxResponseBytes     = 64 * 1024
+	encryptedRequestVersion     = byte(1)
+	responseFrameSuccess        = byte(0)
+	responseFrameError          = byte(1)
+)
+
+func newClient(ctx context.Context, config *ClientConfig) request.RoundTripperClient {
+	return &client{ctx: ctx, config: config}
+}
+
+type client struct {
+	ctx      context.Context
+	httpRTT  http.RoundTripper
+	config   *ClientConfig
+	assembly request.TransportClientAssembly
+
+	requestLock sync.Mutex
+	lastRequest time.Time
+}
+
+type unavailableRoundTripper struct{}
+
+func (u unavailableRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	return nil, newError("unavailable HTTP transport")
+}
+
+func (c *client) OnTransportClientAssemblyReady(assembly request.TransportClientAssembly) {
+	c.assembly = assembly
+}
+
+func (c *client) RoundTrip(ctx context.Context, req request.Request, opts ...request.RoundTripperOption) (resp request.Response, err error) {
+	var streamingWriter io.Writer
+	for _, v := range opts {
+		if streamingResp, ok := v.(request.OptionSupportsStreamingResponse); ok {
+			streamingWriter = streamingResp.GetResponseWriter()
+		}
+	}
+
+	if c.httpRTT == nil {
+		c.initHTTPRoundTripper(ctx)
+	}
+
+	originRequestURL, err := c.buildOriginRequestURL(req)
+	if err != nil {
+		return request.Response{}, err
+	}
+
+	viewerURL, err := buildViewerURL(clientViewerURL(c.config), originRequestURL)
+	if err != nil {
+		return request.Response{}, err
+	}
+	viewerReq, err := http.NewRequestWithContext(ctx, http.MethodGet, viewerURL, nil)
+	if err != nil {
+		return request.Response{}, err
+	}
+	c.applyViewerHeaders(viewerReq)
+
+	viewerResp, err := c.doHTTPRoundTrip(ctx, viewerReq)
+	if err != nil {
+		return request.Response{}, err
+	}
+	viewerBody, err := readLimitedHTTPBody(viewerResp, int64(clientMaxViewerBodyBytes(c.config)), "viewer")
+	if err != nil {
+		return request.Response{}, err
+	}
+
+	docID, err := extractDocumentID(viewerBody)
+	if err != nil {
+		return request.Response{}, err
+	}
+
+	textURL, err := buildTextURL(clientTextURL(c.config), docID)
+	if err != nil {
+		return request.Response{}, err
+	}
+	textReq, err := http.NewRequestWithContext(ctx, http.MethodGet, textURL, nil)
+	if err != nil {
+		return request.Response{}, err
+	}
+	c.applyViewerHeaders(textReq)
+
+	textResp, err := c.doHTTPRoundTrip(ctx, textReq)
+	if err != nil {
+		return request.Response{}, err
+	}
+	textBody, err := readLimitedHTTPBody(textResp, int64(clientMaxViewerBodyBytes(c.config)), "viewer text")
+	if err != nil {
+		return request.Response{}, err
+	}
+
+	originBase64, err := decodeViewerTextData(textBody)
+	if err != nil {
+		return request.Response{}, err
+	}
+	serverBody, err := decodeBase64Text(originBase64)
+	if err != nil {
+		return request.Response{}, newError("unable to decode origin response body").Base(err)
+	}
+	result, err := c.decodeServerBody(serverBody)
+	if err != nil {
+		return request.Response{}, err
+	}
+
+	if streamingWriter != nil {
+		if _, err := streamingWriter.Write(result); err != nil {
+			return request.Response{}, err
+		}
+		return request.Response{}, nil
+	}
+	return request.Response{Data: result}, nil
+}
+
+func (c *client) initHTTPRoundTripper(ctx context.Context) {
+	var backdrop http.RoundTripper = unavailableRoundTripper{}
+	if c.config != nil && c.config.AllowHttp {
+		backdrop = &http.Transport{
+			DialContext: func(_ context.Context, network, addr string) (gonet.Conn, error) {
+				return c.assembly.AutoImplDialer().Dial(ctx)
+			},
+			DialTLSContext: func(_ context.Context, network, addr string) (gonet.Conn, error) {
+				return nil, newError("unexpected TLS dial for HTTP request")
+			},
+		}
+	}
+	c.httpRTT = transportcommon.NewALPNAwareHTTPRoundTripperWithH2Pool(c.ctx, func(ctx context.Context, addr string) (gonet.Conn, error) {
+		return c.assembly.AutoImplDialer().Dial(ctx)
+	}, backdrop, int(c.config.GetH2PoolSize()))
+}
+
+func (c *client) applyViewerHeaders(req *http.Request) {
+	if c.config == nil {
+		return
+	}
+	if c.config.UserAgent != "" {
+		req.Header.Set("User-Agent", c.config.UserAgent)
+	}
+	if c.config.ViewerHostHeader != "" {
+		req.Host = c.config.ViewerHostHeader
+	}
+}
+
+func (c *client) doHTTPRoundTrip(ctx context.Context, req *http.Request) (*http.Response, error) {
+	if err := c.waitForRequestSlot(ctx); err != nil {
+		return nil, err
+	}
+	return c.httpRTT.RoundTrip(req)
+}
+
+func (c *client) waitForRequestSlot(ctx context.Context) error {
+	interval := time.Duration(clientMinRequestIntervalMs(c.config)) * time.Millisecond
+	if interval <= 0 {
+		return nil
+	}
+
+	c.requestLock.Lock()
+	defer c.requestLock.Unlock()
+
+	if !c.lastRequest.IsZero() {
+		wait := interval - time.Since(c.lastRequest)
+		if wait > 0 {
+			timer := time.NewTimer(wait)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
+		}
+	}
+	c.lastRequest = time.Now()
+	return nil
+}
+
+func (c *client) buildOriginRequestURL(req request.Request) (string, error) {
+	if c.config == nil || c.config.OriginUrl == "" {
+		return "", newError("origin_url is required")
+	}
+	originURL, err := renderOriginURL(c.config)
+	if err != nil {
+		return "", err
+	}
+	if len(c.config.SharedKey) == 0 {
+		nonce, err := randomURLToken(12)
+		if err != nil {
+			return "", err
+		}
+		return originURL + "/r/" +
+			base64.RawURLEncoding.EncodeToString(req.ConnectionTag) + "/" +
+			base64.RawURLEncoding.EncodeToString(req.Data) + "/" +
+			nonce + ".txt", nil
+	}
+
+	combined, err := encryptClientRequest(c.config.SharedKey, req.ConnectionTag, req.Data)
+	if err != nil {
+		return "", err
+	}
+	return originURL + "/t/" + base64.RawURLEncoding.EncodeToString(combined) + ".log", nil
+}
+
+func (c *client) decodeServerBody(body []byte) ([]byte, error) {
+	if c.config == nil || len(c.config.SharedKey) == 0 {
+		return body, nil
+	}
+	frame, err := decryptResponseFrame(c.config.SharedKey, body)
+	if err != nil {
+		return nil, err
+	}
+	if len(frame) == 0 {
+		return nil, newError("empty encrypted response frame")
+	}
+	switch frame[0] {
+	case responseFrameSuccess:
+		return frame[1:], nil
+	case responseFrameError:
+		return nil, newError("server returned error: ", string(frame[1:]))
+	default:
+		return nil, newError("unknown encrypted response frame type: ", frame[0])
+	}
+}
+
+func clientViewerURL(config *ClientConfig) string {
+	if config != nil && config.ViewerUrl != "" {
+		return config.ViewerUrl
+	}
+	return defaultViewerURL
+}
+
+func clientTextURL(config *ClientConfig) string {
+	if config != nil && config.TextUrl != "" {
+		return config.TextUrl
+	}
+	return defaultTextURL
+}
+
+func clientMaxViewerBodyBytes(config *ClientConfig) int {
+	if config != nil && config.MaxViewerBodyBytes > 0 {
+		return int(config.MaxViewerBodyBytes)
+	}
+	return defaultMaxViewerBodyBytes
+}
+
+func clientMinRequestIntervalMs(config *ClientConfig) int {
+	if config != nil && config.MinRequestIntervalMs > 0 {
+		return int(config.MinRequestIntervalMs)
+	}
+	return defaultMinRequestIntervalMs
+}
+
+func buildViewerURL(viewerURL string, originURL string) (string, error) {
+	parsed, err := neturl.Parse(viewerURL)
+	if err != nil {
+		return "", newError("invalid viewer_url").Base(err)
+	}
+	query := parsed.Query()
+	query.Set("url", originURL)
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), nil
+}
+
+func buildTextURL(textURL string, docID string) (string, error) {
+	parsed, err := neturl.Parse(textURL)
+	if err != nil {
+		return "", newError("invalid text_url").Base(err)
+	}
+	query := parsed.Query()
+	query.Set("id", docID)
+	if query.Get("page") == "" {
+		query.Set("page", "0")
+	}
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), nil
+}
+
+func readLimitedHTTPBody(resp *http.Response, maxBytes int64, label string) ([]byte, error) {
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, newError(label, " returned non-200 response: ", resp.Status)
+	}
+	body, err := readLimited(resp.Body, maxBytes)
+	if err != nil {
+		return nil, newError("unable to read ", label, " body").Base(err)
+	}
+	return body, nil
+}
+
+func readLimited(reader io.Reader, maxBytes int64) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(reader, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, newError("body exceeds limit: ", maxBytes)
+	}
+	return body, nil
+}
+
+func extractDocumentID(body []byte) (string, error) {
+	original := string(body)
+	candidates := []string{
+		original,
+		decodeKnownURLEscapes(original),
+		decodeKnownJSEscapes(original),
+		decodeKnownURLEscapes(decodeKnownJSEscapes(original)),
+		decodeKnownJSEscapes(decodeKnownURLEscapes(original)),
+	}
+	for _, candidate := range candidates {
+		if id, ok := findDocumentID(candidate); ok {
+			return id, nil
+		}
+	}
+	return "", newError("unable to find Google Docs Viewer text document id")
+}
+
+func decodeKnownURLEscapes(s string) string {
+	replacer := strings.NewReplacer(
+		"%2F", "/", "%2f", "/",
+		"%3F", "?", "%3f", "?",
+		"%3D", "=", "%3d", "=",
+		"%26", "&",
+	)
+	return replacer.Replace(s)
+}
+
+func decodeKnownJSEscapes(s string) string {
+	replacer := strings.NewReplacer(
+		`\/`, `/`,
+		`\x2F`, `/`, `\x2f`, `/`, `\u002F`, `/`, `\u002f`, `/`,
+		`\x3F`, `?`, `\x3f`, `?`, `\u003F`, `?`, `\u003f`, `?`,
+		`\x3D`, `=`, `\x3d`, `=`, `\u003D`, `=`, `\u003d`, `=`,
+		`\x26`, `&`, `\u0026`, `&`,
+	)
+	return replacer.Replace(s)
+}
+
+func findDocumentID(s string) (string, bool) {
+	for _, marker := range []string{"viewerng/text?id=", "text?id="} {
+		if id, ok := findDocumentIDAfterMarker(s, marker); ok {
+			return id, true
+		}
+	}
+	return "", false
+}
+
+func findDocumentIDAfterMarker(s string, marker string) (string, bool) {
+	pos := strings.Index(s, marker)
+	if pos < 0 {
+		return "", false
+	}
+	start := pos + len(marker)
+	end := start
+	for end < len(s) {
+		switch s[end] {
+		case '&', '"', '\'', '\\', '<', '>', ' ', '\t', '\r', '\n':
+			goto done
+		default:
+			end++
+		}
+	}
+done:
+	if end == start {
+		return "", false
+	}
+	id := s[start:end]
+	if decoded, err := neturl.QueryUnescape(id); err == nil {
+		id = decoded
+	}
+	return id, true
+}
+
+type viewerTextResponse struct {
+	Mimetype string `json:"mimetype"`
+	Data     string `json:"data"`
+}
+
+func decodeViewerTextData(body []byte) ([]byte, error) {
+	trimmed := strings.TrimSpace(string(body))
+	trimmed = stripAntiXSSIPrefix(trimmed)
+	if strings.HasPrefix(trimmed, "{") {
+		var response viewerTextResponse
+		if err := json.Unmarshal([]byte(trimmed), &response); err != nil {
+			return nil, newError("unable to parse viewer text JSON").Base(err)
+		}
+		if response.Data == "" {
+			return nil, newError("viewer text JSON is missing data")
+		}
+		return []byte(response.Data), nil
+	}
+	return []byte(trimmed), nil
+}
+
+func stripAntiXSSIPrefix(s string) string {
+	const prefix = ")]}'"
+	s = strings.TrimSpace(s)
+	if strings.HasPrefix(s, prefix) {
+		s = strings.TrimSpace(strings.TrimPrefix(s, prefix))
+		if strings.HasPrefix(s, ",") {
+			s = strings.TrimSpace(strings.TrimPrefix(s, ","))
+		}
+	}
+	return s
+}
+
+func decodeBase64Text(data []byte) ([]byte, error) {
+	text := strings.TrimSpace(string(data))
+	if decoded, err := base64.StdEncoding.DecodeString(text); err == nil {
+		return decoded, nil
+	}
+	return base64.RawStdEncoding.DecodeString(text)
+}
+
+func encryptClientRequest(key []byte, session []byte, payload []byte) ([]byte, error) {
+	if len(session) > 0xffff {
+		return nil, newError("session tag is too long")
+	}
+	frame := make([]byte, 1+2+len(session)+len(payload))
+	frame[0] = encryptedRequestVersion
+	binary.BigEndian.PutUint16(frame[1:3], uint16(len(session)))
+	copy(frame[3:], session)
+	copy(frame[3+len(session):], payload)
+	return encryptAEAD(key, frame)
+}
+
+func decryptClientRequest(key []byte, combined []byte) (session []byte, payload []byte, err error) {
+	frame, err := decryptAEAD(key, combined)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(frame) < 3 {
+		return nil, nil, newError("encrypted request frame is too short")
+	}
+	if frame[0] != encryptedRequestVersion {
+		return nil, nil, newError("unknown encrypted request frame version: ", frame[0])
+	}
+	sessionLength := int(binary.BigEndian.Uint16(frame[1:3]))
+	if len(frame) < 3+sessionLength {
+		return nil, nil, newError("encrypted request frame has invalid session length")
+	}
+	session = make([]byte, sessionLength)
+	copy(session, frame[3:3+sessionLength])
+	payload = make([]byte, len(frame)-3-sessionLength)
+	copy(payload, frame[3+sessionLength:])
+	return session, payload, nil
+}
+
+func encryptResponseFrame(key []byte, frame []byte) ([]byte, error) {
+	return encryptAEAD(key, frame)
+}
+
+func decryptResponseFrame(key []byte, combined []byte) ([]byte, error) {
+	return decryptAEAD(key, combined)
+}
+
+func encryptAEAD(key []byte, plaintext []byte) ([]byte, error) {
+	aead, err := newAES256GCM(key)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, newError("unable to generate nonce").Base(err)
+	}
+	sealed := aead.Seal(nil, nonce, plaintext, nil)
+	combined := make([]byte, 0, len(nonce)+len(sealed))
+	combined = append(combined, nonce...)
+	combined = append(combined, sealed...)
+	return combined, nil
+}
+
+func decryptAEAD(key []byte, combined []byte) ([]byte, error) {
+	aead, err := newAES256GCM(key)
+	if err != nil {
+		return nil, err
+	}
+	if len(combined) < aead.NonceSize()+aead.Overhead() {
+		return nil, newError("encrypted blob is too short")
+	}
+	nonce := combined[:aead.NonceSize()]
+	ciphertext := combined[aead.NonceSize():]
+	plaintext, err := aead.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, newError("unable to decrypt encrypted blob").Base(err)
+	}
+	return plaintext, nil
+}
+
+func newAES256GCM(key []byte) (cipher.AEAD, error) {
+	if len(key) != 32 {
+		return nil, newError("shared_key must be 32 bytes for AES-256-GCM")
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, newError("unable to create AES cipher").Base(err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, newError("unable to create AES-GCM AEAD").Base(err)
+	}
+	return aead, nil
+}
+
+func randomURLToken(size int) (string, error) {
+	raw := make([]byte, size)
+	if _, err := io.ReadFull(rand.Reader, raw); err != nil {
+		return "", newError("unable to generate URL token").Base(err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}
+
+func newServer(ctx context.Context, config *ServerConfig) request.RoundTripperServer {
+	return &server{ctx: ctx, config: config}
+}
+
+type server struct {
+	ctx      context.Context
+	listener net.Listener
+	assembly request.TransportServerAssembly
+	config   *ServerConfig
+}
+
+func (s *server) OnTransportServerAssemblyReady(assembly request.TransportServerAssembly) {
+	s.assembly = assembly
+}
+
+func (s *server) ServeHTTP(writer http.ResponseWriter, r *http.Request) {
+	s.onRequest(writer, r)
+}
+
+func (s *server) onRequest(writer http.ResponseWriter, httpReq *http.Request) {
+	if httpReq.Method != http.MethodGet {
+		http.NotFound(writer, httpReq)
+		return
+	}
+	tail, ok := pathTail(httpReq.URL.Path, serverPathPrefix(s.config))
+	if !ok {
+		http.NotFound(writer, httpReq)
+		return
+	}
+	if len(s.config.GetSharedKey()) == 0 {
+		s.handlePlainRequest(writer, httpReq, tail)
+		return
+	}
+	s.handleEncryptedRequest(writer, httpReq, tail)
+}
+
+func (s *server) handlePlainRequest(writer http.ResponseWriter, httpReq *http.Request, tail string) {
+	if !strings.HasPrefix(tail, "/r/") {
+		http.NotFound(writer, httpReq)
+		return
+	}
+	parts := strings.Split(strings.TrimPrefix(tail, "/r/"), "/")
+	if len(parts) != 3 || !strings.HasSuffix(parts[2], ".txt") || strings.TrimSuffix(parts[2], ".txt") == "" {
+		http.NotFound(writer, httpReq)
+		return
+	}
+	session, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		http.NotFound(writer, httpReq)
+		return
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		http.NotFound(writer, httpReq)
+		return
+	}
+	if len(payload) > serverMaxRequestBytes(s.config) {
+		newError("plaintext request exceeds max_request_bytes").AtInfo().WriteToLog()
+		http.NotFound(writer, httpReq)
+		return
+	}
+	response, err := s.roundTrip(s.roundTripContext(), request.Request{Data: payload, ConnectionTag: session})
+	if err != nil {
+		newError("unable to process plaintext request").Base(err).AtInfo().WriteToLog()
+		http.NotFound(writer, httpReq)
+		return
+	}
+	writer.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	_, err = io.WriteString(writer, base64.StdEncoding.EncodeToString(response))
+	if err != nil {
+		newError("unable to write plaintext response").Base(err).AtInfo().WriteToLog()
+	}
+}
+
+func (s *server) handleEncryptedRequest(writer http.ResponseWriter, httpReq *http.Request, tail string) {
+	if !strings.HasPrefix(tail, "/t/") {
+		http.NotFound(writer, httpReq)
+		return
+	}
+	combinedText := strings.TrimPrefix(tail, "/t/")
+	if !strings.HasSuffix(combinedText, ".log") {
+		http.NotFound(writer, httpReq)
+		return
+	}
+	combinedText = strings.TrimSuffix(combinedText, ".log")
+	combined, err := base64.RawURLEncoding.DecodeString(combinedText)
+	if err != nil {
+		s.writeEncryptedError(writer, "invalid encrypted request encoding")
+		return
+	}
+	session, payload, err := decryptClientRequest(s.config.SharedKey, combined)
+	if err != nil {
+		s.writeEncryptedError(writer, err.Error())
+		return
+	}
+	if len(payload) > serverMaxRequestBytes(s.config) {
+		s.writeEncryptedError(writer, "request exceeds max_request_bytes")
+		return
+	}
+	response, err := s.roundTrip(s.roundTripContext(), request.Request{Data: payload, ConnectionTag: session})
+	if err != nil {
+		s.writeEncryptedError(writer, err.Error())
+		return
+	}
+	frame := make([]byte, 1+len(response))
+	frame[0] = responseFrameSuccess
+	copy(frame[1:], response)
+	encrypted, err := encryptResponseFrame(s.config.SharedKey, frame)
+	if err != nil {
+		s.writeEncryptedError(writer, err.Error())
+		return
+	}
+	writeBase64Text(writer, encrypted)
+}
+
+func (s *server) writeEncryptedError(writer http.ResponseWriter, message string) {
+	frame := append([]byte{responseFrameError}, []byte(message)...)
+	encrypted, err := encryptResponseFrame(s.config.SharedKey, frame)
+	if err != nil {
+		newError("unable to encrypt error response").Base(err).AtInfo().WriteToLog()
+		http.Error(writer, "encrypted error unavailable", http.StatusInternalServerError)
+		return
+	}
+	writeBase64Text(writer, encrypted)
+}
+
+func (s *server) roundTrip(ctx context.Context, req request.Request) ([]byte, error) {
+	resp, err := s.assembly.TripperReceiver().OnRoundTrip(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.Data) > serverMaxResponseBytes(s.config) {
+		return nil, newError("response exceeds max_response_bytes")
+	}
+	return resp.Data, nil
+}
+
+func (s *server) roundTripContext() context.Context {
+	if s.ctx != nil {
+		return s.ctx
+	}
+	return context.Background()
+}
+
+func writeBase64Text(writer http.ResponseWriter, data []byte) {
+	writer.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	_, err := io.WriteString(writer, base64.StdEncoding.EncodeToString(data))
+	if err != nil {
+		newError("unable to write response").Base(err).AtInfo().WriteToLog()
+	}
+}
+
+func pathTail(path string, prefix string) (string, bool) {
+	if prefix == "/" {
+		return path, strings.HasPrefix(path, "/")
+	}
+	if path == prefix {
+		return "", true
+	}
+	if strings.HasPrefix(path, prefix+"/") {
+		return strings.TrimPrefix(path, prefix), true
+	}
+	return "", false
+}
+
+func serverPathPrefix(config *ServerConfig) string {
+	if config != nil && config.PathPrefix != "" {
+		prefix := config.PathPrefix
+		if !strings.HasPrefix(prefix, "/") {
+			prefix = "/" + prefix
+		}
+		prefix = strings.TrimRight(prefix, "/")
+		if prefix == "" {
+			return "/"
+		}
+		return prefix
+	}
+	return defaultPathPrefix
+}
+
+func serverMaxRequestBytes(config *ServerConfig) int {
+	if config != nil && config.MaxRequestBytes > 0 {
+		return int(config.MaxRequestBytes)
+	}
+	return defaultMaxRequestBytes
+}
+
+func serverMaxResponseBytes(config *ServerConfig) int {
+	if config != nil && config.MaxResponseBytes > 0 {
+		return int(config.MaxResponseBytes)
+	}
+	return defaultMaxResponseBytes
+}
+
+func (s *server) Start() error {
+	listener, err := s.assembly.AutoImplListener().Listen(s.ctx)
+	if err != nil {
+		return newError("unable to create a listener for gdocsviewer server").Base(err)
+	}
+	s.listener = listener
+	go func() {
+		httpServer := http.Server{
+			ReadHeaderTimeout: 240 * time.Second,
+			ReadTimeout:       240 * time.Second,
+			WriteTimeout:      240 * time.Second,
+			IdleTimeout:       240 * time.Second,
+			Handler:           s,
+		}
+		err := httpServer.Serve(s.listener)
+		if err != nil {
+			newError("unable to serve listener for gdocsviewer server").Base(err).WriteToLog()
+		}
+	}()
+	return nil
+}
+
+func (s *server) Close() error {
+	if s.listener == nil {
+		return nil
+	}
+	return s.listener.Close()
+}
+
+func init() {
+	common.Must(common.RegisterConfig((*ClientConfig)(nil), func(ctx context.Context, config interface{}) (interface{}, error) {
+		clientConfig, ok := config.(*ClientConfig)
+		if !ok {
+			return nil, newError("not a ClientConfig")
+		}
+		return newClient(ctx, clientConfig), nil
+	}))
+	common.Must(common.RegisterConfig((*ServerConfig)(nil), func(ctx context.Context, config interface{}) (interface{}, error) {
+		serverConfig, ok := config.(*ServerConfig)
+		if !ok {
+			return nil, newError("not a ServerConfig")
+		}
+		return newServer(ctx, serverConfig), nil
+	}))
+}

--- a/transport/internet/request/roundtripper/gdocsviewer/gdocsviewer_test.go
+++ b/transport/internet/request/roundtripper/gdocsviewer/gdocsviewer_test.go
@@ -1,0 +1,670 @@
+package gdocsviewer
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	neturl "net/url"
+	"strings"
+	"testing"
+
+	"github.com/v2fly/v2ray-core/v5/transport/internet/request"
+)
+
+func TestBuildOriginRequestURLPlaintext(t *testing.T) {
+	c := &client{config: &ClientConfig{
+		OriginUrl: "https://{abc}-origin.test/gdocsviewer/",
+		OriginUrlReplacementRules: []*OriginUrlReplacementRule{{
+			Name:    "abc",
+			Pattern: "[a-z0-9]{14}",
+		}},
+	}}
+
+	got, err := c.buildOriginRequestURL(request.Request{
+		ConnectionTag: []byte{1, 2, 3},
+		Data:          []byte("payload"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := neturl.Parse(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(parsed.Host, "-origin.test") {
+		t.Fatalf("unexpected generated host %q", parsed.Host)
+	}
+	generated := strings.TrimSuffix(parsed.Host, "-origin.test")
+	if len(generated) != 14 || !allBytesIn(generated, "abcdefghijklmnopqrstuvwxyz0123456789") {
+		t.Fatalf("unexpected generated label %q", generated)
+	}
+	parts := strings.Split(strings.TrimPrefix(parsed.Path, "/gdocsviewer/r/"), "/")
+	if len(parts) != 3 {
+		t.Fatalf("unexpected path %q", parsed.Path)
+	}
+	if parts[0] != "AQID" {
+		t.Fatalf("unexpected session segment %q", parts[0])
+	}
+	if parts[1] != "cGF5bG9hZA" {
+		t.Fatalf("unexpected payload segment %q", parts[1])
+	}
+	if !strings.HasSuffix(parts[2], ".txt") || strings.TrimSuffix(parts[2], ".txt") == "" {
+		t.Fatalf("unexpected nonce segment %q", parts[2])
+	}
+}
+
+func TestBuildOriginRequestURLEncrypted(t *testing.T) {
+	key := bytes.Repeat([]byte{7}, 32)
+	c := &client{config: &ClientConfig{
+		OriginUrl: "https://origin-{abc}.test/base",
+		SharedKey: key,
+		OriginUrlReplacementRules: []*OriginUrlReplacementRule{{
+			Name:    "abc",
+			Pattern: "[a-f0-9]{8}",
+		}},
+	}}
+
+	got, err := c.buildOriginRequestURL(request.Request{
+		ConnectionTag: []byte("session"),
+		Data:          []byte("payload"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := neturl.Parse(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(parsed.Host, "origin-") || !strings.HasSuffix(parsed.Host, ".test") {
+		t.Fatalf("unexpected generated host %q", parsed.Host)
+	}
+	encoded := strings.TrimSuffix(strings.TrimPrefix(parsed.Path, "/base/t/"), ".log")
+	combined, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, payload, err := decryptClientRequest(key, combined)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(session) != "session" || string(payload) != "payload" {
+		t.Fatalf("unexpected decrypted request: session=%q payload=%q", session, payload)
+	}
+}
+
+func TestOriginURLReplacementUsesOneValuePerRule(t *testing.T) {
+	c := &client{config: &ClientConfig{
+		OriginUrl: "https://{abc}.{abc}.origin.test/g",
+		OriginUrlReplacementRules: []*OriginUrlReplacementRule{{
+			Name:    "abc",
+			Pattern: "[a-z0-9]{14}",
+		}},
+	}}
+
+	got, err := c.buildOriginRequestURL(request.Request{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := neturl.Parse(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	labels := strings.Split(parsed.Host, ".")
+	if len(labels) < 2 || labels[0] != labels[1] {
+		t.Fatalf("expected repeated placeholder to share one generated value, host=%q", parsed.Host)
+	}
+}
+
+func TestOriginURLReplacementAllowsValidUnusedRule(t *testing.T) {
+	c := &client{config: &ClientConfig{
+		OriginUrl: "https://origin.test/g",
+		OriginUrlReplacementRules: []*OriginUrlReplacementRule{{
+			Name:    "unused",
+			Pattern: "[a-z0-9]{14}",
+		}},
+	}}
+
+	got, err := c.buildOriginRequestURL(request.Request{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := neturl.Parse(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Host != "origin.test" {
+		t.Fatalf("unexpected host %q", parsed.Host)
+	}
+}
+
+func TestOriginURLReplacementRejectsInvalidRules(t *testing.T) {
+	tests := []struct {
+		name string
+		rule *OriginUrlReplacementRule
+	}{
+		{name: "invalid name", rule: &OriginUrlReplacementRule{Name: "bad/name", Pattern: "[a-z]{4}"}},
+		{name: "invalid pattern", rule: &OriginUrlReplacementRule{Name: "abc", Pattern: "[a-z"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := &client{config: &ClientConfig{
+				OriginUrl:                 "https://origin.test/g",
+				OriginUrlReplacementRules: []*OriginUrlReplacementRule{test.rule},
+			}}
+			if _, err := c.buildOriginRequestURL(request.Request{}); err == nil {
+				t.Fatal("expected invalid replacement rule error")
+			}
+		})
+	}
+}
+
+func TestGenerateOriginURLReplacementPatternSyntax(t *testing.T) {
+	got, err := generateOriginURLReplacement(&OriginUrlReplacementRule{Name: "abc", Pattern: "[a-z0-9]{14}"}, zeroReader{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 14 || !allBytesIn(got, "abcdefghijklmnopqrstuvwxyz0123456789") {
+		t.Fatalf("unexpected generated value %q", got)
+	}
+
+	got, err = generateOriginURLReplacement(&OriginUrlReplacementRule{Name: "abc", Pattern: `edge\-\{x\}`}, zeroReader{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "edge-{x}" {
+		t.Fatalf("unexpected escaped literal output %q", got)
+	}
+
+	got, err = generateOriginURLReplacement(&OriginUrlReplacementRule{Name: "abc", Pattern: "edge-[a-f0-9]{8}"}, zeroReader{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(got, "edge-") || len(got) != len("edge-")+8 || !allBytesIn(strings.TrimPrefix(got, "edge-"), "abcdef0123456789") {
+		t.Fatalf("unexpected generated value %q", got)
+	}
+}
+
+func TestGenerateOriginURLReplacementRejectsUnsupportedPatterns(t *testing.T) {
+	tests := []string{
+		"",
+		"[a-z",
+		"[z-a]",
+		"[a-z]{0}",
+		"[a-z]{257}",
+		"(abc)",
+		"a|b",
+		"[a-z]+",
+		"[a-z]{1,2}",
+	}
+	for _, pattern := range tests {
+		t.Run(pattern, func(t *testing.T) {
+			_, err := generateOriginURLReplacement(&OriginUrlReplacementRule{Name: "abc", Pattern: pattern}, zeroReader{})
+			if err == nil {
+				t.Fatal("expected pattern error")
+			}
+		})
+	}
+}
+
+func TestRoundTripPlaintextViewerFlowAndHeaders(t *testing.T) {
+	rt := &recordingRoundTripper{}
+	rt.fn = func(req *http.Request) (*http.Response, error) {
+		switch len(rt.requests) {
+		case 1:
+			if req.URL.Host != "viewer.test" || req.URL.Path != "/viewer" {
+				t.Fatalf("unexpected viewer request URL %s", req.URL.String())
+			}
+			origin := req.URL.Query().Get("url")
+			originURL, err := neturl.Parse(origin)
+			if err != nil {
+				t.Fatal(err)
+			}
+			parts := strings.Split(strings.TrimPrefix(originURL.Path, "/gdocsviewer/r/"), "/")
+			if len(parts) != 3 || parts[0] != "c2Vzc2lvbg" || parts[1] != "cmVxdWVzdA" || !strings.HasSuffix(parts[2], ".txt") {
+				t.Fatalf("unexpected origin request URL %q", origin)
+			}
+			return textHTTPResponse(http.StatusOK, `... "/viewerng/text?id=doc-1&authuser=0" ...`), nil
+		case 2:
+			if req.URL.Path != "/viewerng/text" || req.URL.Query().Get("id") != "doc-1" || req.URL.Query().Get("page") != "0" {
+				t.Fatalf("unexpected text request URL %s", req.URL.String())
+			}
+			return textHTTPResponse(http.StatusOK, viewerTextBodyForServerBody([]byte("response"))), nil
+		default:
+			t.Fatalf("unexpected request count %d", len(rt.requests))
+			return nil, nil
+		}
+	}
+	c := &client{httpRTT: rt, config: &ClientConfig{
+		ViewerUrl:            "https://viewer.test/viewer",
+		TextUrl:              "https://viewer.test/viewerng/text",
+		OriginUrl:            "https://origin.test/gdocsviewer",
+		ViewerHostHeader:     "docs.example",
+		UserAgent:            "gdocsviewer-test",
+		MinRequestIntervalMs: 1,
+	}}
+
+	resp, err := c.RoundTrip(context.Background(), request.Request{
+		ConnectionTag: []byte("session"),
+		Data:          []byte("request"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(resp.Data) != "response" {
+		t.Fatalf("unexpected response %q", resp.Data)
+	}
+	if len(rt.requests) != 2 {
+		t.Fatalf("unexpected request count %d", len(rt.requests))
+	}
+	for _, req := range rt.requests {
+		if req.Host != "docs.example" || req.Header.Get("User-Agent") != "gdocsviewer-test" {
+			t.Fatalf("headers not applied: host=%q ua=%q", req.Host, req.Header.Get("User-Agent"))
+		}
+	}
+}
+
+func TestExtractDocumentIDVariants(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "raw", body: `"/viewerng/text?id=raw-doc&x=1"`, want: "raw-doc"},
+		{name: "relative text endpoint", body: `"text?id=relative-doc","status?id=relative-doc"`, want: "relative-doc"},
+		{name: "url escaped", body: `viewerng%2Ftext%3Fid%3Durl-doc%26x%3D1`, want: "url-doc"},
+		{name: "js slash escaped", body: `viewerng\/text?id=js-doc&x=1`, want: "js-doc"},
+		{name: "js unicode escaped", body: `viewerng\u002Ftext\u003Fid\u003Dunicode-doc\u0026x\u003D1`, want: "unicode-doc"},
+		{name: "js unicode relative", body: `text?id\u003dunicode-relative-doc`, want: "unicode-relative-doc"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := extractDocumentID([]byte(test.body))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Fatalf("got %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestDecodeViewerTextData(t *testing.T) {
+	originBody := base64.StdEncoding.EncodeToString([]byte("response"))
+	wrapped := viewerTextBodyForOriginBody(originBody)
+
+	got, err := decodeViewerTextData([]byte(wrapped))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != originBody {
+		t.Fatalf("got %q, want %q", got, originBody)
+	}
+
+	got, err = decodeViewerTextData([]byte(originBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != originBody {
+		t.Fatalf("got %q, want %q", got, originBody)
+	}
+}
+
+func TestRoundTripEncryptedErrorFrame(t *testing.T) {
+	key := bytes.Repeat([]byte{9}, 32)
+	encryptedError, err := encryptResponseFrame(key, append([]byte{responseFrameError}, []byte("blocked")...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := &recordingRoundTripper{}
+	rt.fn = func(req *http.Request) (*http.Response, error) {
+		if len(rt.requests) == 1 {
+			return textHTTPResponse(http.StatusOK, `viewerng/text?id=doc-error`), nil
+		}
+		return textHTTPResponse(http.StatusOK, viewerTextBodyForOriginBody(base64.StdEncoding.EncodeToString(encryptedError))), nil
+	}
+	c := &client{httpRTT: rt, config: &ClientConfig{
+		ViewerUrl:            "https://viewer.test/viewer",
+		TextUrl:              "https://viewer.test/viewerng/text",
+		OriginUrl:            "https://origin.test/gdocsviewer",
+		SharedKey:            key,
+		MinRequestIntervalMs: 1,
+	}}
+
+	_, err = c.RoundTrip(context.Background(), request.Request{Data: []byte("request")})
+	if err == nil || !strings.Contains(err.Error(), "blocked") {
+		t.Fatalf("expected encrypted error frame, got %v", err)
+	}
+}
+
+func TestRoundTripRejectsMalformedViewerData(t *testing.T) {
+	rt := &recordingRoundTripper{}
+	rt.fn = func(req *http.Request) (*http.Response, error) {
+		if len(rt.requests) == 1 {
+			return textHTTPResponse(http.StatusOK, `viewerng/text?id=doc-bad`), nil
+		}
+		return textHTTPResponse(http.StatusOK, `)]}'`+"\n"+`{"mimetype":"text/plain","data":`), nil
+	}
+	c := &client{httpRTT: rt, config: &ClientConfig{
+		ViewerUrl:            "https://viewer.test/viewer",
+		TextUrl:              "https://viewer.test/viewerng/text",
+		OriginUrl:            "https://origin.test/gdocsviewer",
+		MinRequestIntervalMs: 1,
+	}}
+
+	_, err := c.RoundTrip(context.Background(), request.Request{})
+	if err == nil {
+		t.Fatal("expected malformed viewer JSON error")
+	}
+}
+
+func TestRoundTripRejectsInvalidOriginBase64Body(t *testing.T) {
+	rt := &recordingRoundTripper{}
+	rt.fn = func(req *http.Request) (*http.Response, error) {
+		if len(rt.requests) == 1 {
+			return textHTTPResponse(http.StatusOK, `viewerng/text?id=doc-invalid`), nil
+		}
+		return textHTTPResponse(http.StatusOK, viewerTextBodyForOriginBody("not base64")), nil
+	}
+	c := &client{httpRTT: rt, config: &ClientConfig{
+		ViewerUrl:            "https://viewer.test/viewer",
+		TextUrl:              "https://viewer.test/viewerng/text",
+		OriginUrl:            "https://origin.test/gdocsviewer",
+		MinRequestIntervalMs: 1,
+	}}
+
+	_, err := c.RoundTrip(context.Background(), request.Request{})
+	if err == nil {
+		t.Fatal("expected invalid origin base64 error")
+	}
+}
+
+func TestServerPlaintextSuccessAndErrors(t *testing.T) {
+	receiver := &fakeTripperReceiver{
+		fn: func(ctx context.Context, req request.Request, opts ...request.RoundTripperOption) (request.Response, error) {
+			return request.Response{Data: []byte("pong")}, nil
+		},
+	}
+	s := &server{
+		config:   &ServerConfig{PathPrefix: "/g", MaxRequestBytes: 10},
+		assembly: fakeServerAssembly{receiver: receiver},
+	}
+
+	rec := httptest.NewRecorder()
+	s.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/g/r/"+base64.RawURLEncoding.EncodeToString([]byte("session"))+"/"+base64.RawURLEncoding.EncodeToString([]byte("ping"))+"/nonce.txt", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q", rec.Code, rec.Body.String())
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(rec.Body.String()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(decoded) != "pong" {
+		t.Fatalf("unexpected response body %q", decoded)
+	}
+	if receiver.calls != 1 || string(receiver.last.ConnectionTag) != "session" || string(receiver.last.Data) != "ping" {
+		t.Fatalf("unexpected receiver state calls=%d req=%+v", receiver.calls, receiver.last)
+	}
+
+	rec = httptest.NewRecorder()
+	s.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/g/r/c2Vzc2lvbg/"+base64.RawURLEncoding.EncodeToString([]byte("too large payload"))+"/nonce.txt", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected request-size rejection 404, got %d", rec.Code)
+	}
+
+	receiver.fn = func(ctx context.Context, req request.Request, opts ...request.RoundTripperOption) (request.Response, error) {
+		return request.Response{}, errors.New("backend failed")
+	}
+	rec = httptest.NewRecorder()
+	s.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/g/r/c2Vzc2lvbg/cGluZw/nonce.txt", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected backend error 404, got %d", rec.Code)
+	}
+}
+
+func TestServerRoundTripIgnoresHTTPRequestContextCancellation(t *testing.T) {
+	receiver := &fakeTripperReceiver{
+		fn: func(ctx context.Context, req request.Request, opts ...request.RoundTripperOption) (request.Response, error) {
+			if err := ctx.Err(); err != nil {
+				return request.Response{}, fmt.Errorf("roundtrip context is canceled: %w", err)
+			}
+			return request.Response{Data: []byte("pong")}, nil
+		},
+	}
+	s := &server{
+		ctx:      context.Background(),
+		config:   &ServerConfig{PathPrefix: "/g"},
+		assembly: fakeServerAssembly{receiver: receiver},
+	}
+
+	canceledContext, cancel := context.WithCancel(context.Background())
+	cancel()
+	httpReq := httptest.NewRequest(http.MethodGet, "/g/r/c2Vzc2lvbg/cGluZw/nonce.txt", nil).WithContext(canceledContext)
+	rec := httptest.NewRecorder()
+	s.ServeHTTP(rec, httpReq)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q", rec.Code, rec.Body.String())
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(rec.Body.String()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(decoded) != "pong" {
+		t.Fatalf("unexpected response body %q", decoded)
+	}
+}
+
+func TestServerModeGating(t *testing.T) {
+	key := bytes.Repeat([]byte{3}, 32)
+
+	plain := &server{config: &ServerConfig{PathPrefix: "/g"}, assembly: fakeServerAssembly{receiver: &fakeTripperReceiver{}}}
+	rec := httptest.NewRecorder()
+	plain.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/g/t/not-encrypted.log", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("plaintext server accepted encrypted path: %d", rec.Code)
+	}
+
+	encrypted := &server{config: &ServerConfig{PathPrefix: "/g", SharedKey: key}, assembly: fakeServerAssembly{receiver: &fakeTripperReceiver{}}}
+	rec = httptest.NewRecorder()
+	encrypted.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/g/r/cw/cA/nonce.txt", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("encrypted server accepted plaintext path: %d", rec.Code)
+	}
+}
+
+func TestServerEncryptedSuccessErrorAndLimits(t *testing.T) {
+	key := bytes.Repeat([]byte{4}, 32)
+	receiver := &fakeTripperReceiver{
+		fn: func(ctx context.Context, req request.Request, opts ...request.RoundTripperOption) (request.Response, error) {
+			return request.Response{Data: []byte("encrypted-pong")}, nil
+		},
+	}
+	s := &server{
+		config:   &ServerConfig{PathPrefix: "/g", SharedKey: key, MaxRequestBytes: 10, MaxResponseBytes: 20},
+		assembly: fakeServerAssembly{receiver: receiver},
+	}
+
+	rec := httptest.NewRecorder()
+	s.ServeHTTP(rec, encryptedServerRequest(t, key, "/g", []byte("session"), []byte("ping")))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q", rec.Code, rec.Body.String())
+	}
+	frame := decryptServerHTTPBody(t, key, rec.Body.String())
+	if frame[0] != responseFrameSuccess || string(frame[1:]) != "encrypted-pong" {
+		t.Fatalf("unexpected encrypted success frame %q", frame)
+	}
+	if receiver.calls != 1 || string(receiver.last.ConnectionTag) != "session" || string(receiver.last.Data) != "ping" {
+		t.Fatalf("unexpected receiver state calls=%d req=%+v", receiver.calls, receiver.last)
+	}
+
+	rec = httptest.NewRecorder()
+	s.ServeHTTP(rec, encryptedServerRequest(t, key, "/g", []byte("session"), []byte("too large payload")))
+	frame = decryptServerHTTPBody(t, key, rec.Body.String())
+	if rec.Code != http.StatusOK || frame[0] != responseFrameError || !strings.Contains(string(frame[1:]), "max_request_bytes") {
+		t.Fatalf("unexpected encrypted size error status=%d frame=%q", rec.Code, frame)
+	}
+
+	receiver.fn = func(ctx context.Context, req request.Request, opts ...request.RoundTripperOption) (request.Response, error) {
+		return request.Response{}, errors.New("backend failed")
+	}
+	rec = httptest.NewRecorder()
+	s.ServeHTTP(rec, encryptedServerRequest(t, key, "/g", []byte("session"), []byte("ping")))
+	frame = decryptServerHTTPBody(t, key, rec.Body.String())
+	if rec.Code != http.StatusOK || frame[0] != responseFrameError || !strings.Contains(string(frame[1:]), "backend failed") {
+		t.Fatalf("unexpected encrypted backend error status=%d frame=%q", rec.Code, frame)
+	}
+
+	receiver.fn = func(ctx context.Context, req request.Request, opts ...request.RoundTripperOption) (request.Response, error) {
+		return request.Response{Data: []byte("this response is too large")}, nil
+	}
+	rec = httptest.NewRecorder()
+	s.ServeHTTP(rec, encryptedServerRequest(t, key, "/g", []byte("session"), []byte("ping")))
+	frame = decryptServerHTTPBody(t, key, rec.Body.String())
+	if rec.Code != http.StatusOK || frame[0] != responseFrameError || !strings.Contains(string(frame[1:]), "max_response_bytes") {
+		t.Fatalf("unexpected encrypted response-size error status=%d frame=%q", rec.Code, frame)
+	}
+}
+
+func TestServerEncryptedAEADMismatchSignalsEncryptedError(t *testing.T) {
+	serverKey := bytes.Repeat([]byte{5}, 32)
+	clientKey := bytes.Repeat([]byte{6}, 32)
+	s := &server{
+		config:   &ServerConfig{PathPrefix: "/g", SharedKey: serverKey},
+		assembly: fakeServerAssembly{receiver: &fakeTripperReceiver{}},
+	}
+
+	rec := httptest.NewRecorder()
+	s.ServeHTTP(rec, encryptedServerRequest(t, clientKey, "/g", []byte("session"), []byte("ping")))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q", rec.Code, rec.Body.String())
+	}
+	frame := decryptServerHTTPBody(t, serverKey, rec.Body.String())
+	if frame[0] != responseFrameError {
+		t.Fatalf("unexpected frame %q", frame)
+	}
+	if _, err := decryptResponseFrame(clientKey, mustDecodeStdBase64(t, rec.Body.String())); err == nil {
+		t.Fatal("expected client key mismatch to fail decryption")
+	}
+}
+
+type recordingRoundTripper struct {
+	requests []*http.Request
+	fn       func(*http.Request) (*http.Response, error)
+}
+
+func (r *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.requests = append(r.requests, req.Clone(req.Context()))
+	return r.fn(req)
+}
+
+func textHTTPResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func viewerTextBodyForServerBody(body []byte) string {
+	return viewerTextBodyForOriginBody(base64.StdEncoding.EncodeToString(body))
+}
+
+func viewerTextBodyForOriginBody(originBody string) string {
+	body, err := json.Marshal(viewerTextResponse{Mimetype: "text/plain", Data: originBody})
+	if err != nil {
+		panic(err)
+	}
+	return ")]}'\n" + string(body)
+}
+
+type fakeServerAssembly struct {
+	receiver request.TripperReceiver
+}
+
+func (f fakeServerAssembly) TripperReceiver() request.TripperReceiver {
+	return f.receiver
+}
+
+func (f fakeServerAssembly) SessionReceiver() request.SessionReceiver {
+	return nil
+}
+
+func (f fakeServerAssembly) AutoImplListener() request.Listener {
+	return nil
+}
+
+type fakeTripperReceiver struct {
+	calls int
+	last  request.Request
+	fn    func(context.Context, request.Request, ...request.RoundTripperOption) (request.Response, error)
+}
+
+func (f *fakeTripperReceiver) OnRoundTrip(ctx context.Context, req request.Request, opts ...request.RoundTripperOption) (request.Response, error) {
+	f.calls++
+	f.last = request.Request{
+		Data:          append([]byte(nil), req.Data...),
+		ConnectionTag: append([]byte(nil), req.ConnectionTag...),
+	}
+	if f.fn != nil {
+		return f.fn(ctx, req, opts...)
+	}
+	return request.Response{}, nil
+}
+
+func encryptedServerRequest(t *testing.T, key []byte, prefix string, session []byte, payload []byte) *http.Request {
+	t.Helper()
+	combined, err := encryptClientRequest(key, session, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return httptest.NewRequest(http.MethodGet, prefix+"/t/"+base64.RawURLEncoding.EncodeToString(combined)+".log", nil)
+}
+
+func decryptServerHTTPBody(t *testing.T, key []byte, body string) []byte {
+	t.Helper()
+	combined := mustDecodeStdBase64(t, body)
+	frame, err := decryptResponseFrame(key, combined)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(frame) == 0 {
+		t.Fatal("empty frame")
+	}
+	return frame
+}
+
+func mustDecodeStdBase64(t *testing.T, body string) []byte {
+	t.Helper()
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return decoded
+}
+
+type zeroReader struct{}
+
+func (z zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+func allBytesIn(value string, allowed string) bool {
+	for i := 0; i < len(value); i++ {
+		if !strings.Contains(allowed, string(value[i])) {
+			return false
+		}
+	}
+	return true
+}

--- a/transport/internet/request/roundtripper/gdocsviewer/gdocsviewer_test.go
+++ b/transport/internet/request/roundtripper/gdocsviewer/gdocsviewer_test.go
@@ -231,12 +231,12 @@ func TestRoundTripPlaintextViewerFlowAndHeaders(t *testing.T) {
 			if len(parts) != 3 || parts[0] != "c2Vzc2lvbg" || parts[1] != "cmVxdWVzdA" || !strings.HasSuffix(parts[2], ".txt") {
 				t.Fatalf("unexpected origin request URL %q", origin)
 			}
-			return textHTTPResponse(http.StatusOK, `... "/viewerng/text?id=doc-1&authuser=0" ...`), nil
+			return textHTTPResponse(`... "/viewerng/text?id=doc-1&authuser=0" ...`), nil
 		case 2:
 			if req.URL.Path != "/viewerng/text" || req.URL.Query().Get("id") != "doc-1" || req.URL.Query().Get("page") != "0" {
 				t.Fatalf("unexpected text request URL %s", req.URL.String())
 			}
-			return textHTTPResponse(http.StatusOK, viewerTextBodyForServerBody([]byte("response"))), nil
+			return textHTTPResponse(viewerTextBodyForServerBody([]byte("response"))), nil
 		default:
 			t.Fatalf("unexpected request count %d", len(rt.requests))
 			return nil, nil
@@ -327,9 +327,9 @@ func TestRoundTripEncryptedErrorFrame(t *testing.T) {
 	rt := &recordingRoundTripper{}
 	rt.fn = func(req *http.Request) (*http.Response, error) {
 		if len(rt.requests) == 1 {
-			return textHTTPResponse(http.StatusOK, `viewerng/text?id=doc-error`), nil
+			return textHTTPResponse(`viewerng/text?id=doc-error`), nil
 		}
-		return textHTTPResponse(http.StatusOK, viewerTextBodyForOriginBody(base64.StdEncoding.EncodeToString(encryptedError))), nil
+		return textHTTPResponse(viewerTextBodyForOriginBody(base64.StdEncoding.EncodeToString(encryptedError))), nil
 	}
 	c := &client{httpRTT: rt, config: &ClientConfig{
 		ViewerUrl:            "https://viewer.test/viewer",
@@ -349,9 +349,9 @@ func TestRoundTripRejectsMalformedViewerData(t *testing.T) {
 	rt := &recordingRoundTripper{}
 	rt.fn = func(req *http.Request) (*http.Response, error) {
 		if len(rt.requests) == 1 {
-			return textHTTPResponse(http.StatusOK, `viewerng/text?id=doc-bad`), nil
+			return textHTTPResponse(`viewerng/text?id=doc-bad`), nil
 		}
-		return textHTTPResponse(http.StatusOK, `)]}'`+"\n"+`{"mimetype":"text/plain","data":`), nil
+		return textHTTPResponse(`)]}'` + "\n" + `{"mimetype":"text/plain","data":`), nil
 	}
 	c := &client{httpRTT: rt, config: &ClientConfig{
 		ViewerUrl:            "https://viewer.test/viewer",
@@ -370,9 +370,9 @@ func TestRoundTripRejectsInvalidOriginBase64Body(t *testing.T) {
 	rt := &recordingRoundTripper{}
 	rt.fn = func(req *http.Request) (*http.Response, error) {
 		if len(rt.requests) == 1 {
-			return textHTTPResponse(http.StatusOK, `viewerng/text?id=doc-invalid`), nil
+			return textHTTPResponse(`viewerng/text?id=doc-invalid`), nil
 		}
-		return textHTTPResponse(http.StatusOK, viewerTextBodyForOriginBody("not base64")), nil
+		return textHTTPResponse(viewerTextBodyForOriginBody("not base64")), nil
 	}
 	c := &client{httpRTT: rt, config: &ClientConfig{
 		ViewerUrl:            "https://viewer.test/viewer",
@@ -493,7 +493,7 @@ func TestServerEncryptedSuccessErrorAndLimits(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	s.ServeHTTP(rec, encryptedServerRequest(t, key, "/g", []byte("session"), []byte("ping")))
+	s.ServeHTTP(rec, encryptedServerRequest(t, key, []byte("session"), []byte("ping")))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%q", rec.Code, rec.Body.String())
 	}
@@ -506,7 +506,7 @@ func TestServerEncryptedSuccessErrorAndLimits(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
-	s.ServeHTTP(rec, encryptedServerRequest(t, key, "/g", []byte("session"), []byte("too large payload")))
+	s.ServeHTTP(rec, encryptedServerRequest(t, key, []byte("session"), []byte("too large payload")))
 	frame = decryptServerHTTPBody(t, key, rec.Body.String())
 	if rec.Code != http.StatusOK || frame[0] != responseFrameError || !strings.Contains(string(frame[1:]), "max_request_bytes") {
 		t.Fatalf("unexpected encrypted size error status=%d frame=%q", rec.Code, frame)
@@ -516,7 +516,7 @@ func TestServerEncryptedSuccessErrorAndLimits(t *testing.T) {
 		return request.Response{}, errors.New("backend failed")
 	}
 	rec = httptest.NewRecorder()
-	s.ServeHTTP(rec, encryptedServerRequest(t, key, "/g", []byte("session"), []byte("ping")))
+	s.ServeHTTP(rec, encryptedServerRequest(t, key, []byte("session"), []byte("ping")))
 	frame = decryptServerHTTPBody(t, key, rec.Body.String())
 	if rec.Code != http.StatusOK || frame[0] != responseFrameError || !strings.Contains(string(frame[1:]), "backend failed") {
 		t.Fatalf("unexpected encrypted backend error status=%d frame=%q", rec.Code, frame)
@@ -526,7 +526,7 @@ func TestServerEncryptedSuccessErrorAndLimits(t *testing.T) {
 		return request.Response{Data: []byte("this response is too large")}, nil
 	}
 	rec = httptest.NewRecorder()
-	s.ServeHTTP(rec, encryptedServerRequest(t, key, "/g", []byte("session"), []byte("ping")))
+	s.ServeHTTP(rec, encryptedServerRequest(t, key, []byte("session"), []byte("ping")))
 	frame = decryptServerHTTPBody(t, key, rec.Body.String())
 	if rec.Code != http.StatusOK || frame[0] != responseFrameError || !strings.Contains(string(frame[1:]), "max_response_bytes") {
 		t.Fatalf("unexpected encrypted response-size error status=%d frame=%q", rec.Code, frame)
@@ -542,7 +542,7 @@ func TestServerEncryptedAEADMismatchSignalsEncryptedError(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	s.ServeHTTP(rec, encryptedServerRequest(t, clientKey, "/g", []byte("session"), []byte("ping")))
+	s.ServeHTTP(rec, encryptedServerRequest(t, clientKey, []byte("session"), []byte("ping")))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%q", rec.Code, rec.Body.String())
 	}
@@ -565,10 +565,10 @@ func (r *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 	return r.fn(req)
 }
 
-func textHTTPResponse(status int, body string) *http.Response {
+func textHTTPResponse(body string) *http.Response {
 	return &http.Response{
-		StatusCode: status,
-		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		StatusCode: http.StatusOK,
+		Status:     fmt.Sprintf("%d %s", http.StatusOK, http.StatusText(http.StatusOK)),
 		Header:     make(http.Header),
 		Body:       io.NopCloser(strings.NewReader(body)),
 	}
@@ -620,13 +620,13 @@ func (f *fakeTripperReceiver) OnRoundTrip(ctx context.Context, req request.Reque
 	return request.Response{}, nil
 }
 
-func encryptedServerRequest(t *testing.T, key []byte, prefix string, session []byte, payload []byte) *http.Request {
+func encryptedServerRequest(t *testing.T, key []byte, session []byte, payload []byte) *http.Request {
 	t.Helper()
 	combined, err := encryptClientRequest(key, session, payload)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return httptest.NewRequest(http.MethodGet, prefix+"/t/"+base64.RawURLEncoding.EncodeToString(combined)+".log", nil)
+	return httptest.NewRequest(http.MethodGet, "/g/t/"+base64.RawURLEncoding.EncodeToString(combined)+".log", nil)
 }
 
 func decryptServerHTTPBody(t *testing.T, key []byte, body string) []byte {

--- a/transport/internet/request/roundtripper/gdocsviewer/origin_url_pattern.go
+++ b/transport/internet/request/roundtripper/gdocsviewer/origin_url_pattern.go
@@ -1,0 +1,187 @@
+package gdocsviewer
+
+import (
+	crand "crypto/rand"
+	"io"
+	"math/big"
+	"strings"
+)
+
+const maxGeneratedOriginURLReplacementBytes = 256
+
+type originURLPatternAtom struct {
+	choices []byte
+	count   int
+}
+
+func renderOriginURL(config *ClientConfig) (string, error) {
+	if config == nil || config.OriginUrl == "" {
+		return "", newError("origin_url is required")
+	}
+	originURL := config.OriginUrl
+	for _, rule := range config.OriginUrlReplacementRules {
+		value, err := generateOriginURLReplacement(rule, crand.Reader)
+		if err != nil {
+			return "", err
+		}
+		originURL = strings.ReplaceAll(originURL, "{"+rule.Name+"}", value)
+	}
+	return strings.TrimRight(originURL, "/"), nil
+}
+
+func generateOriginURLReplacement(rule *OriginUrlReplacementRule, random io.Reader) (string, error) {
+	if rule == nil {
+		return "", newError("origin_url_replacement_rules contains nil rule")
+	}
+	if err := validateOriginURLReplacementName(rule.Name); err != nil {
+		return "", err
+	}
+	compiled, length, err := compileOriginURLPattern(rule.Pattern)
+	if err != nil {
+		return "", err
+	}
+	out := make([]byte, 0, length)
+	for _, atom := range compiled {
+		for i := 0; i < atom.count; i++ {
+			index, err := randomIndex(random, len(atom.choices))
+			if err != nil {
+				return "", newError("unable to generate origin URL replacement").Base(err)
+			}
+			out = append(out, atom.choices[index])
+		}
+	}
+	return string(out), nil
+}
+
+func validateOriginURLReplacementName(name string) error {
+	if name == "" {
+		return newError("origin URL replacement rule name is required")
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '-' || c == '.' {
+			continue
+		}
+		return newError("invalid origin URL replacement rule name: ", name)
+	}
+	return nil
+}
+
+func compileOriginURLPattern(pattern string) ([]originURLPatternAtom, int, error) {
+	if pattern == "" {
+		return nil, 0, newError("origin URL replacement pattern is required")
+	}
+	var atoms []originURLPatternAtom
+	totalLength := 0
+	for i := 0; i < len(pattern); {
+		var atom originURLPatternAtom
+		var err error
+		switch pattern[i] {
+		case '[':
+			atom.choices, i, err = parseOriginURLPatternClass(pattern, i)
+			if err != nil {
+				return nil, 0, err
+			}
+		case '\\':
+			if i+1 >= len(pattern) {
+				return nil, 0, newError("dangling escape in origin URL replacement pattern")
+			}
+			atom.choices = []byte{pattern[i+1]}
+			i += 2
+		case '(', ')', '|', '*', '+', '?':
+			return nil, 0, newError("unsupported origin URL replacement pattern operator: ", string(pattern[i]))
+		case '{', '}':
+			return nil, 0, newError("unexpected repeat marker in origin URL replacement pattern")
+		default:
+			atom.choices = []byte{pattern[i]}
+			i++
+		}
+		atom.count = 1
+		if i < len(pattern) && pattern[i] == '{' {
+			atom.count, i, err = parseOriginURLPatternRepeat(pattern, i)
+			if err != nil {
+				return nil, 0, err
+			}
+		}
+		totalLength += atom.count
+		if totalLength > maxGeneratedOriginURLReplacementBytes {
+			return nil, 0, newError("origin URL replacement output exceeds limit: ", maxGeneratedOriginURLReplacementBytes)
+		}
+		atoms = append(atoms, atom)
+	}
+	return atoms, totalLength, nil
+}
+
+func parseOriginURLPatternClass(pattern string, pos int) ([]byte, int, error) {
+	var choices []byte
+	i := pos + 1
+	for i < len(pattern) {
+		if pattern[i] == ']' {
+			if len(choices) == 0 {
+				return nil, 0, newError("empty character class in origin URL replacement pattern")
+			}
+			return choices, i + 1, nil
+		}
+		start, next, escaped, err := readOriginURLClassChar(pattern, i)
+		if err != nil {
+			return nil, 0, err
+		}
+		if !escaped && next < len(pattern) && pattern[next] == '-' && next+1 < len(pattern) && pattern[next+1] != ']' {
+			end, afterEnd, _, err := readOriginURLClassChar(pattern, next+1)
+			if err != nil {
+				return nil, 0, err
+			}
+			if end < start {
+				return nil, 0, newError("invalid descending range in origin URL replacement pattern")
+			}
+			for c := int(start); c <= int(end); c++ {
+				choices = append(choices, byte(c))
+			}
+			i = afterEnd
+			continue
+		}
+		choices = append(choices, start)
+		i = next
+	}
+	return nil, 0, newError("unterminated character class in origin URL replacement pattern")
+}
+
+func readOriginURLClassChar(pattern string, pos int) (byte, int, bool, error) {
+	if pattern[pos] == '\\' {
+		if pos+1 >= len(pattern) {
+			return 0, 0, false, newError("dangling escape in origin URL replacement character class")
+		}
+		return pattern[pos+1], pos + 2, true, nil
+	}
+	return pattern[pos], pos + 1, false, nil
+}
+
+func parseOriginURLPatternRepeat(pattern string, pos int) (int, int, error) {
+	i := pos + 1
+	if i >= len(pattern) || pattern[i] < '0' || pattern[i] > '9' {
+		return 0, 0, newError("origin URL replacement repeat must be a fixed count")
+	}
+	count := 0
+	for i < len(pattern) && pattern[i] >= '0' && pattern[i] <= '9' {
+		count = count*10 + int(pattern[i]-'0')
+		if count > maxGeneratedOriginURLReplacementBytes {
+			return 0, 0, newError("origin URL replacement repeat exceeds limit: ", maxGeneratedOriginURLReplacementBytes)
+		}
+		i++
+	}
+	if i >= len(pattern) || pattern[i] != '}' {
+		return 0, 0, newError("unterminated repeat in origin URL replacement pattern")
+	}
+	if count == 0 {
+		return 0, 0, newError("origin URL replacement repeat must be greater than zero")
+	}
+	return count, i + 1, nil
+}
+
+func randomIndex(random io.Reader, size int) (int, error) {
+	value, err := crand.Int(random, big.NewInt(int64(size)))
+	if err != nil {
+		return 0, err
+	}
+	return int(value.Int64()), nil
+}

--- a/transport/internet/request/stereotype/gdocsviewer/config.pb.go
+++ b/transport/internet/request/stereotype/gdocsviewer/config.pb.go
@@ -1,0 +1,301 @@
+package gdocsviewer
+
+import (
+	_ "github.com/v2fly/v2ray-core/v5/common/protoext"
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+)
+
+const (
+	// Verify that this generated code is sufficiently up-to-date.
+	_ = protoimpl.EnforceVersion(20 - protoimpl.MinVersion)
+	// Verify that runtime/protoimpl is sufficiently up-to-date.
+	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
+)
+
+type Config struct {
+	state                     protoimpl.MessageState      `protogen:"open.v1"`
+	ViewerUrl                 string                      `protobuf:"bytes,1,opt,name=viewer_url,json=viewerUrl,proto3" json:"viewer_url,omitempty"`
+	TextUrl                   string                      `protobuf:"bytes,2,opt,name=text_url,json=textUrl,proto3" json:"text_url,omitempty"`
+	OriginUrl                 string                      `protobuf:"bytes,3,opt,name=origin_url,json=originUrl,proto3" json:"origin_url,omitempty"`
+	ViewerHostHeader          string                      `protobuf:"bytes,4,opt,name=viewer_host_header,json=viewerHostHeader,proto3" json:"viewer_host_header,omitempty"`
+	UserAgent                 string                      `protobuf:"bytes,5,opt,name=user_agent,json=userAgent,proto3" json:"user_agent,omitempty"`
+	AllowHttp                 bool                        `protobuf:"varint,6,opt,name=allow_http,json=allowHttp,proto3" json:"allow_http,omitempty"`
+	H2PoolSize                int32                       `protobuf:"varint,7,opt,name=h2_pool_size,json=h2PoolSize,proto3" json:"h2_pool_size,omitempty"`
+	MaxViewerBodyBytes        int32                       `protobuf:"varint,8,opt,name=max_viewer_body_bytes,json=maxViewerBodyBytes,proto3" json:"max_viewer_body_bytes,omitempty"`
+	MinRequestIntervalMs      int32                       `protobuf:"varint,9,opt,name=min_request_interval_ms,json=minRequestIntervalMs,proto3" json:"min_request_interval_ms,omitempty"`
+	SharedKey                 []byte                      `protobuf:"bytes,10,opt,name=shared_key,json=sharedKey,proto3" json:"shared_key,omitempty"`
+	PathPrefix                string                      `protobuf:"bytes,11,opt,name=path_prefix,json=pathPrefix,proto3" json:"path_prefix,omitempty"`
+	MaxRequestBytes           int32                       `protobuf:"varint,12,opt,name=max_request_bytes,json=maxRequestBytes,proto3" json:"max_request_bytes,omitempty"`
+	MaxResponseBytes          int32                       `protobuf:"varint,13,opt,name=max_response_bytes,json=maxResponseBytes,proto3" json:"max_response_bytes,omitempty"`
+	OriginUrlReplacementRules []*OriginUrlReplacementRule `protobuf:"bytes,14,rep,name=origin_url_replacement_rules,json=originUrlReplacementRules,proto3" json:"origin_url_replacement_rules,omitempty"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
+}
+
+func (x *Config) Reset() {
+	*x = Config{}
+	mi := &file_transport_internet_request_stereotype_gdocsviewer_config_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Config) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Config) ProtoMessage() {}
+
+func (x *Config) ProtoReflect() protoreflect.Message {
+	mi := &file_transport_internet_request_stereotype_gdocsviewer_config_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Config.ProtoReflect.Descriptor instead.
+func (*Config) Descriptor() ([]byte, []int) {
+	return file_transport_internet_request_stereotype_gdocsviewer_config_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *Config) GetViewerUrl() string {
+	if x != nil {
+		return x.ViewerUrl
+	}
+	return ""
+}
+
+func (x *Config) GetTextUrl() string {
+	if x != nil {
+		return x.TextUrl
+	}
+	return ""
+}
+
+func (x *Config) GetOriginUrl() string {
+	if x != nil {
+		return x.OriginUrl
+	}
+	return ""
+}
+
+func (x *Config) GetViewerHostHeader() string {
+	if x != nil {
+		return x.ViewerHostHeader
+	}
+	return ""
+}
+
+func (x *Config) GetUserAgent() string {
+	if x != nil {
+		return x.UserAgent
+	}
+	return ""
+}
+
+func (x *Config) GetAllowHttp() bool {
+	if x != nil {
+		return x.AllowHttp
+	}
+	return false
+}
+
+func (x *Config) GetH2PoolSize() int32 {
+	if x != nil {
+		return x.H2PoolSize
+	}
+	return 0
+}
+
+func (x *Config) GetMaxViewerBodyBytes() int32 {
+	if x != nil {
+		return x.MaxViewerBodyBytes
+	}
+	return 0
+}
+
+func (x *Config) GetMinRequestIntervalMs() int32 {
+	if x != nil {
+		return x.MinRequestIntervalMs
+	}
+	return 0
+}
+
+func (x *Config) GetSharedKey() []byte {
+	if x != nil {
+		return x.SharedKey
+	}
+	return nil
+}
+
+func (x *Config) GetPathPrefix() string {
+	if x != nil {
+		return x.PathPrefix
+	}
+	return ""
+}
+
+func (x *Config) GetMaxRequestBytes() int32 {
+	if x != nil {
+		return x.MaxRequestBytes
+	}
+	return 0
+}
+
+func (x *Config) GetMaxResponseBytes() int32 {
+	if x != nil {
+		return x.MaxResponseBytes
+	}
+	return 0
+}
+
+func (x *Config) GetOriginUrlReplacementRules() []*OriginUrlReplacementRule {
+	if x != nil {
+		return x.OriginUrlReplacementRules
+	}
+	return nil
+}
+
+type OriginUrlReplacementRule struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Pattern       string                 `protobuf:"bytes,2,opt,name=pattern,proto3" json:"pattern,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OriginUrlReplacementRule) Reset() {
+	*x = OriginUrlReplacementRule{}
+	mi := &file_transport_internet_request_stereotype_gdocsviewer_config_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OriginUrlReplacementRule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OriginUrlReplacementRule) ProtoMessage() {}
+
+func (x *OriginUrlReplacementRule) ProtoReflect() protoreflect.Message {
+	mi := &file_transport_internet_request_stereotype_gdocsviewer_config_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OriginUrlReplacementRule.ProtoReflect.Descriptor instead.
+func (*OriginUrlReplacementRule) Descriptor() ([]byte, []int) {
+	return file_transport_internet_request_stereotype_gdocsviewer_config_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *OriginUrlReplacementRule) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *OriginUrlReplacementRule) GetPattern() string {
+	if x != nil {
+		return x.Pattern
+	}
+	return ""
+}
+
+var File_transport_internet_request_stereotype_gdocsviewer_config_proto protoreflect.FileDescriptor
+
+const file_transport_internet_request_stereotype_gdocsviewer_config_proto_rawDesc = "" +
+	"\n" +
+	">transport/internet/request/stereotype/gdocsviewer/config.proto\x12<v2ray.core.transport.internet.request.stereotype.gdocsviewer\x1a common/protoext/extensions.proto\"\xaf\x05\n" +
+	"\x06Config\x12\x1d\n" +
+	"\n" +
+	"viewer_url\x18\x01 \x01(\tR\tviewerUrl\x12\x19\n" +
+	"\btext_url\x18\x02 \x01(\tR\atextUrl\x12\x1d\n" +
+	"\n" +
+	"origin_url\x18\x03 \x01(\tR\toriginUrl\x12,\n" +
+	"\x12viewer_host_header\x18\x04 \x01(\tR\x10viewerHostHeader\x12\x1d\n" +
+	"\n" +
+	"user_agent\x18\x05 \x01(\tR\tuserAgent\x12\x1d\n" +
+	"\n" +
+	"allow_http\x18\x06 \x01(\bR\tallowHttp\x12 \n" +
+	"\fh2_pool_size\x18\a \x01(\x05R\n" +
+	"h2PoolSize\x121\n" +
+	"\x15max_viewer_body_bytes\x18\b \x01(\x05R\x12maxViewerBodyBytes\x125\n" +
+	"\x17min_request_interval_ms\x18\t \x01(\x05R\x14minRequestIntervalMs\x12\x1d\n" +
+	"\n" +
+	"shared_key\x18\n" +
+	" \x01(\fR\tsharedKey\x12\x1f\n" +
+	"\vpath_prefix\x18\v \x01(\tR\n" +
+	"pathPrefix\x12*\n" +
+	"\x11max_request_bytes\x18\f \x01(\x05R\x0fmaxRequestBytes\x12,\n" +
+	"\x12max_response_bytes\x18\r \x01(\x05R\x10maxResponseBytes\x12\x97\x01\n" +
+	"\x1corigin_url_replacement_rules\x18\x0e \x03(\v2V.v2ray.core.transport.internet.request.stereotype.gdocsviewer.OriginUrlReplacementRuleR\x19originUrlReplacementRules: \x82\xb5\x18\x1c\n" +
+	"\ttransport\x12\vgdocsviewer\x90\xff)\x01\"H\n" +
+	"\x18OriginUrlReplacementRule\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
+	"\apattern\x18\x02 \x01(\tR\apatternB\xd5\x01\n" +
+	"@com.v2ray.core.transport.internet.request.stereotype.gdocsviewerP\x01ZPgithub.com/v2fly/v2ray-core/v5/transport/internet/request/stereotype/gdocsviewer\xaa\x02<V2Ray.Core.Transport.Internet.Request.Stereotype.Gdocsviewerb\x06proto3"
+
+var (
+	file_transport_internet_request_stereotype_gdocsviewer_config_proto_rawDescOnce sync.Once
+	file_transport_internet_request_stereotype_gdocsviewer_config_proto_rawDescData []byte
+)
+
+func file_transport_internet_request_stereotype_gdocsviewer_config_proto_rawDescGZIP() []byte {
+	file_transport_internet_request_stereotype_gdocsviewer_config_proto_rawDescOnce.Do(func() {
+		file_transport_internet_request_stereotype_gdocsviewer_config_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_transport_internet_request_stereotype_gdocsviewer_config_proto_rawDesc), len(file_transport_internet_request_stereotype_gdocsviewer_config_proto_rawDesc)))
+	})
+	return file_transport_internet_request_stereotype_gdocsviewer_config_proto_rawDescData
+}
+
+var file_transport_internet_request_stereotype_gdocsviewer_config_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_transport_internet_request_stereotype_gdocsviewer_config_proto_goTypes = []any{
+	(*Config)(nil),                   // 0: v2ray.core.transport.internet.request.stereotype.gdocsviewer.Config
+	(*OriginUrlReplacementRule)(nil), // 1: v2ray.core.transport.internet.request.stereotype.gdocsviewer.OriginUrlReplacementRule
+}
+var file_transport_internet_request_stereotype_gdocsviewer_config_proto_depIdxs = []int32{
+	1, // 0: v2ray.core.transport.internet.request.stereotype.gdocsviewer.Config.origin_url_replacement_rules:type_name -> v2ray.core.transport.internet.request.stereotype.gdocsviewer.OriginUrlReplacementRule
+	1, // [1:1] is the sub-list for method output_type
+	1, // [1:1] is the sub-list for method input_type
+	1, // [1:1] is the sub-list for extension type_name
+	1, // [1:1] is the sub-list for extension extendee
+	0, // [0:1] is the sub-list for field type_name
+}
+
+func init() { file_transport_internet_request_stereotype_gdocsviewer_config_proto_init() }
+func file_transport_internet_request_stereotype_gdocsviewer_config_proto_init() {
+	if File_transport_internet_request_stereotype_gdocsviewer_config_proto != nil {
+		return
+	}
+	type x struct{}
+	out := protoimpl.TypeBuilder{
+		File: protoimpl.DescBuilder{
+			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_transport_internet_request_stereotype_gdocsviewer_config_proto_rawDesc), len(file_transport_internet_request_stereotype_gdocsviewer_config_proto_rawDesc)),
+			NumEnums:      0,
+			NumMessages:   2,
+			NumExtensions: 0,
+			NumServices:   0,
+		},
+		GoTypes:           file_transport_internet_request_stereotype_gdocsviewer_config_proto_goTypes,
+		DependencyIndexes: file_transport_internet_request_stereotype_gdocsviewer_config_proto_depIdxs,
+		MessageInfos:      file_transport_internet_request_stereotype_gdocsviewer_config_proto_msgTypes,
+	}.Build()
+	File_transport_internet_request_stereotype_gdocsviewer_config_proto = out.File
+	file_transport_internet_request_stereotype_gdocsviewer_config_proto_goTypes = nil
+	file_transport_internet_request_stereotype_gdocsviewer_config_proto_depIdxs = nil
+}

--- a/transport/internet/request/stereotype/gdocsviewer/config.proto
+++ b/transport/internet/request/stereotype/gdocsviewer/config.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+
+package v2ray.core.transport.internet.request.stereotype.gdocsviewer;
+option csharp_namespace = "V2Ray.Core.Transport.Internet.Request.Stereotype.Gdocsviewer";
+option go_package = "github.com/v2fly/v2ray-core/v5/transport/internet/request/stereotype/gdocsviewer";
+option java_package = "com.v2ray.core.transport.internet.request.stereotype.gdocsviewer";
+option java_multiple_files = true;
+
+import "common/protoext/extensions.proto";
+
+message Config {
+  option (v2ray.core.common.protoext.message_opt).type = "transport";
+  option (v2ray.core.common.protoext.message_opt).short_name = "gdocsviewer";
+  option (v2ray.core.common.protoext.message_opt).allow_restricted_mode_load = true;
+
+  string viewer_url = 1;
+  string text_url = 2;
+  string origin_url = 3;
+  string viewer_host_header = 4;
+  string user_agent = 5;
+  bool allow_http = 6;
+  int32 h2_pool_size = 7;
+  int32 max_viewer_body_bytes = 8;
+  int32 min_request_interval_ms = 9;
+  bytes shared_key = 10;
+  string path_prefix = 11;
+  int32 max_request_bytes = 12;
+  int32 max_response_bytes = 13;
+  repeated OriginUrlReplacementRule origin_url_replacement_rules = 14;
+}
+
+message OriginUrlReplacementRule {
+  string name = 1;
+  string pattern = 2;
+}

--- a/transport/internet/request/stereotype/gdocsviewer/errors.generated.go
+++ b/transport/internet/request/stereotype/gdocsviewer/errors.generated.go
@@ -1,0 +1,9 @@
+package gdocsviewer
+
+import "github.com/v2fly/v2ray-core/v5/common/errors"
+
+type errPathObjHolder struct{}
+
+func newError(values ...interface{}) *errors.Error {
+	return errors.New(values...).WithPathObj(errPathObjHolder{})
+}

--- a/transport/internet/request/stereotype/gdocsviewer/gdocsviewer.go
+++ b/transport/internet/request/stereotype/gdocsviewer/gdocsviewer.go
@@ -1,0 +1,140 @@
+package gdocsviewer
+
+import (
+	"context"
+
+	"github.com/v2fly/v2ray-core/v5/common"
+	"github.com/v2fly/v2ray-core/v5/common/net"
+	"github.com/v2fly/v2ray-core/v5/common/serial"
+	"github.com/v2fly/v2ray-core/v5/transport/internet"
+	"github.com/v2fly/v2ray-core/v5/transport/internet/request/assembler/simple"
+	"github.com/v2fly/v2ray-core/v5/transport/internet/request/assembly"
+	roundtripper "github.com/v2fly/v2ray-core/v5/transport/internet/request/roundtripper/gdocsviewer"
+)
+
+//go:generate go run github.com/v2fly/v2ray-core/v5/common/errors/errorgen
+
+const protocolName = "gdocsviewer"
+
+func init() {
+	common.Must(common.RegisterConfig((*Config)(nil), func(ctx context.Context, config interface{}) (interface{}, error) {
+		return nil, newError("gdocsviewer is a transport")
+	}))
+
+	common.Must(internet.RegisterTransportDialer(protocolName, dial))
+	common.Must(internet.RegisterTransportListener(protocolName, listen))
+}
+
+func dial(ctx context.Context, dest net.Destination, streamSettings *internet.MemoryStreamConfig) (internet.Connection, error) {
+	setting := streamSettings.ProtocolSettings.(*Config)
+	requestConfig := buildClientRequestConfig(setting)
+	constructedSetting := &internet.MemoryStreamConfig{
+		ProtocolName:     "request",
+		ProtocolSettings: requestConfig,
+		SecurityType:     streamSettings.SecurityType,
+		SecuritySettings: streamSettings.SecuritySettings,
+		SocketSettings:   streamSettings.SocketSettings,
+	}
+	return internet.Dial(ctx, dest, constructedSetting)
+}
+
+func listen(ctx context.Context, address net.Address, port net.Port, streamSettings *internet.MemoryStreamConfig, callback internet.ConnHandler) (internet.Listener, error) {
+	setting := streamSettings.ProtocolSettings.(*Config)
+	requestConfig := buildServerRequestConfig(setting)
+	constructedSetting := &internet.MemoryStreamConfig{
+		ProtocolName:     "request",
+		ProtocolSettings: requestConfig,
+		SecurityType:     streamSettings.SecurityType,
+		SecuritySettings: streamSettings.SecuritySettings,
+		SocketSettings:   streamSettings.SocketSettings,
+	}
+	return internet.ListenTCP(ctx, address, port, constructedSetting, callback)
+}
+
+func buildClientRequestConfig(setting *Config) *assembly.Config {
+	if setting == nil {
+		setting = &Config{}
+	}
+	requestConfig := &assembly.Config{
+		Assembler: serial.ToTypedMessage(&simple.ClientConfig{
+			MaxWriteSize:             int32(maxRequestBytes(setting)),
+			WaitSubsequentWriteMs:    10,
+			InitialPollingIntervalMs: minRequestIntervalMs(setting),
+			MaxPollingIntervalMs:     1000,
+			MinPollingIntervalMs:     minRequestIntervalMs(setting),
+			BackoffFactor:            1.5,
+			FailedRetryIntervalMs:    1000,
+		}),
+		Roundtripper: serial.ToTypedMessage(&roundtripper.ClientConfig{
+			ViewerUrl:                 setting.ViewerUrl,
+			TextUrl:                   setting.TextUrl,
+			OriginUrl:                 setting.OriginUrl,
+			ViewerHostHeader:          setting.ViewerHostHeader,
+			UserAgent:                 setting.UserAgent,
+			AllowHttp:                 setting.AllowHttp,
+			H2PoolSize:                setting.H2PoolSize,
+			MaxViewerBodyBytes:        setting.MaxViewerBodyBytes,
+			MinRequestIntervalMs:      setting.MinRequestIntervalMs,
+			SharedKey:                 setting.SharedKey,
+			OriginUrlReplacementRules: convertOriginURLReplacementRules(setting.OriginUrlReplacementRules),
+		}),
+	}
+	return requestConfig
+}
+
+func convertOriginURLReplacementRules(rules []*OriginUrlReplacementRule) []*roundtripper.OriginUrlReplacementRule {
+	if len(rules) == 0 {
+		return nil
+	}
+	converted := make([]*roundtripper.OriginUrlReplacementRule, 0, len(rules))
+	for _, rule := range rules {
+		if rule == nil {
+			converted = append(converted, nil)
+			continue
+		}
+		converted = append(converted, &roundtripper.OriginUrlReplacementRule{
+			Name:    rule.Name,
+			Pattern: rule.Pattern,
+		})
+	}
+	return converted
+}
+
+func buildServerRequestConfig(setting *Config) *assembly.Config {
+	if setting == nil {
+		setting = &Config{}
+	}
+	requestConfig := &assembly.Config{
+		Assembler: serial.ToTypedMessage(&simple.ServerConfig{
+			MaxWriteSize: int32(maxResponseBytes(setting)),
+		}),
+		Roundtripper: serial.ToTypedMessage(&roundtripper.ServerConfig{
+			PathPrefix:       setting.PathPrefix,
+			MaxRequestBytes:  setting.MaxRequestBytes,
+			MaxResponseBytes: setting.MaxResponseBytes,
+			SharedKey:        setting.SharedKey,
+		}),
+	}
+	return requestConfig
+}
+
+func maxRequestBytes(config *Config) int {
+	if config != nil && config.MaxRequestBytes > 0 {
+		return int(config.MaxRequestBytes)
+	}
+	return 1100
+}
+
+func maxResponseBytes(config *Config) int {
+	if config != nil && config.MaxResponseBytes > 0 {
+		return int(config.MaxResponseBytes)
+	}
+	return 64 * 1024
+}
+
+func minRequestIntervalMs(config *Config) int32 {
+	if config != nil && config.MinRequestIntervalMs > 0 {
+		return config.MinRequestIntervalMs
+	}
+	return 100
+}

--- a/transport/internet/request/stereotype/gdocsviewer/gdocsviewer_test.go
+++ b/transport/internet/request/stereotype/gdocsviewer/gdocsviewer_test.go
@@ -1,0 +1,90 @@
+package gdocsviewer
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/v2fly/v2ray-core/v5/common/serial"
+	"github.com/v2fly/v2ray-core/v5/transport/internet/request/assembler/simple"
+	roundtripper "github.com/v2fly/v2ray-core/v5/transport/internet/request/roundtripper/gdocsviewer"
+)
+
+func TestBuildClientRequestConfig(t *testing.T) {
+	key := bytes.Repeat([]byte{8}, 32)
+	config := buildClientRequestConfig(&Config{
+		ViewerUrl:            "https://viewer.example/viewer",
+		TextUrl:              "https://viewer.example/viewerng/text",
+		OriginUrl:            "https://origin.example/g",
+		ViewerHostHeader:     "docs.example",
+		UserAgent:            "ua",
+		AllowHttp:            true,
+		H2PoolSize:           4,
+		MaxViewerBodyBytes:   1234,
+		MinRequestIntervalMs: 5,
+		MaxRequestBytes:      777,
+		SharedKey:            key,
+		OriginUrlReplacementRules: []*OriginUrlReplacementRule{{
+			Name:    "abc",
+			Pattern: "[a-z0-9]{14}",
+		}},
+	})
+
+	assembler, err := serial.GetInstanceOf(config.Assembler)
+	if err != nil {
+		t.Fatal(err)
+	}
+	simpleConfig := assembler.(*simple.ClientConfig)
+	if simpleConfig.MaxWriteSize != 777 || simpleConfig.InitialPollingIntervalMs != 5 {
+		t.Fatalf("unexpected simple client config %+v", simpleConfig)
+	}
+
+	rt, err := serial.GetInstanceOf(config.Roundtripper)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rtConfig := rt.(*roundtripper.ClientConfig)
+	if rtConfig.OriginUrl != "https://origin.example/g" ||
+		rtConfig.ViewerHostHeader != "docs.example" ||
+		rtConfig.UserAgent != "ua" ||
+		!rtConfig.AllowHttp ||
+		rtConfig.H2PoolSize != 4 ||
+		rtConfig.MaxViewerBodyBytes != 1234 ||
+		rtConfig.MinRequestIntervalMs != 5 ||
+		!bytes.Equal(rtConfig.SharedKey, key) ||
+		len(rtConfig.OriginUrlReplacementRules) != 1 ||
+		rtConfig.OriginUrlReplacementRules[0].Name != "abc" ||
+		rtConfig.OriginUrlReplacementRules[0].Pattern != "[a-z0-9]{14}" {
+		t.Fatalf("unexpected gdocsviewer client config %+v", rtConfig)
+	}
+}
+
+func TestBuildServerRequestConfig(t *testing.T) {
+	key := bytes.Repeat([]byte{8}, 32)
+	config := buildServerRequestConfig(&Config{
+		PathPrefix:       "/g",
+		MaxRequestBytes:  777,
+		MaxResponseBytes: 888,
+		SharedKey:        key,
+	})
+
+	assembler, err := serial.GetInstanceOf(config.Assembler)
+	if err != nil {
+		t.Fatal(err)
+	}
+	simpleConfig := assembler.(*simple.ServerConfig)
+	if simpleConfig.MaxWriteSize != 888 {
+		t.Fatalf("unexpected simple server config %+v", simpleConfig)
+	}
+
+	rt, err := serial.GetInstanceOf(config.Roundtripper)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rtConfig := rt.(*roundtripper.ServerConfig)
+	if rtConfig.PathPrefix != "/g" ||
+		rtConfig.MaxRequestBytes != 777 ||
+		rtConfig.MaxResponseBytes != 888 ||
+		!bytes.Equal(rtConfig.SharedKey, key) {
+		t.Fatalf("unexpected gdocsviewer server config %+v", rtConfig)
+	}
+}


### PR DESCRIPTION
This pull request adds a Google Docs Viewer based transport based on the tunnel method utilized in https://github.com/0xinf0/gdocs-tunnel.

This tunnel method has been tested to work correctly in Iran without requiring special network position, however, due to its slowness, it is not suitable in environments where other protocol could work.

This merge request's change set is primarily generated by LLM, and its protocol design might need to be adjusted from time to time. Please be prepared to update client/server config and core versions in the future when the need arise.

-------------------------------------------
[Machine Generated Summary]
This pull request introduces support for a new `gdocsviewer` transport mechanism in the V2Ray core, including its configuration, error handling, and pattern-based URL generation. The main changes add protocol buffer definitions and generated Go code for configuration, implement a system for generating and validating origin URL replacements, and register the new transport in the distribution.

**New gdocsviewer transport integration:**

* Registered the `gdocsviewer` roundtripper and stereotype modules in the main distribution by updating the import list in `all.go`.

**Configuration and protocol definitions:**

* Added a new protocol buffer definition file `config.proto` describing `ClientConfig`, `ServerConfig`, and `OriginUrlReplacementRule` for the `gdocsviewer` transport, supporting advanced configuration options such as URL templates and replacement rules.
* Generated the corresponding Go code for these configuration structures in `config.pb.go`, enabling their use throughout the codebase.

**Core logic and utilities:**

* Implemented `origin_url_pattern.go`, which provides functions to render and validate origin URLs based on configurable replacement patterns, including pattern parsing, random value generation, and error handling for invalid patterns.
* Added a dedicated error helper in `errors.generated.go` to provide contextual error reporting for the `gdocsviewer` module.