### PR TITLE
Guard Android DNS resolver hack behind !cgo

### DIFF
--- a/transport/internet/system_dns_android.go
+++ b/transport/internet/system_dns_android.go
@@ -1,5 +1,5 @@
-//go:build android
-// +build android
+//go:build android && !cgo
+// +build android,!cgo
 
 package internet
 


### PR DESCRIPTION
When v2ray-core is compiled with CGO, this hack is not needed. This also makes it problematic to use v2ray-core as a native library on Android, which almost comes with CGO enabled (compiled with NDK).

Example for what is broken: shadowsocks/v2ray-plugin-android#44.