### PR TITLE
Fix v4 X-Forwarded-For transport config

### DIFF
--- a/infra/conf/v4/transport_internet.go
+++ b/infra/conf/v4/transport_internet.go
@@ -172,6 +172,7 @@ type WebSocketConfig struct {
 	MaxEarlyData         int32             `json:"maxEarlyData"`
 	UseBrowserForwarding bool              `json:"useBrowserForwarding"`
 	EarlyDataHeaderName  string            `json:"earlyDataHeaderName"`
+	ParseXForwardedFor   bool              `json:"parseXForwardedFor"`
 }
 
 // Build implements Buildable.
@@ -190,6 +191,7 @@ func (c *WebSocketConfig) Build() (proto.Message, error) {
 		MaxEarlyData:         c.MaxEarlyData,
 		UseBrowserForwarding: c.UseBrowserForwarding,
 		EarlyDataHeaderName:  c.EarlyDataHeaderName,
+		ParseXForwardedFor:   c.ParseXForwardedFor,
 	}
 	if c.AcceptProxyProtocol {
 		config.AcceptProxyProtocol = c.AcceptProxyProtocol
@@ -198,16 +200,18 @@ func (c *WebSocketConfig) Build() (proto.Message, error) {
 }
 
 type HTTPConfig struct {
-	Host    *cfgcommon.StringList            `json:"host"`
-	Path    string                           `json:"path"`
-	Method  string                           `json:"method"`
-	Headers map[string]*cfgcommon.StringList `json:"headers"`
+	Host               *cfgcommon.StringList            `json:"host"`
+	Path               string                           `json:"path"`
+	Method             string                           `json:"method"`
+	Headers            map[string]*cfgcommon.StringList `json:"headers"`
+	ParseXForwardedFor bool                             `json:"parseXForwardedFor"`
 }
 
 // Build implements Buildable.
 func (c *HTTPConfig) Build() (proto.Message, error) {
 	config := &http.Config{
-		Path: c.Path,
+		Path:               c.Path,
+		ParseXForwardedFor: c.ParseXForwardedFor,
 	}
 	if c.Host != nil {
 		config.Host = []string(*c.Host)

--- a/infra/conf/v4/transport_test.go
+++ b/infra/conf/v4/transport_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/v2fly/v2ray-core/v5/transport/internet/headers/http"
 	"github.com/v2fly/v2ray-core/v5/transport/internet/headers/noop"
 	"github.com/v2fly/v2ray-core/v5/transport/internet/headers/tls"
+	internethttp "github.com/v2fly/v2ray-core/v5/transport/internet/http"
 	"github.com/v2fly/v2ray-core/v5/transport/internet/kcp"
 	"github.com/v2fly/v2ray-core/v5/transport/internet/quic"
 	"github.com/v2fly/v2ray-core/v5/transport/internet/tcp"
@@ -92,7 +93,12 @@ func TestTransportConfig(t *testing.T) {
 					}
 				},
 				"wsSettings": {
-					"path": "/t"
+					"path": "/t",
+					"parseXForwardedFor": true
+				},
+				"httpSettings": {
+					"path": "/h2",
+					"parseXForwardedFor": true
 				},
 				"quicSettings": {
 					"key": "abcd",
@@ -156,7 +162,15 @@ func TestTransportConfig(t *testing.T) {
 					{
 						ProtocolName: "websocket",
 						Settings: serial.ToTypedMessage(&websocket.Config{
-							Path: "/t",
+							Path:               "/t",
+							ParseXForwardedFor: true,
+						}),
+					},
+					{
+						ProtocolName: "http",
+						Settings: serial.ToTypedMessage(&internethttp.Config{
+							Path:               "/h2",
+							ParseXForwardedFor: true,
 						}),
 					},
 					{


### PR DESCRIPTION
## Summary

Fixes #3329.
Fix legacy v4 JSON config handling for `parseXForwardedFor` on WebSocket and HTTP transports.

After the transport-level `parse_x_forwarded_for` gate was added, v4 JSON configs could not actually enable it through `wsSettings` or `httpSettings`. As a result, access logs continued to show the direct reverse-proxy peer
address, such as `127.0.0.1`, even when users added `parseXForwardedFor: true`.

## Changes

- Add `parseXForwardedFor` to v4 `wsSettings`.
- Add `parseXForwardedFor` to v4 `httpSettings`.
- Wire both fields into their transport protobuf configs.
- Add v4 transport config test coverage for both WebSocket and HTTP.
