### PR TITLE
common/errors: implement Unwrap on *Error for errors.Is/As support

### DIFF
--- a/common/errors/errors.go
+++ b/common/errors/errors.go
@@ -78,6 +78,12 @@ func (err *Error) Inner() error {
 	return err.inner
 }
 
+// Unwrap implements the standard library's errors.Unwrap contract, allowing
+// errors.Is and errors.As to traverse to the underlying error.
+func (err *Error) Unwrap() error {
+	return err.inner
+}
+
 func (err *Error) Base(e error) *Error {
 	err.inner = e
 	return err

--- a/common/errors/errors_test.go
+++ b/common/errors/errors_test.go
@@ -63,26 +63,23 @@ func TestErrorMessage(t *testing.T) {
 	}
 }
 
-// errUnwrapSentinel is a sentinel for exercising errors.Is traversal.
 var errUnwrapSentinel = stderrors.New("unwrap sentinel")
 
-// typedUnwrapErr is a concrete error type for exercising errors.As traversal.
 type typedUnwrapErr struct{ code int }
 
 func (typedUnwrapErr) Error() string { return "typed unwrap error" }
 
 func TestErrorUnwrap(t *testing.T) {
-	base := stderrors.New("base")
-	if got := stderrors.Unwrap(New("wrapper").Base(base)); got != base {
-		t.Errorf("Unwrap() = %v, want the wrapped base error", got)
+	expected := stderrors.New("base")
+	if actual := stderrors.Unwrap(New("wrapper").Base(expected)); actual != expected {
+		t.Errorf("Unwrap() = %v, expected the wrapped base error", actual)
 	}
-	if got := stderrors.Unwrap(New("no inner")); got != nil {
-		t.Errorf("Unwrap() of an error with no inner = %v, want nil", got)
+	if actual := stderrors.Unwrap(New("no inner")); actual != nil {
+		t.Errorf("Unwrap() = %v, expected nil", actual)
 	}
 }
 
 func TestErrorIsThroughChain(t *testing.T) {
-	// Three *Error layers, matching the real-world depth of a wrapped error.
 	chain := New("a").Base(New("b").Base(New("c").Base(errUnwrapSentinel)))
 	if !stderrors.Is(chain, errUnwrapSentinel) {
 		t.Errorf("errors.Is could not find the sentinel through the *Error chain: %v", chain)
@@ -91,28 +88,26 @@ func TestErrorIsThroughChain(t *testing.T) {
 
 func TestErrorAsThroughChain(t *testing.T) {
 	chain := New("outer").Base(New("inner").Base(typedUnwrapErr{code: 42}))
-	var got typedUnwrapErr
-	if !stderrors.As(chain, &got) {
+	var actual typedUnwrapErr
+	if !stderrors.As(chain, &actual) {
 		t.Fatalf("errors.As could not extract typedUnwrapErr through the *Error chain: %v", chain)
 	}
-	if got.code != 42 {
-		t.Errorf("extracted typedUnwrapErr.code = %d, want 42", got.code)
+	if actual.code != 42 {
+		t.Errorf("extracted code = %d, expected 42", actual.code)
 	}
 }
 
-// TestErrorAsSyscallErrno mirrors the motivating case: a syscall.Errno from a
-// failed bind, wrapped by three *Error layers (as ListenTCP -> ListenTCP ->
-// worker.Start do), must remain recoverable via the standard errors.As.
+// The motivating case: recover a syscall.Errno from a multi-layer wrap.
 func TestErrorAsSyscallErrno(t *testing.T) {
-	const want = syscall.Errno(4242) // arbitrary; only round-trip traversal is asserted
+	const expected = syscall.Errno(4242)
 	chain := New("failed to listen TCP on 443").Base(
 		New("failed to listen on address: 0.0.0.0:443").Base(
-			New("failed to listen TCP on 0.0.0.0:443").Base(want)))
-	var got syscall.Errno
-	if !stderrors.As(chain, &got) {
+			New("failed to listen TCP on 0.0.0.0:443").Base(expected)))
+	var actual syscall.Errno
+	if !stderrors.As(chain, &actual) {
 		t.Fatalf("errors.As could not extract syscall.Errno through the *Error chain: %v", chain)
 	}
-	if got != want {
-		t.Errorf("extracted errno = %d, want %d", got, want)
+	if actual != expected {
+		t.Errorf("extracted errno = %d, expected %d", actual, expected)
 	}
 }

--- a/common/errors/errors_test.go
+++ b/common/errors/errors_test.go
@@ -1,8 +1,10 @@
 package errors_test
 
 import (
+	stderrors "errors"
 	"io"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -58,5 +60,59 @@ func TestErrorMessage(t *testing.T) {
 		if diff := cmp.Diff(d.msg, d.err.Error()); diff != "" {
 			t.Error(diff)
 		}
+	}
+}
+
+// errUnwrapSentinel is a sentinel for exercising errors.Is traversal.
+var errUnwrapSentinel = stderrors.New("unwrap sentinel")
+
+// typedUnwrapErr is a concrete error type for exercising errors.As traversal.
+type typedUnwrapErr struct{ code int }
+
+func (typedUnwrapErr) Error() string { return "typed unwrap error" }
+
+func TestErrorUnwrap(t *testing.T) {
+	base := stderrors.New("base")
+	if got := stderrors.Unwrap(New("wrapper").Base(base)); got != base {
+		t.Errorf("Unwrap() = %v, want the wrapped base error", got)
+	}
+	if got := stderrors.Unwrap(New("no inner")); got != nil {
+		t.Errorf("Unwrap() of an error with no inner = %v, want nil", got)
+	}
+}
+
+func TestErrorIsThroughChain(t *testing.T) {
+	// Three *Error layers, matching the real-world depth of a wrapped error.
+	chain := New("a").Base(New("b").Base(New("c").Base(errUnwrapSentinel)))
+	if !stderrors.Is(chain, errUnwrapSentinel) {
+		t.Errorf("errors.Is could not find the sentinel through the *Error chain: %v", chain)
+	}
+}
+
+func TestErrorAsThroughChain(t *testing.T) {
+	chain := New("outer").Base(New("inner").Base(typedUnwrapErr{code: 42}))
+	var got typedUnwrapErr
+	if !stderrors.As(chain, &got) {
+		t.Fatalf("errors.As could not extract typedUnwrapErr through the *Error chain: %v", chain)
+	}
+	if got.code != 42 {
+		t.Errorf("extracted typedUnwrapErr.code = %d, want 42", got.code)
+	}
+}
+
+// TestErrorAsSyscallErrno mirrors the motivating case: a syscall.Errno from a
+// failed bind, wrapped by three *Error layers (as ListenTCP -> ListenTCP ->
+// worker.Start do), must remain recoverable via the standard errors.As.
+func TestErrorAsSyscallErrno(t *testing.T) {
+	const want = syscall.Errno(4242) // arbitrary; only round-trip traversal is asserted
+	chain := New("failed to listen TCP on 443").Base(
+		New("failed to listen on address: 0.0.0.0:443").Base(
+			New("failed to listen TCP on 0.0.0.0:443").Base(want)))
+	var got syscall.Errno
+	if !stderrors.As(chain, &got) {
+		t.Fatalf("errors.As could not extract syscall.Errno through the *Error chain: %v", chain)
+	}
+	if got != want {
+		t.Errorf("extracted errno = %d, want %d", got, want)
 	}
 }


### PR DESCRIPTION
Add `Unwrap()` to `*Error` so `errors.Is`/`As`/`Unwrap` traverse the inner chain. Until now `*Error` exposed its wrapped error only through `Inner()`/`Cause()`, so standard-library unwrapping stopped at the first `*Error`.

A low-level error wrapped in `*Error` layers can now be recovered directly:

```go
var errno syscall.Errno
errors.As(listenErr, &errno) // now found through the *Error chain
```

Strictly additive: `Unwrap` returns the existing `inner` field (`nil` when unset), so it can only surface matches that were previously unreachable, never change one.
