### PR TITLE
gdocsviewer: allow adding headers in public config

### DIFF
--- a/common/protofilter/filter.go
+++ b/common/protofilter/filter.go
@@ -68,7 +68,7 @@ func filterMessage(ctx context.Context, message protoreflect.Message) error {
 		switch descriptor.Kind() {
 		case protoreflect.MessageKind:
 			if descriptor.IsMap() {
-				err = filterMap(ctx, value.Map())
+				err = filterMap(ctx, descriptor, value.Map())
 				break
 			}
 			if descriptor.IsList() {
@@ -117,7 +117,10 @@ func filterMessage(ctx context.Context, message protoreflect.Message) error {
 	return nil
 }
 
-func filterMap(ctx context.Context, mapValue protoreflect.Map) error {
+func filterMap(ctx context.Context, descriptor protoreflect.FieldDescriptor, mapValue protoreflect.Map) error {
+	if descriptor.MapValue().Kind() != protoreflect.MessageKind {
+		return nil
+	}
 	var err error
 	mapValue.Range(func(key protoreflect.MapKey, value protoreflect.Value) bool {
 		err = filterMessage(ctx, value.Message())

--- a/transport/internet/request/stereotype/gdocsviewer/config.pb.go
+++ b/transport/internet/request/stereotype/gdocsviewer/config.pb.go
@@ -32,6 +32,7 @@ type Config struct {
 	MaxRequestBytes           int32                       `protobuf:"varint,12,opt,name=max_request_bytes,json=maxRequestBytes,proto3" json:"max_request_bytes,omitempty"`
 	MaxResponseBytes          int32                       `protobuf:"varint,13,opt,name=max_response_bytes,json=maxResponseBytes,proto3" json:"max_response_bytes,omitempty"`
 	OriginUrlReplacementRules []*OriginUrlReplacementRule `protobuf:"bytes,14,rep,name=origin_url_replacement_rules,json=originUrlReplacementRules,proto3" json:"origin_url_replacement_rules,omitempty"`
+	RequestHeaders            map[string]string           `protobuf:"bytes,15,rep,name=request_headers,json=requestHeaders,proto3" json:"request_headers,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields             protoimpl.UnknownFields
 	sizeCache                 protoimpl.SizeCache
 }
@@ -164,6 +165,13 @@ func (x *Config) GetOriginUrlReplacementRules() []*OriginUrlReplacementRule {
 	return nil
 }
 
+func (x *Config) GetRequestHeaders() map[string]string {
+	if x != nil {
+		return x.RequestHeaders
+	}
+	return nil
+}
+
 type OriginUrlReplacementRule struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -220,7 +228,7 @@ var File_transport_internet_request_stereotype_gdocsviewer_config_proto protoref
 
 const file_transport_internet_request_stereotype_gdocsviewer_config_proto_rawDesc = "" +
 	"\n" +
-	">transport/internet/request/stereotype/gdocsviewer/config.proto\x12<v2ray.core.transport.internet.request.stereotype.gdocsviewer\x1a common/protoext/extensions.proto\"\xaf\x05\n" +
+	">transport/internet/request/stereotype/gdocsviewer/config.proto\x12<v2ray.core.transport.internet.request.stereotype.gdocsviewer\x1a common/protoext/extensions.proto\"\xf6\x06\n" +
 	"\x06Config\x12\x1d\n" +
 	"\n" +
 	"viewer_url\x18\x01 \x01(\tR\tviewerUrl\x12\x19\n" +
@@ -243,7 +251,11 @@ const file_transport_internet_request_stereotype_gdocsviewer_config_proto_rawDes
 	"pathPrefix\x12*\n" +
 	"\x11max_request_bytes\x18\f \x01(\x05R\x0fmaxRequestBytes\x12,\n" +
 	"\x12max_response_bytes\x18\r \x01(\x05R\x10maxResponseBytes\x12\x97\x01\n" +
-	"\x1corigin_url_replacement_rules\x18\x0e \x03(\v2V.v2ray.core.transport.internet.request.stereotype.gdocsviewer.OriginUrlReplacementRuleR\x19originUrlReplacementRules: \x82\xb5\x18\x1c\n" +
+	"\x1corigin_url_replacement_rules\x18\x0e \x03(\v2V.v2ray.core.transport.internet.request.stereotype.gdocsviewer.OriginUrlReplacementRuleR\x19originUrlReplacementRules\x12\x81\x01\n" +
+	"\x0frequest_headers\x18\x0f \x03(\v2X.v2ray.core.transport.internet.request.stereotype.gdocsviewer.Config.RequestHeadersEntryR\x0erequestHeaders\x1aA\n" +
+	"\x13RequestHeadersEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01: \x82\xb5\x18\x1c\n" +
 	"\ttransport\x12\vgdocsviewer\x90\xff)\x01\"H\n" +
 	"\x18OriginUrlReplacementRule\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
@@ -262,18 +274,20 @@ func file_transport_internet_request_stereotype_gdocsviewer_config_proto_rawDesc
 	return file_transport_internet_request_stereotype_gdocsviewer_config_proto_rawDescData
 }
 
-var file_transport_internet_request_stereotype_gdocsviewer_config_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_transport_internet_request_stereotype_gdocsviewer_config_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_transport_internet_request_stereotype_gdocsviewer_config_proto_goTypes = []any{
 	(*Config)(nil),                   // 0: v2ray.core.transport.internet.request.stereotype.gdocsviewer.Config
 	(*OriginUrlReplacementRule)(nil), // 1: v2ray.core.transport.internet.request.stereotype.gdocsviewer.OriginUrlReplacementRule
+	nil,                              // 2: v2ray.core.transport.internet.request.stereotype.gdocsviewer.Config.RequestHeadersEntry
 }
 var file_transport_internet_request_stereotype_gdocsviewer_config_proto_depIdxs = []int32{
 	1, // 0: v2ray.core.transport.internet.request.stereotype.gdocsviewer.Config.origin_url_replacement_rules:type_name -> v2ray.core.transport.internet.request.stereotype.gdocsviewer.OriginUrlReplacementRule
-	1, // [1:1] is the sub-list for method output_type
-	1, // [1:1] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	2, // 1: v2ray.core.transport.internet.request.stereotype.gdocsviewer.Config.request_headers:type_name -> v2ray.core.transport.internet.request.stereotype.gdocsviewer.Config.RequestHeadersEntry
+	2, // [2:2] is the sub-list for method output_type
+	2, // [2:2] is the sub-list for method input_type
+	2, // [2:2] is the sub-list for extension type_name
+	2, // [2:2] is the sub-list for extension extendee
+	0, // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_transport_internet_request_stereotype_gdocsviewer_config_proto_init() }
@@ -287,7 +301,7 @@ func file_transport_internet_request_stereotype_gdocsviewer_config_proto_init() 
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_transport_internet_request_stereotype_gdocsviewer_config_proto_rawDesc), len(file_transport_internet_request_stereotype_gdocsviewer_config_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/transport/internet/request/stereotype/gdocsviewer/config.proto
+++ b/transport/internet/request/stereotype/gdocsviewer/config.proto
@@ -27,6 +27,7 @@ message Config {
   int32 max_request_bytes = 12;
   int32 max_response_bytes = 13;
   repeated OriginUrlReplacementRule origin_url_replacement_rules = 14;
+  map<string, string> request_headers = 15;
 }
 
 message OriginUrlReplacementRule {

--- a/transport/internet/request/stereotype/gdocsviewer/gdocsviewer.go
+++ b/transport/internet/request/stereotype/gdocsviewer/gdocsviewer.go
@@ -83,6 +83,7 @@ func buildClientRequestConfig(setting *Config) *assembly.Config {
 			MinRequestIntervalMs:      setting.MinRequestIntervalMs,
 			SharedKey:                 setting.SharedKey,
 			OriginUrlReplacementRules: convertOriginURLReplacementRules(setting.OriginUrlReplacementRules),
+			RequestHeaders:            setting.RequestHeaders,
 		}),
 	}
 	return requestConfig

--- a/transport/internet/request/stereotype/gdocsviewer/gdocsviewer_test.go
+++ b/transport/internet/request/stereotype/gdocsviewer/gdocsviewer_test.go
@@ -27,6 +27,9 @@ func TestBuildClientRequestConfig(t *testing.T) {
 			Name:    "abc",
 			Pattern: "[a-z0-9]{14}",
 		}},
+		RequestHeaders: map[string]string{
+			"Accept-Language": "en-US,en;q=0.9",
+		},
 	})
 
 	assembler, err := serial.GetInstanceOf(config.Assembler)
@@ -57,7 +60,8 @@ func TestBuildClientRequestConfig(t *testing.T) {
 		!bytes.Equal(rtConfig.SharedKey, key) ||
 		len(rtConfig.OriginUrlReplacementRules) != 1 ||
 		rtConfig.OriginUrlReplacementRules[0].Name != "abc" ||
-		rtConfig.OriginUrlReplacementRules[0].Pattern != "[a-z0-9]{14}" {
+		rtConfig.OriginUrlReplacementRules[0].Pattern != "[a-z0-9]{14}" ||
+		rtConfig.RequestHeaders["Accept-Language"] != "en-US,en;q=0.9" {
 		t.Fatalf("unexpected gdocsviewer client config %+v", rtConfig)
 	}
 }


### PR DESCRIPTION
This pull request export the additional header config in public facing transport config.

----
This pull request introduces support for custom request headers in the GDocsViewer transport configuration. The main changes add a `request_headers` map field to the configuration, update the code to propagate this field, and add tests to ensure the new functionality works as expected.

### GDocsViewer request header support

* Added a `map<string, string> request_headers` field to the `Config` message in `config.proto`, and regenerated the corresponding Go code to handle this field. [[1]](diffhunk://#diff-e845b5c1d7cf512f2311e6a5b6274943b5ac96a42cb572dda9a5799170a4f0cdR30) [[2]](diffhunk://#diff-21834978e71b3eac4d1234cc5111e83690bfd2024adbb70b8d20eb333fbed327R35) [[3]](diffhunk://#diff-21834978e71b3eac4d1234cc5111e83690bfd2024adbb70b8d20eb333fbed327R168-R174) [[4]](diffhunk://#diff-21834978e71b3eac4d1234cc5111e83690bfd2024adbb70b8d20eb333fbed327L223-R231) [[5]](diffhunk://#diff-21834978e71b3eac4d1234cc5111e83690bfd2024adbb70b8d20eb333fbed327L246-R258) [[6]](diffhunk://#diff-21834978e71b3eac4d1234cc5111e83690bfd2024adbb70b8d20eb333fbed327L265-R290) [[7]](diffhunk://#diff-21834978e71b3eac4d1234cc5111e83690bfd2024adbb70b8d20eb333fbed327L290-R304)
* Updated `buildClientRequestConfig` in `gdocsviewer.go` to propagate the `RequestHeaders` field into the runtime configuration.
* Extended the test `TestBuildClientRequestConfig` to set and validate the new `RequestHeaders` field, ensuring it is correctly handled in the configuration. [[1]](diffhunk://#diff-868c785407bcbd6e1593406e1bace76b7258dd7fe2106e1971d608c1a8d55fb2R30-R32) [[2]](diffhunk://#diff-868c785407bcbd6e1593406e1bace76b7258dd7fe2106e1971d608c1a8d55fb2L60-R64)

### Internal proto filtering improvement

* Improved the `filterMap` function in `protofilter/filter.go` to accept and use the field descriptor, skipping non-message map values for efficiency and correctness. [[1]](diffhunk://#diff-4859bedddc2068f36e6d934627ca8e48498f9cd780ffb35137c58113d2d2f215L71-R71) [[2]](diffhunk://#diff-4859bedddc2068f36e6d934627ca8e48498f9cd780ffb35137c58113d2d2f215L120-R123)