### PR TITLE
GDocsViewer: Refine poll logic and allow custom headers to reduce rate limiting

### DIFF
--- a/transport/internet/request/assembler/simple/client.go
+++ b/transport/internet/request/assembler/simple/client.go
@@ -54,7 +54,7 @@ type simpleAssemblerClientSession struct {
 }
 
 func (s *simpleAssemblerClientSession) keepRunning() {
-	s.currentWriteWait = int(s.assembler.config.InitialPollingIntervalMs)
+	s.currentWriteWait = clientInitialPollingIntervalMs(s.assembler.config)
 	for s.ctx.Err() == nil {
 		s.runOnce()
 	}
@@ -65,6 +65,7 @@ func (s *simpleAssemblerClientSession) runOnce() {
 	if s.currentWriteWait != 0 {
 		waitTimer := time.NewTimer(time.Millisecond * time.Duration(s.currentWriteWait))
 		waitForFirstWrite := true
+		maxWriteSize := clientMaxWriteSize(s.assembler.config)
 	copyFromWriterLoop:
 		for {
 			select {
@@ -72,12 +73,12 @@ func (s *simpleAssemblerClientSession) runOnce() {
 				return
 			case data := <-s.writerChan:
 				sendBuffer.Write(data)
-				if sendBuffer.Len() >= int(s.assembler.config.MaxWriteSize) {
+				if sendBuffer.Len() >= maxWriteSize {
 					break copyFromWriterLoop
 				}
 				if waitForFirstWrite {
 					waitForFirstWrite = false
-					waitTimer.Reset(time.Millisecond * time.Duration(s.assembler.config.WaitSubsequentWriteMs))
+					waitTimer.Reset(time.Millisecond * time.Duration(clientWaitSubsequentWriteMs(s.assembler.config)))
 				}
 			case <-waitTimer.C:
 				break copyFromWriterLoop
@@ -91,8 +92,9 @@ func (s *simpleAssemblerClientSession) runOnce() {
 	for sendBuffer.Len() != 0 || firstRound {
 		firstRound = false
 		sendAmount := sendBuffer.Len()
-		if sendAmount > int(s.assembler.config.MaxWriteSize) {
-			sendAmount = int(s.assembler.config.MaxWriteSize)
+		maxWriteSize := clientMaxWriteSize(s.assembler.config)
+		if sendAmount > maxWriteSize {
+			sendAmount = maxWriteSize
 		}
 		data := sendBuffer.Next(sendAmount)
 		if len(data) != 0 {
@@ -105,7 +107,7 @@ func (s *simpleAssemblerClientSession) runOnce() {
 				if s.ctx.Err() != nil {
 					return
 				}
-				time.Sleep(time.Millisecond * time.Duration(s.assembler.config.FailedRetryIntervalMs))
+				time.Sleep(time.Millisecond * time.Duration(clientFailedRetryIntervalMs(s.assembler.config)))
 				continue
 			}
 			if len(resp.Data) != 0 {
@@ -118,16 +120,65 @@ func (s *simpleAssemblerClientSession) runOnce() {
 		}
 	}
 	if pollConnection {
-		s.currentWriteWait = int(s.assembler.config.BackoffFactor * float32(s.currentWriteWait))
-		if s.currentWriteWait > int(s.assembler.config.MaxPollingIntervalMs) {
-			s.currentWriteWait = int(s.assembler.config.MaxPollingIntervalMs)
+		s.currentWriteWait = int(clientBackoffFactor(s.assembler.config) * float32(s.currentWriteWait))
+		if s.currentWriteWait > clientMaxPollingIntervalMs(s.assembler.config) {
+			s.currentWriteWait = clientMaxPollingIntervalMs(s.assembler.config)
 		}
-		if s.currentWriteWait < int(s.assembler.config.MinPollingIntervalMs) {
-			s.currentWriteWait = int(s.assembler.config.MinPollingIntervalMs)
+		if s.currentWriteWait < clientMinPollingIntervalMs(s.assembler.config) {
+			s.currentWriteWait = clientMinPollingIntervalMs(s.assembler.config)
 		}
 	} else {
 		s.currentWriteWait = int(0)
 	}
+}
+
+func clientMaxWriteSize(config *ClientConfig) int {
+	if config != nil && config.MaxWriteSize > 0 {
+		return int(config.MaxWriteSize)
+	}
+	return 4096
+}
+
+func clientWaitSubsequentWriteMs(config *ClientConfig) int {
+	if config != nil && config.WaitSubsequentWriteMs > 0 {
+		return int(config.WaitSubsequentWriteMs)
+	}
+	return 10
+}
+
+func clientInitialPollingIntervalMs(config *ClientConfig) int {
+	if config != nil && config.InitialPollingIntervalMs > 0 {
+		return int(config.InitialPollingIntervalMs)
+	}
+	return 100
+}
+
+func clientMaxPollingIntervalMs(config *ClientConfig) int {
+	if config != nil && config.MaxPollingIntervalMs > 0 {
+		return int(config.MaxPollingIntervalMs)
+	}
+	return 1000
+}
+
+func clientMinPollingIntervalMs(config *ClientConfig) int {
+	if config != nil && config.MinPollingIntervalMs > 0 {
+		return int(config.MinPollingIntervalMs)
+	}
+	return 10
+}
+
+func clientBackoffFactor(config *ClientConfig) float32 {
+	if config != nil && config.BackoffFactor > 1 {
+		return config.BackoffFactor
+	}
+	return 1.5
+}
+
+func clientFailedRetryIntervalMs(config *ClientConfig) int {
+	if config != nil && config.FailedRetryIntervalMs > 0 {
+		return int(config.FailedRetryIntervalMs)
+	}
+	return 1000
 }
 
 func (s *simpleAssemblerClientSession) Read(p []byte) (n int, err error) {

--- a/transport/internet/request/assembler/simple/config.pb.go
+++ b/transport/internet/request/assembler/simple/config.pb.go
@@ -109,10 +109,11 @@ func (x *ClientConfig) GetFailedRetryIntervalMs() int32 {
 }
 
 type ServerConfig struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	MaxWriteSize  int32                  `protobuf:"varint,1,opt,name=max_write_size,json=maxWriteSize,proto3" json:"max_write_size,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	MaxWriteSize          int32                  `protobuf:"varint,1,opt,name=max_write_size,json=maxWriteSize,proto3" json:"max_write_size,omitempty"`
+	PollingResponseWaitMs int32                  `protobuf:"varint,2,opt,name=polling_response_wait_ms,json=pollingResponseWaitMs,proto3" json:"polling_response_wait_ms,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *ServerConfig) Reset() {
@@ -152,6 +153,13 @@ func (x *ServerConfig) GetMaxWriteSize() int32 {
 	return 0
 }
 
+func (x *ServerConfig) GetPollingResponseWaitMs() int32 {
+	if x != nil {
+		return x.PollingResponseWaitMs
+	}
+	return 0
+}
+
 var File_transport_internet_request_assembler_simple_config_proto protoreflect.FileDescriptor
 
 const file_transport_internet_request_assembler_simple_config_proto_rawDesc = "" +
@@ -165,9 +173,10 @@ const file_transport_internet_request_assembler_simple_config_proto_rawDesc = ""
 	"\x17min_polling_interval_ms\x18\x05 \x01(\x05R\x14minPollingIntervalMs\x12%\n" +
 	"\x0ebackoff_factor\x18\x06 \x01(\x02R\rbackoffFactor\x127\n" +
 	"\x18failed_retry_interval_ms\x18\a \x01(\x05R\x15failedRetryIntervalMs:0\x82\xb5\x18,\n" +
-	"\"transport.request.assembler.client\x12\x06simple\"f\n" +
+	"\"transport.request.assembler.client\x12\x06simple\"\x9f\x01\n" +
 	"\fServerConfig\x12$\n" +
-	"\x0emax_write_size\x18\x01 \x01(\x05R\fmaxWriteSize:0\x82\xb5\x18,\n" +
+	"\x0emax_write_size\x18\x01 \x01(\x05R\fmaxWriteSize\x127\n" +
+	"\x18polling_response_wait_ms\x18\x02 \x01(\x05R\x15pollingResponseWaitMs:0\x82\xb5\x18,\n" +
 	"\"transport.request.assembler.server\x12\x06simpleB\xc3\x01\n" +
 	":com.v2ray.core.transport.internet.request.assembler.simpleP\x01ZJgithub.com/v2fly/v2ray-core/v5/transport/internet/request/assembler/simple\xaa\x026V2Ray.Core.Transport.Internet.Request.Assembler.Simpleb\x06proto3"
 

--- a/transport/internet/request/assembler/simple/config.proto
+++ b/transport/internet/request/assembler/simple/config.proto
@@ -26,4 +26,5 @@ message ServerConfig {
   option (v2ray.core.common.protoext.message_opt).short_name = "simple";
 
   int32 max_write_size = 1;
+  int32 polling_response_wait_ms = 2;
 }

--- a/transport/internet/request/assembler/simple/server.go
+++ b/transport/internet/request/assembler/simple/server.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"sync"
+	"time"
 
 	"github.com/v2fly/v2ray-core/v5/common"
 
@@ -11,12 +12,13 @@ import (
 )
 
 func newServer(config *ServerConfig) request.SessionAssemblerServer {
-	return &simpleAssemblerServer{}
+	return &simpleAssemblerServer{config: config}
 }
 
 type simpleAssemblerServer struct {
 	sessions sync.Map
 	assembly request.TransportServerAssembly
+	config   *ServerConfig
 }
 
 func (s *simpleAssemblerServer) OnTransportServerAssemblyReady(assembly request.TransportServerAssembly) {
@@ -26,7 +28,7 @@ func (s *simpleAssemblerServer) OnTransportServerAssemblyReady(assembly request.
 func (s *simpleAssemblerServer) OnRoundTrip(ctx context.Context, req request.Request, opts ...request.RoundTripperOption,
 ) (resp request.Response, err error) {
 	connectionID := req.ConnectionTag
-	session := newSimpleAssemblerServerSession(ctx)
+	session := newSimpleAssemblerServerSession(ctx, serverMaxWriteSize(s.config), serverPollingResponseWait(s.config))
 	loadedSession, loaded := s.sessions.LoadOrStore(string(connectionID), session)
 	if loaded {
 		session = loadedSession.(*simpleAssemblerServerSession)
@@ -38,7 +40,7 @@ func (s *simpleAssemblerServer) OnRoundTrip(ctx context.Context, req request.Req
 	return session.OnRoundTrip(ctx, req, opts...)
 }
 
-func newSimpleAssemblerServerSession(ctx context.Context) *simpleAssemblerServerSession {
+func newSimpleAssemblerServerSession(ctx context.Context, maxWriteSize int, pollingResponseWait time.Duration) *simpleAssemblerServerSession {
 	sessionCtx, finish := context.WithCancel(ctx)
 	return &simpleAssemblerServerSession{
 		readBuffer:       bytes.NewBuffer(nil),
@@ -46,7 +48,9 @@ func newSimpleAssemblerServerSession(ctx context.Context) *simpleAssemblerServer
 		requestProcessed: make(chan struct{}),
 		writeLock:        new(sync.Mutex),
 		writeBuffer:      bytes.NewBuffer(nil),
-		maxWriteSize:     4096,
+		writeAvailable:   make(chan struct{}, 1),
+		maxWriteSize:     maxWriteSize,
+		pollingWait:      pollingResponseWait,
 		ctx:              sessionCtx,
 		finish:           finish,
 	}
@@ -54,13 +58,15 @@ func newSimpleAssemblerServerSession(ctx context.Context) *simpleAssemblerServer
 
 type simpleAssemblerServerSession struct {
 	maxWriteSize int
+	pollingWait  time.Duration
 
 	readBuffer       *bytes.Buffer
 	readChan         chan []byte
 	requestProcessed chan struct{}
 
-	writeLock   *sync.Mutex
-	writeBuffer *bytes.Buffer
+	writeLock      *sync.Mutex
+	writeBuffer    *bytes.Buffer
+	writeAvailable chan struct{}
 
 	ctx    context.Context
 	finish func()
@@ -81,11 +87,15 @@ func (s *simpleAssemblerServerSession) Read(p []byte) (n int, err error) {
 func (s *simpleAssemblerServerSession) Write(p []byte) (n int, err error) {
 	s.writeLock.Lock()
 
+	wasEmpty := s.writeBuffer.Len() == 0
 	n, err = s.writeBuffer.Write(p)
 	length := s.writeBuffer.Len()
 	s.writeLock.Unlock()
 	if err != nil {
 		return 0, err
+	}
+	if n > 0 && wasEmpty {
+		s.signalWriteAvailable()
 	}
 	if length > s.maxWriteSize {
 		select {
@@ -112,18 +122,78 @@ func (s *simpleAssemblerServerSession) OnRoundTrip(ctx context.Context, req requ
 		}
 	}
 
+	data := s.nextWriteData()
+	if len(data) == 0 && len(req.Data) == 0 && s.pollingWait > 0 {
+		data, err = s.waitForWriteData(ctx)
+		if err != nil {
+			return request.Response{}, err
+		}
+	}
+	if err := s.signalRequestProcessed(); err != nil {
+		return request.Response{}, err
+	}
+	return request.Response{Data: data}, nil
+}
+
+func (s *simpleAssemblerServerSession) nextWriteData() []byte {
 	s.writeLock.Lock()
 	nextWrite := s.writeBuffer.Next(s.maxWriteSize)
 	data := make([]byte, len(nextWrite))
 	copy(data, nextWrite)
 	s.writeLock.Unlock()
+	return data
+}
+
+func (s *simpleAssemblerServerSession) waitForWriteData(ctx context.Context) ([]byte, error) {
+	timer := time.NewTimer(s.pollingWait)
+	defer timer.Stop()
+	for {
+		select {
+		case <-s.writeAvailable:
+			data := s.nextWriteData()
+			if len(data) != 0 {
+				return data, nil
+			}
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-s.ctx.Done():
+			return nil, s.ctx.Err()
+		case <-timer.C:
+			return nil, nil
+		}
+	}
+}
+
+func (s *simpleAssemblerServerSession) signalWriteAvailable() {
 	select {
-	case s.requestProcessed <- struct{}{}:
-	case <-s.ctx.Done():
-		return request.Response{}, s.ctx.Err()
+	case s.writeAvailable <- struct{}{}:
 	default:
 	}
-	return request.Response{Data: data}, nil
+}
+
+func (s *simpleAssemblerServerSession) signalRequestProcessed() error {
+	select {
+	case s.requestProcessed <- struct{}{}:
+		return nil
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	default:
+		return nil
+	}
+}
+
+func serverMaxWriteSize(config *ServerConfig) int {
+	if config != nil && config.MaxWriteSize > 0 {
+		return int(config.MaxWriteSize)
+	}
+	return 4096
+}
+
+func serverPollingResponseWait(config *ServerConfig) time.Duration {
+	if config != nil && config.PollingResponseWaitMs > 0 {
+		return time.Duration(config.PollingResponseWaitMs) * time.Millisecond
+	}
+	return 0
 }
 
 func init() {

--- a/transport/internet/request/roundtripper/gdocsviewer/config.pb.go
+++ b/transport/internet/request/roundtripper/gdocsviewer/config.pb.go
@@ -29,6 +29,7 @@ type ClientConfig struct {
 	MinRequestIntervalMs      int32                       `protobuf:"varint,9,opt,name=min_request_interval_ms,json=minRequestIntervalMs,proto3" json:"min_request_interval_ms,omitempty"`
 	SharedKey                 []byte                      `protobuf:"bytes,10,opt,name=shared_key,json=sharedKey,proto3" json:"shared_key,omitempty"`
 	OriginUrlReplacementRules []*OriginUrlReplacementRule `protobuf:"bytes,11,rep,name=origin_url_replacement_rules,json=originUrlReplacementRules,proto3" json:"origin_url_replacement_rules,omitempty"`
+	RequestHeaders            map[string]string           `protobuf:"bytes,12,rep,name=request_headers,json=requestHeaders,proto3" json:"request_headers,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields             protoimpl.UnknownFields
 	sizeCache                 protoimpl.SizeCache
 }
@@ -136,6 +137,13 @@ func (x *ClientConfig) GetSharedKey() []byte {
 func (x *ClientConfig) GetOriginUrlReplacementRules() []*OriginUrlReplacementRule {
 	if x != nil {
 		return x.OriginUrlReplacementRules
+	}
+	return nil
+}
+
+func (x *ClientConfig) GetRequestHeaders() map[string]string {
+	if x != nil {
+		return x.RequestHeaders
 	}
 	return nil
 }
@@ -264,7 +272,7 @@ var File_transport_internet_request_roundtripper_gdocsviewer_config_proto protor
 
 const file_transport_internet_request_roundtripper_gdocsviewer_config_proto_rawDesc = "" +
 	"\n" +
-	"@transport/internet/request/roundtripper/gdocsviewer/config.proto\x12>v2ray.core.transport.internet.request.roundtripper.gdocsviewer\x1a common/protoext/extensions.proto\"\xd4\x04\n" +
+	"@transport/internet/request/roundtripper/gdocsviewer/config.proto\x12>v2ray.core.transport.internet.request.roundtripper.gdocsviewer\x1a common/protoext/extensions.proto\"\xa3\x06\n" +
 	"\fClientConfig\x12\x1d\n" +
 	"\n" +
 	"viewer_url\x18\x01 \x01(\tR\tviewerUrl\x12\x19\n" +
@@ -283,7 +291,11 @@ const file_transport_internet_request_roundtripper_gdocsviewer_config_proto_rawD
 	"\n" +
 	"shared_key\x18\n" +
 	" \x01(\fR\tsharedKey\x12\x99\x01\n" +
-	"\x1corigin_url_replacement_rules\x18\v \x03(\v2X.v2ray.core.transport.internet.request.roundtripper.gdocsviewer.OriginUrlReplacementRuleR\x19originUrlReplacementRules:8\x82\xb5\x184\n" +
+	"\x1corigin_url_replacement_rules\x18\v \x03(\v2X.v2ray.core.transport.internet.request.roundtripper.gdocsviewer.OriginUrlReplacementRuleR\x19originUrlReplacementRules\x12\x89\x01\n" +
+	"\x0frequest_headers\x18\f \x03(\v2`.v2ray.core.transport.internet.request.roundtripper.gdocsviewer.ClientConfig.RequestHeadersEntryR\x0erequestHeaders\x1aA\n" +
+	"\x13RequestHeadersEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01:8\x82\xb5\x184\n" +
 	"%transport.request.roundtripper.client\x12\vgdocsviewer\"\xe2\x01\n" +
 	"\fServerConfig\x12\x1f\n" +
 	"\vpath_prefix\x18\x01 \x01(\tR\n" +
@@ -310,19 +322,21 @@ func file_transport_internet_request_roundtripper_gdocsviewer_config_proto_rawDe
 	return file_transport_internet_request_roundtripper_gdocsviewer_config_proto_rawDescData
 }
 
-var file_transport_internet_request_roundtripper_gdocsviewer_config_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_transport_internet_request_roundtripper_gdocsviewer_config_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_transport_internet_request_roundtripper_gdocsviewer_config_proto_goTypes = []any{
 	(*ClientConfig)(nil),             // 0: v2ray.core.transport.internet.request.roundtripper.gdocsviewer.ClientConfig
 	(*ServerConfig)(nil),             // 1: v2ray.core.transport.internet.request.roundtripper.gdocsviewer.ServerConfig
 	(*OriginUrlReplacementRule)(nil), // 2: v2ray.core.transport.internet.request.roundtripper.gdocsviewer.OriginUrlReplacementRule
+	nil,                              // 3: v2ray.core.transport.internet.request.roundtripper.gdocsviewer.ClientConfig.RequestHeadersEntry
 }
 var file_transport_internet_request_roundtripper_gdocsviewer_config_proto_depIdxs = []int32{
 	2, // 0: v2ray.core.transport.internet.request.roundtripper.gdocsviewer.ClientConfig.origin_url_replacement_rules:type_name -> v2ray.core.transport.internet.request.roundtripper.gdocsviewer.OriginUrlReplacementRule
-	1, // [1:1] is the sub-list for method output_type
-	1, // [1:1] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	3, // 1: v2ray.core.transport.internet.request.roundtripper.gdocsviewer.ClientConfig.request_headers:type_name -> v2ray.core.transport.internet.request.roundtripper.gdocsviewer.ClientConfig.RequestHeadersEntry
+	2, // [2:2] is the sub-list for method output_type
+	2, // [2:2] is the sub-list for method input_type
+	2, // [2:2] is the sub-list for extension type_name
+	2, // [2:2] is the sub-list for extension extendee
+	0, // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_transport_internet_request_roundtripper_gdocsviewer_config_proto_init() }
@@ -336,7 +350,7 @@ func file_transport_internet_request_roundtripper_gdocsviewer_config_proto_init(
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_transport_internet_request_roundtripper_gdocsviewer_config_proto_rawDesc), len(file_transport_internet_request_roundtripper_gdocsviewer_config_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   3,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/transport/internet/request/roundtripper/gdocsviewer/config.proto
+++ b/transport/internet/request/roundtripper/gdocsviewer/config.proto
@@ -23,6 +23,7 @@ message ClientConfig {
   int32 min_request_interval_ms = 9;
   bytes shared_key = 10;
   repeated OriginUrlReplacementRule origin_url_replacement_rules = 11;
+  map<string, string> request_headers = 12;
 }
 
 message ServerConfig {

--- a/transport/internet/request/roundtripper/gdocsviewer/gdocsviewer.go
+++ b/transport/internet/request/roundtripper/gdocsviewer/gdocsviewer.go
@@ -14,6 +14,7 @@ import (
 	gonet "net"
 	"net/http"
 	neturl "net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -32,6 +33,7 @@ const (
 	defaultMinRequestIntervalMs = 100
 	defaultMaxRequestBytes      = 1100
 	defaultMaxResponseBytes     = 64 * 1024
+	debugBodyPreviewBytes       = 2048
 	encryptedRequestVersion     = byte(1)
 	responseFrameSuccess        = byte(0)
 	responseFrameError          = byte(1)
@@ -92,13 +94,20 @@ func (c *client) RoundTrip(ctx context.Context, req request.Request, opts ...req
 	if err != nil {
 		return request.Response{}, err
 	}
-	viewerBody, err := readLimitedHTTPBody(viewerResp, int64(clientMaxViewerBodyBytes(c.config)), "viewer")
+	viewerBody, err := readLimitedHTTPBody(viewerResp, int64(clientMaxViewerBodyBytes(c.config)), "viewer", viewerReq.URL.String())
 	if err != nil {
 		return request.Response{}, err
 	}
 
 	docID, err := extractDocumentID(viewerBody)
 	if err != nil {
+		newError("unable to extract Google Docs Viewer text document id",
+			" viewer_url=", viewerURL,
+			" origin_url=", originRequestURL,
+			" response_headers=", viewerResp.Header,
+			" response_body_len=", len(viewerBody),
+			" response_body_preview=", debugBodyPreview(viewerBody),
+		).AtDebug().WriteToLog()
 		return request.Response{}, err
 	}
 
@@ -116,17 +125,30 @@ func (c *client) RoundTrip(ctx context.Context, req request.Request, opts ...req
 	if err != nil {
 		return request.Response{}, err
 	}
-	textBody, err := readLimitedHTTPBody(textResp, int64(clientMaxViewerBodyBytes(c.config)), "viewer text")
+	textBody, err := readLimitedHTTPBody(textResp, int64(clientMaxViewerBodyBytes(c.config)), "viewer text", textReq.URL.String())
 	if err != nil {
 		return request.Response{}, err
 	}
 
 	originBase64, err := decodeViewerTextData(textBody)
 	if err != nil {
+		newError("unable to decode Google Docs Viewer text data",
+			" text_url=", textURL,
+			" document_id=", docID,
+			" response_headers=", textResp.Header,
+			" response_body_len=", len(textBody),
+			" response_body_preview=", debugBodyPreview(textBody),
+		).AtDebug().WriteToLog()
 		return request.Response{}, err
 	}
 	serverBody, err := decodeBase64Text(originBase64)
 	if err != nil {
+		newError("unable to decode base64 origin response body",
+			" text_url=", textURL,
+			" document_id=", docID,
+			" origin_body_len=", len(originBase64),
+			" origin_body_preview=", debugBodyPreview(originBase64),
+		).AtDebug().WriteToLog()
 		return request.Response{}, newError("unable to decode origin response body").Base(err)
 	}
 	result, err := c.decodeServerBody(serverBody)
@@ -169,6 +191,13 @@ func (c *client) applyViewerHeaders(req *http.Request) {
 	}
 	if c.config.ViewerHostHeader != "" {
 		req.Host = c.config.ViewerHostHeader
+	}
+	for name, value := range c.config.RequestHeaders {
+		if strings.EqualFold(name, "Host") {
+			req.Host = value
+			continue
+		}
+		req.Header.Set(name, value)
 	}
 }
 
@@ -304,17 +333,69 @@ func buildTextURL(textURL string, docID string) (string, error) {
 	return parsed.String(), nil
 }
 
-func readLimitedHTTPBody(resp *http.Response, maxBytes int64, label string) ([]byte, error) {
+func readLimitedHTTPBody(resp *http.Response, maxBytes int64, label string, requestURL string) ([]byte, error) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		_, _ = io.Copy(io.Discard, resp.Body)
+		preview, truncated, err := readAndDrainBodyPreview(resp.Body, debugBodyPreviewBytes)
+		if err != nil {
+			newError(label, " returned non-200 response",
+				" url=", requestURL,
+				" status=", resp.Status,
+				" headers=", resp.Header,
+				" body_read_error=", err,
+				" body_preview=", debugBodyPreviewWithTruncation(preview, truncated),
+			).AtDebug().WriteToLog()
+		} else {
+			newError(label, " returned non-200 response",
+				" url=", requestURL,
+				" status=", resp.Status,
+				" headers=", resp.Header,
+				" body_preview=", debugBodyPreviewWithTruncation(preview, truncated),
+			).AtDebug().WriteToLog()
+		}
 		return nil, newError(label, " returned non-200 response: ", resp.Status)
 	}
 	body, err := readLimited(resp.Body, maxBytes)
 	if err != nil {
+		newError("unable to read ", label, " body",
+			" url=", requestURL,
+			" status=", resp.Status,
+			" headers=", resp.Header,
+		).Base(err).AtDebug().WriteToLog()
 		return nil, newError("unable to read ", label, " body").Base(err)
 	}
 	return body, nil
+}
+
+func readAndDrainBodyPreview(reader io.Reader, previewBytes int64) ([]byte, bool, error) {
+	preview, err := io.ReadAll(io.LimitReader(reader, previewBytes+1))
+	if err != nil {
+		return preview, false, err
+	}
+	truncated := int64(len(preview)) > previewBytes
+	if truncated {
+		preview = preview[:previewBytes]
+	}
+	if _, err := io.Copy(io.Discard, reader); err != nil {
+		return preview, truncated, err
+	}
+	return preview, truncated, nil
+}
+
+func debugBodyPreview(body []byte) string {
+	truncated := len(body) > debugBodyPreviewBytes
+	if truncated {
+		body = body[:debugBodyPreviewBytes]
+	}
+	return debugBodyPreviewWithTruncation(body, truncated)
+}
+
+func debugBodyPreviewWithTruncation(body []byte, truncated bool) string {
+	preview := strconv.QuoteToASCII(string(body))
+	if truncated {
+		return preview + " ... [truncated]"
+	}
+	return preview
 }
 
 func readLimited(reader io.Reader, maxBytes int64) ([]byte, error) {

--- a/transport/internet/request/roundtripper/gdocsviewer/gdocsviewer_test.go
+++ b/transport/internet/request/roundtripper/gdocsviewer/gdocsviewer_test.go
@@ -243,11 +243,17 @@ func TestRoundTripPlaintextViewerFlowAndHeaders(t *testing.T) {
 		}
 	}
 	c := &client{httpRTT: rt, config: &ClientConfig{
-		ViewerUrl:            "https://viewer.test/viewer",
-		TextUrl:              "https://viewer.test/viewerng/text",
-		OriginUrl:            "https://origin.test/gdocsviewer",
-		ViewerHostHeader:     "docs.example",
-		UserAgent:            "gdocsviewer-test",
+		ViewerUrl:        "https://viewer.test/viewer",
+		TextUrl:          "https://viewer.test/viewerng/text",
+		OriginUrl:        "https://origin.test/gdocsviewer",
+		ViewerHostHeader: "docs.example",
+		UserAgent:        "gdocsviewer-test",
+		RequestHeaders: map[string]string{
+			"Accept-Language": "en-US,en;q=0.9",
+			"Host":            "docs.custom",
+			"User-Agent":      "gdocsviewer-custom-agent",
+			"X-Gdocs-Test":    "1",
+		},
 		MinRequestIntervalMs: 1,
 	}}
 
@@ -265,8 +271,11 @@ func TestRoundTripPlaintextViewerFlowAndHeaders(t *testing.T) {
 		t.Fatalf("unexpected request count %d", len(rt.requests))
 	}
 	for _, req := range rt.requests {
-		if req.Host != "docs.example" || req.Header.Get("User-Agent") != "gdocsviewer-test" {
+		if req.Host != "docs.custom" || req.Header.Get("User-Agent") != "gdocsviewer-custom-agent" {
 			t.Fatalf("headers not applied: host=%q ua=%q", req.Host, req.Header.Get("User-Agent"))
+		}
+		if req.Header.Get("Accept-Language") != "en-US,en;q=0.9" || req.Header.Get("X-Gdocs-Test") != "1" {
+			t.Fatalf("custom headers not applied: accept-language=%q x-gdocs-test=%q", req.Header.Get("Accept-Language"), req.Header.Get("X-Gdocs-Test"))
 		}
 	}
 }

--- a/transport/internet/request/stereotype/gdocsviewer/gdocsviewer.go
+++ b/transport/internet/request/stereotype/gdocsviewer/gdocsviewer.go
@@ -16,6 +16,12 @@ import (
 
 const protocolName = "gdocsviewer"
 
+const (
+	defaultPollingResponseWaitMs = 10000
+	defaultMaxPollingIntervalMs  = 10000
+	defaultFailedRetryIntervalMs = 10000
+)
+
 func init() {
 	common.Must(common.RegisterConfig((*Config)(nil), func(ctx context.Context, config interface{}) (interface{}, error) {
 		return nil, newError("gdocsviewer is a transport")
@@ -60,10 +66,10 @@ func buildClientRequestConfig(setting *Config) *assembly.Config {
 			MaxWriteSize:             int32(maxRequestBytes(setting)),
 			WaitSubsequentWriteMs:    10,
 			InitialPollingIntervalMs: minRequestIntervalMs(setting),
-			MaxPollingIntervalMs:     1000,
+			MaxPollingIntervalMs:     maxPollingIntervalMs(setting),
 			MinPollingIntervalMs:     minRequestIntervalMs(setting),
 			BackoffFactor:            1.5,
-			FailedRetryIntervalMs:    1000,
+			FailedRetryIntervalMs:    defaultFailedRetryIntervalMs,
 		}),
 		Roundtripper: serial.ToTypedMessage(&roundtripper.ClientConfig{
 			ViewerUrl:                 setting.ViewerUrl,
@@ -106,7 +112,8 @@ func buildServerRequestConfig(setting *Config) *assembly.Config {
 	}
 	requestConfig := &assembly.Config{
 		Assembler: serial.ToTypedMessage(&simple.ServerConfig{
-			MaxWriteSize: int32(maxResponseBytes(setting)),
+			MaxWriteSize:          int32(maxResponseBytes(setting)),
+			PollingResponseWaitMs: defaultPollingResponseWaitMs,
 		}),
 		Roundtripper: serial.ToTypedMessage(&roundtripper.ServerConfig{
 			PathPrefix:       setting.PathPrefix,
@@ -116,6 +123,14 @@ func buildServerRequestConfig(setting *Config) *assembly.Config {
 		}),
 	}
 	return requestConfig
+}
+
+func maxPollingIntervalMs(config *Config) int32 {
+	minInterval := minRequestIntervalMs(config)
+	if minInterval > defaultMaxPollingIntervalMs {
+		return minInterval
+	}
+	return defaultMaxPollingIntervalMs
 }
 
 func maxRequestBytes(config *Config) int {

--- a/transport/internet/request/stereotype/gdocsviewer/gdocsviewer_test.go
+++ b/transport/internet/request/stereotype/gdocsviewer/gdocsviewer_test.go
@@ -34,7 +34,11 @@ func TestBuildClientRequestConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	simpleConfig := assembler.(*simple.ClientConfig)
-	if simpleConfig.MaxWriteSize != 777 || simpleConfig.InitialPollingIntervalMs != 5 {
+	if simpleConfig.MaxWriteSize != 777 ||
+		simpleConfig.InitialPollingIntervalMs != 5 ||
+		simpleConfig.MinPollingIntervalMs != 5 ||
+		simpleConfig.MaxPollingIntervalMs != defaultMaxPollingIntervalMs ||
+		simpleConfig.FailedRetryIntervalMs != defaultFailedRetryIntervalMs {
 		t.Fatalf("unexpected simple client config %+v", simpleConfig)
 	}
 
@@ -72,7 +76,7 @@ func TestBuildServerRequestConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	simpleConfig := assembler.(*simple.ServerConfig)
-	if simpleConfig.MaxWriteSize != 888 {
+	if simpleConfig.MaxWriteSize != 888 || simpleConfig.PollingResponseWaitMs != defaultPollingResponseWaitMs {
 		t.Fatalf("unexpected simple server config %+v", simpleConfig)
 	}
 


### PR DESCRIPTION
This merge requests adds custom header support for GDocsViewer to reduce rate limiting, and refined polling parameters.

----------------
[Machine Generated]
This pull request introduces several improvements and new features to the simple assembler transport and the GDocsViewer roundtripper. The main changes are the addition of polling response wait support on the server side, improved configuration handling for client and server parameters, and support for custom request headers in the GDocsViewer client. These changes enhance protocol flexibility, efficiency, and extensibility.

### Simple Assembler Transport Improvements

* **Server-side polling response wait:** Added the `polling_response_wait_ms` field to `ServerConfig` and implemented logic in the server to wait for writes up to the configured polling interval, improving efficiency and reducing unnecessary polling. [[1]](diffhunk://#diff-4298f6f6a0db344daa914722890c64c060b8c51028f7853730a9ee0e95743bd2R114) [[2]](diffhunk://#diff-4298f6f6a0db344daa914722890c64c060b8c51028f7853730a9ee0e95743bd2R156-R162) [[3]](diffhunk://#diff-4298f6f6a0db344daa914722890c64c060b8c51028f7853730a9ee0e95743bd2L168-R179) [[4]](diffhunk://#diff-59642945f92a72c9beaf800d75e53ba24c6f1890234c4c12d2b8ec9db48118a1R29) [[5]](diffhunk://#diff-6293b328006f1e9a97d6cf829b3331f18ade5041aa57e9c41acebb61ef92b9a6R7-R21) [[6]](diffhunk://#diff-6293b328006f1e9a97d6cf829b3331f18ade5041aa57e9c41acebb61ef92b9a6L29-R31) [[7]](diffhunk://#diff-6293b328006f1e9a97d6cf829b3331f18ade5041aa57e9c41acebb61ef92b9a6L41-R69) [[8]](diffhunk://#diff-6293b328006f1e9a97d6cf829b3331f18ade5041aa57e9c41acebb61ef92b9a6R90-R99) [[9]](diffhunk://#diff-6293b328006f1e9a97d6cf829b3331f18ade5041aa57e9c41acebb61ef92b9a6R125-R196)
* **Config-driven client parameters:** Refactored the client to use helper functions for all timing and size parameters, providing sensible defaults and improving robustness against incomplete configs. [[1]](diffhunk://#diff-9645071f910a0447aa5e089be0681cc41d444b3c22e97f20df7e68921fd6b23fL57-R57) [[2]](diffhunk://#diff-9645071f910a0447aa5e089be0681cc41d444b3c22e97f20df7e68921fd6b23fR68-R81) [[3]](diffhunk://#diff-9645071f910a0447aa5e089be0681cc41d444b3c22e97f20df7e68921fd6b23fL94-R97) [[4]](diffhunk://#diff-9645071f910a0447aa5e089be0681cc41d444b3c22e97f20df7e68921fd6b23fL108-R110) [[5]](diffhunk://#diff-9645071f910a0447aa5e089be0681cc41d444b3c22e97f20df7e68921fd6b23fL121-R183)
* **Improved synchronization and signaling:** Introduced a write-available channel and improved signaling in the server session to better coordinate data availability and request processing. [[1]](diffhunk://#diff-6293b328006f1e9a97d6cf829b3331f18ade5041aa57e9c41acebb61ef92b9a6R90-R99) [[2]](diffhunk://#diff-6293b328006f1e9a97d6cf829b3331f18ade5041aa57e9c41acebb61ef92b9a6R125-R196)

### GDocsViewer Roundtripper Enhancements

* **Custom request headers:** Added a `request_headers` map field to the GDocsViewer `ClientConfig`, with corresponding protobuf and Go code changes, allowing users to specify arbitrary HTTP headers for outgoing requests. [[1]](diffhunk://#diff-87a353b7d1156a4cb267c219a8d3316264eda5c17963a3119496a36afb5db746R32) [[2]](diffhunk://#diff-87a353b7d1156a4cb267c219a8d3316264eda5c17963a3119496a36afb5db746R144-R150) [[3]](diffhunk://#diff-87a353b7d1156a4cb267c219a8d3316264eda5c17963a3119496a36afb5db746L267-R275) [[4]](diffhunk://#diff-87a353b7d1156a4cb267c219a8d3316264eda5c17963a3119496a36afb5db746L286-R298) [[5]](diffhunk://#diff-87a353b7d1156a4cb267c219a8d3316264eda5c17963a3119496a36afb5db746L313-R339) [[6]](diffhunk://#diff-87a353b7d1156a4cb267c219a8d3316264eda5c17963a3119496a36afb5db746L339-R353) [[7]](diffhunk://#diff-6a85a89bb69170d27b269e2f15d99e45d83befcc3694646d17d5701751305f2bR26)

### Miscellaneous

* **Debugging support:** Added a constant `debugBodyPreviewBytes` for body preview size in GDocsViewer, likely to assist with debugging/logging.
* **Minor imports:** Added the `strconv` import to `gdocsviewer.go` for future or current use.…poll logic