### PR TITLE
fix(websocket): serialize concurrent writes

### DIFF
--- a/transport/internet/websocket/connection.go
+++ b/transport/internet/websocket/connection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -20,6 +21,7 @@ type connection struct {
 	conn       *websocket.Conn
 	reader     io.Reader
 	remoteAddr net.Addr
+	writeMu    sync.Mutex
 
 	shouldWait        bool
 	delayedDialFinish context.Context
@@ -111,6 +113,9 @@ func (c *connection) getReader() (io.Reader, error) {
 
 // Write implements io.Writer.
 func (c *connection) Write(b []byte) (int, error) {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+
 	if c.shouldWait {
 		var err error
 		c.conn, err = c.dialer.Dial(b)
@@ -192,12 +197,18 @@ func (c *connection) SetReadDeadline(t time.Time) error {
 }
 
 func (c *connection) SetWriteDeadline(t time.Time) error {
-	if c.shouldWait {
+	// Do not hold writeMu while waiting for the first write to materialize a
+	// delayed connection. The first write needs that mutex to perform the dial.
+	if c.delayedDialFinish != nil {
 		<-c.delayedDialFinish.Done()
-		if c.conn == nil {
-			newError("websocket transport is not materialized when SetWriteDeadline() is called").AtWarning().WriteToLog()
-			return nil
-		}
+	}
+
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+
+	if c.conn == nil {
+		newError("websocket transport is not materialized when SetWriteDeadline() is called").AtWarning().WriteToLog()
+		return nil
 	}
 	return c.conn.SetWriteDeadline(t)
 }

--- a/transport/internet/websocket/connection_test.go
+++ b/transport/internet/websocket/connection_test.go
@@ -1,0 +1,92 @@
+package websocket
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	gorillawebsocket "github.com/gorilla/websocket"
+)
+
+func TestConnectionConcurrentWrites(t *testing.T) {
+	const (
+		writerCount     = 16
+		writesPerWriter = 16
+		payloadSize     = 64 * 1024
+	)
+
+	serverResult := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := (&gorillawebsocket.Upgrader{
+			CheckOrigin: func(*http.Request) bool { return true },
+		}).Upgrade(w, r, nil)
+		if err != nil {
+			serverResult <- err
+			return
+		}
+		defer conn.Close()
+		if err := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+			serverResult <- err
+			return
+		}
+
+		for i := 0; i < writerCount*writesPerWriter; i++ {
+			messageType, payload, err := conn.ReadMessage()
+			if err != nil {
+				serverResult <- err
+				return
+			}
+			if messageType != gorillawebsocket.BinaryMessage {
+				serverResult <- fmt.Errorf("unexpected WebSocket message type: %d", messageType)
+				return
+			}
+			if len(payload) != payloadSize {
+				serverResult <- fmt.Errorf("unexpected payload size: got %d, want %d", len(payload), payloadSize)
+				return
+			}
+		}
+		serverResult <- nil
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	wsConn, _, err := gorillawebsocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn := newConnection(wsConn, wsConn.RemoteAddr())
+	defer conn.Close()
+
+	start := make(chan struct{})
+	writeErrors := make(chan error, writerCount*writesPerWriter)
+	var writers sync.WaitGroup
+	for writerID := 0; writerID < writerCount; writerID++ {
+		writers.Add(1)
+		go func(writerID int) {
+			defer writers.Done()
+			payload := bytes.Repeat([]byte{byte(writerID)}, payloadSize)
+			<-start
+			for i := 0; i < writesPerWriter; i++ {
+				if _, err := conn.Write(payload); err != nil {
+					writeErrors <- err
+					return
+				}
+			}
+		}(writerID)
+	}
+
+	close(start)
+	writers.Wait()
+	close(writeErrors)
+	for err := range writeErrors {
+		t.Errorf("concurrent write failed: %v", err)
+	}
+	if err := <-serverResult; err != nil {
+		t.Fatalf("server failed while reading concurrent writes: %v", err)
+	}
+}


### PR DESCRIPTION

## Summary

Serialize write-side operations in the WebSocket transport to prevent concurrent calls into `gorilla/websocket`.

The V2Ray WebSocket wrapper implements a `net.Conn`-compatible connection, but it previously forwarded writes directly to `gorilla/websocket.Conn.WriteMessage`. Gorilla WebSocket supports only one concurrent writer per connection and intentionally panics when overlapping writes are detected.

This change adds per-connection write synchronization for every protocol using the WebSocket transport.

## Problem

Multiple goroutines can write through the same V2Ray WebSocket connection.

One observed trigger is a UDP association containing traffic for multiple destinations. Separate response goroutines can receive packets concurrently and return them through the same WebSocket:

```text
response goroutine A ─┐
                      ├──> connection.Write
response goroutine B ─┘          │
                                 └──> websocket.Conn.WriteMessage
```

Without serialization, overlapping writes cause Gorilla WebSocket to panic:

```text
panic: concurrent write to websocket connection

github.com/gorilla/websocket.(*messageWriter).flushFrame()
    github.com/gorilla/websocket@v1.5.3/conn.go:617

github.com/v2fly/v2ray-core/v5/transport/internet/websocket.(*connection).Write()
    transport/internet/websocket/connection.go:125
```

Because the panic occurs inside a goroutine, it terminates the entire V2Ray process.

Although Trojan UDP exposed the problem, the unsafe behavior is in the shared WebSocket transport and can affect any caller that writes concurrently.

## Root cause

`transport/internet/websocket.connection` presents a `net.Conn`-compatible interface. Go permits multiple goroutines to invoke methods on a `net.Conn` simultaneously.

However, the underlying Gorilla WebSocket connection has a stricter contract:

- One concurrent reader is allowed.
- One concurrent writer is allowed.
- Applications must serialize `WriteMessage`, `NextWriter`, `SetWriteDeadline`, and other write-side methods.

The V2Ray wrapper did not adapt these different concurrency contracts.

## Changes

- Add a per-connection `sync.Mutex` for WebSocket write-side operations.
- Hold the mutex across the complete `Write` operation.
- Include delayed WebSocket dialing in the protected write operation.
- Serialize `SetWriteDeadline` with data writes.
- Wait for delayed dialing before acquiring the write mutex in `SetWriteDeadline`.
- Add a real loopback WebSocket regression test for concurrent writes.

The mutex is write-specific, so reading and writing can still proceed concurrently.

`Close` and `WriteControl` do not require this mutex because Gorilla WebSocket explicitly permits them to run concurrently with other methods.

## Delayed dialing

When WebSocket early data is enabled, V2Ray delays creating the actual WebSocket until the first call to `Write`.

`SetWriteDeadline` may need to wait for that first write to create the connection. It must not hold the write mutex while waiting, or the following deadlock could occur:

```text
SetWriteDeadline:
    holds write mutex
    waits for delayed dialing

Write:
    waits for write mutex
    must perform delayed dialing
```

The implementation therefore waits for delayed dialing without holding the mutex, then acquires the mutex before modifying the underlying WebSocket write deadline.

## Regression test

`TestConnectionConcurrentWrites` uses a real loopback TCP and WebSocket connection rather than a mocked writer.

The test:

1. Starts a local HTTP server.
2. Upgrades the connection using Gorilla WebSocket.
3. Connects a real Gorilla WebSocket client.
4. Wraps the client with V2Ray's WebSocket `connection`.
5. Starts 16 writer goroutines simultaneously.
6. Sends 16 binary messages from each writer.
7. Uses a 64 KiB payload for every message.
8. Verifies all 256 messages on the server.
9. Verifies every message type and payload size.
10. Runs under Go's race detector.

Total traffic written through the shared connection is 16 MiB:

```text
16 writers × 16 messages × 64 KiB = 16 MiB
```

A server-side read deadline prevents the test from hanging if the connection becomes corrupted.

## Test results

Command:

```bash
go test -race -count=1 \
  -run '^TestConnectionConcurrentWrites$' \
  ./transport/internet/websocket
```

Patched result:

```text
=== RUN   TestConnectionConcurrentWrites
--- PASS: TestConnectionConcurrentWrites
PASS
ok github.com/v2fly/v2ray-core/v5/transport/internet/websocket
```

No panic, data race, missing message, or corrupted frame was detected.

The related packages also pass under the race detector:

```bash
go test -race ./proxy/trojan ./transport/internet/websocket
```

```text
ok github.com/v2fly/v2ray-core/v5/proxy/trojan
ok github.com/v2fly/v2ray-core/v5/transport/internet/websocket
```

## Verification against the original implementation

The same test was copied into an isolated tree containing the original `connection.go`.

Without the race detector, the original implementation reproduced the production failure:

```text
panic: concurrent write to websocket connection

github.com/gorilla/websocket.(*messageWriter).flushFrame()
    github.com/gorilla/websocket@v1.5.3/conn.go:617

github.com/v2fly/v2ray-core/v5/transport/internet/websocket.(*connection).Write()
    transport/internet/websocket/connection.go:125
```

With the race detector enabled, the original implementation produced:

- Multiple concurrent-access reports inside Gorilla WebSocket
- Corrupted WebSocket frame boundaries
- A 4 KiB message where the test expected 64 KiB
- Multiple `broken pipe` write failures
- A failed test result

Comparison:

```text
Original implementation:
    FAIL — concurrent-write panic, data races, and corrupted frames

Patched implementation:
    PASS — all 256 frames intact with no panic or reported race
```

## Impact

This change prevents process-wide crashes caused by concurrent writes and protects all protocols using the WebSocket transport.

The tradeoff is that writes on an individual WebSocket connection are serialized. This matches Gorilla WebSocket's required usage contract and preserves concurrency between separate connections and between the read and write sides of the same connection.
