### PR TITLE
ci: fix release artifacts hash mismatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,6 @@ jobs:
       GOARM: ${{ matrix.goarm }}
       PIE_ENABLED: ${{ matrix.pie }}
       CGO_ENABLED: 0
-      IS_PRERELEASE: ${{ github.event.release.prerelease }}
 
     steps:
       - name: Checkout codebase
@@ -131,11 +130,6 @@ jobs:
         id: get_filename
         run: |
           export _NAME=$(jq ".[\"$GOOS-$GOARCH$GOARM$PIE_ENABLED\"].friendlyName" -r < release/friendly-filenames.json)
-
-          if [ "$GOARCH" = "arm64" ] && [ "$PIE_ENABLED" = "pie" ] && [ "$IS_PRERELEASE" = "true" ]; then
-            export _NAME="${_NAME}-prerelease"
-          fi
-
           echo "GOOS: $GOOS, GOARCH: $GOARCH, GOARM: $GOARM, RELEASE_NAME: $_NAME"
           echo "ASSET_NAME=$_NAME" >> $GITHUB_OUTPUT
           echo "ASSET_NAME=$_NAME" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ on:
 
 jobs:
   build:
+    # Run on push/PR and on prereleased; skip on released to avoid overwriting prerelease zips.
+    if: github.event_name != 'release' || github.event.release.prerelease == true
     strategy:
       matrix:
         # Include amd64 on all platforms.
@@ -211,6 +213,8 @@ jobs:
           overwrite: true
 
   signature:
+    # Same as `build`: only on push/PR and prereleased, skip on released.
+    if: github.event_name != 'release' || github.event.release.prerelease == true
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -296,7 +300,9 @@ jobs:
           overwrite: true
 
   buildContainer:
-    if: github.event_name == 'release'
+    # Run on both prereleased and released (released adds `latest`/major-version tags).
+    # The extra clauses keep it running even though `signature` is skipped on released.
+    if: ${{ !cancelled() && github.event_name == 'release' && needs.signature.result != 'failure' }}
     needs: signature
     name: Build And Push image
     runs-on: ubuntu-latest


### PR DESCRIPTION
# ci: fix release artifacts hash mismatch

The signed `Release` file's SHA256 entries don't match the actually-downloadable zip artifacts (reproducible on every recent release, e.g. v5.49.0's `v2ray-windows-64.zip` is `1a535fa7...` but `Release` says `29a212d1...`).

Root cause: `release.yml` triggers on both `prereleased` and `released` with `overwrite: true`, so the `released` run rebuilds zips with **freshly-fetched** geo data (`v2fly/geoip` and `v2fly/domain-list-community`'s `release` branch HEAD) and overwrites the prerelease zips — but the externally-signed `Release` was signed against the prerelease-time artifacts.

Fix: skip `build` and `signature` on `released`. `buildContainer` still runs on `released` to publish the `latest`/`vX` tags; its `if:` uses `!cancelled() && needs.signature.result != 'failure'` to bypass the default cascade-skip when `signature` is skipped.

The second commit reverts #3521, which is no longer needed now that arm64-pie is built exactly once.

Related:
- Fixes #3049 (closed stale, no diagnosis)
- Regression from #2757 (added `released` trigger + `overwrite: true` to support `latest`/`vX` container tags)
- Reverts #3521 (workaround for the same root cause, now unnecessary)
