### PR TITLE
Fix: CI tests failures

### DIFF
--- a/app/stats/channel.go
+++ b/app/stats/channel.go
@@ -3,8 +3,6 @@ package stats
 import (
 	"context"
 	"sync"
-
-	"github.com/v2fly/v2ray-core/v5/common"
 )
 
 // Channel is an implementation of stats.Channel.
@@ -100,6 +98,7 @@ func (c *Channel) Start() error {
 	defer c.access.Unlock()
 	if !c.Running() {
 		c.closed = make(chan struct{}) // Reset close signal
+		closed := c.closed            // Capture for this goroutine to detect restarts
 		go func() {
 			for {
 				select {
@@ -111,11 +110,18 @@ func (c *Channel) Start() error {
 							pub.broadcastNonBlocking(sub)
 						}
 					}
-				case <-c.closed: // Channel closed
-					for _, sub := range c.Subscribers() { // Remove all subscribers
-						common.Must(c.Unsubscribe(sub))
-						close(sub)
+				case <-closed: // This goroutine's own closed signal
+					// Hold the lock to prevent new subscribers from being added
+					// between checking the generation and closing subscribers.
+					c.access.Lock()
+					if c.closed == closed {
+						// Channel has not been restarted; close all remaining subscribers.
+						for _, sub := range c.subscribers {
+							close(sub)
+						}
+						c.subscribers = nil
 					}
+					c.access.Unlock()
 					return
 				}
 			}

--- a/app/stats/channel.go
+++ b/app/stats/channel.go
@@ -3,6 +3,8 @@ package stats
 import (
 	"context"
 	"sync"
+
+	"github.com/v2fly/v2ray-core/v5/common"
 )
 
 // Channel is an implementation of stats.Channel.
@@ -98,7 +100,6 @@ func (c *Channel) Start() error {
 	defer c.access.Unlock()
 	if !c.Running() {
 		c.closed = make(chan struct{}) // Reset close signal
-		closed := c.closed             // Capture for this goroutine to detect restarts
 		go func() {
 			for {
 				select {
@@ -110,18 +111,11 @@ func (c *Channel) Start() error {
 							pub.broadcastNonBlocking(sub)
 						}
 					}
-				case <-closed: // This goroutine's own closed signal
-					// Hold the lock to prevent new subscribers from being added
-					// between checking the generation and closing subscribers.
-					c.access.Lock()
-					if c.closed == closed {
-						// Channel has not been restarted; close all remaining subscribers.
-						for _, sub := range c.subscribers {
-							close(sub)
-						}
-						c.subscribers = nil
+				case <-c.closed: // Channel closed
+					for _, sub := range c.Subscribers() { // Remove all subscribers
+						common.Must(c.Unsubscribe(sub))
+						close(sub)
 					}
-					c.access.Unlock()
 					return
 				}
 			}

--- a/app/stats/channel.go
+++ b/app/stats/channel.go
@@ -98,7 +98,7 @@ func (c *Channel) Start() error {
 	defer c.access.Unlock()
 	if !c.Running() {
 		c.closed = make(chan struct{}) // Reset close signal
-		closed := c.closed            // Capture for this goroutine to detect restarts
+		closed := c.closed             // Capture for this goroutine to detect restarts
 		go func() {
 			for {
 				select {

--- a/testing/scenarios/common.go
+++ b/testing/scenarios/common.go
@@ -236,7 +236,11 @@ func testTCPConn2(conn net.Conn, payloadSize int, timeout time.Duration) func() 
 		payload := make([]byte, payloadSize)
 		common.Must2(rand.Read(payload))
 
+		if err := conn.SetWriteDeadline(time.Now().Add(timeout)); err != nil {
+			return err
+		}
 		nBytes, err := conn.Write(payload)
+		conn.SetWriteDeadline(time.Time{}) //nolint: errcheck
 		if err != nil {
 			return err
 		}

--- a/testing/scenarios/feature_test.go
+++ b/testing/scenarios/feature_test.go
@@ -2,8 +2,10 @@ package scenarios
 
 import (
 	"context"
+	"crypto/tls"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
@@ -12,6 +14,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	core "github.com/v2fly/v2ray-core/v5"
+	v2dns "github.com/v2fly/v2ray-core/v5/app/dns"
 	"github.com/v2fly/v2ray-core/v5/app/dispatcher"
 	"github.com/v2fly/v2ray-core/v5/app/log"
 	"github.com/v2fly/v2ray-core/v5/app/proxyman"
@@ -553,6 +556,18 @@ func TestUDPConnection(t *testing.T) {
 }
 
 func TestDomainSniffing(t *testing.T) {
+	const domain = "sniffing.test"
+
+	targetServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer targetServer.Close()
+
+	targetURL, err := url.Parse(targetServer.URL)
+	common.Must(err)
+	targetPort, err := net.PortFromString(targetURL.Port())
+	common.Must(err)
+
 	sniffingPort := tcp.PickPort()
 	httpPort := tcp.PickPort()
 	serverConfig := &core.Config{
@@ -568,7 +583,7 @@ func TestDomainSniffing(t *testing.T) {
 				}),
 				ProxySettings: serial.ToTypedMessage(&dokodemo.Config{
 					Address: net.NewIPOrDomain(net.LocalHostIP),
-					Port:    443,
+					Port:    uint32(targetPort),
 					NetworkList: &net.NetworkList{
 						Network: []net.Network{net.Network_TCP},
 					},
@@ -601,6 +616,15 @@ func TestDomainSniffing(t *testing.T) {
 			},
 		},
 		App: []*anypb.Any{
+			serial.ToTypedMessage(&v2dns.Config{
+				StaticHosts: []*v2dns.HostMapping{
+					{
+						Type:   v2dns.DomainMatchingType_Full,
+						Domain: domain,
+						Ip:     [][]byte{{127, 0, 0, 1}},
+					},
+				},
+			}),
 			serial.ToTypedMessage(&router.Config{
 				Rule: []*router.RoutingRule{
 					{
@@ -631,13 +655,17 @@ func TestDomainSniffing(t *testing.T) {
 			Proxy: func(req *http.Request) (*url.URL, error) {
 				return url.Parse("http://127.0.0.1:" + httpPort.String())
 			},
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+				ServerName:         domain,
+			},
 		}
 
 		client := &http.Client{
 			Transport: transport,
 		}
 
-		resp, err := client.Get("https://www.github.com/")
+		resp, err := client.Get("https://" + domain + ":" + targetPort.String() + "/")
 		common.Must(err)
 		defer resp.Body.Close()
 		if resp.StatusCode != 200 {

--- a/testing/scenarios/feature_test.go
+++ b/testing/scenarios/feature_test.go
@@ -14,7 +14,6 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	core "github.com/v2fly/v2ray-core/v5"
-	v2dns "github.com/v2fly/v2ray-core/v5/app/dns"
 	"github.com/v2fly/v2ray-core/v5/app/dispatcher"
 	"github.com/v2fly/v2ray-core/v5/app/log"
 	"github.com/v2fly/v2ray-core/v5/app/proxyman"
@@ -556,7 +555,7 @@ func TestUDPConnection(t *testing.T) {
 }
 
 func TestDomainSniffing(t *testing.T) {
-	const domain = "sniffing.test"
+	const domain = "localhost"
 
 	targetServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -616,15 +615,6 @@ func TestDomainSniffing(t *testing.T) {
 			},
 		},
 		App: []*anypb.Any{
-			serial.ToTypedMessage(&v2dns.Config{
-				StaticHosts: []*v2dns.HostMapping{
-					{
-						Type:   v2dns.DomainMatchingType_Full,
-						Domain: domain,
-						Ip:     [][]byte{{127, 0, 0, 1}},
-					},
-				},
-			}),
 			serial.ToTypedMessage(&router.Config{
 				Rule: []*router.RoutingRule{
 					{

--- a/testing/scenarios/feature_test.go
+++ b/testing/scenarios/feature_test.go
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	core "github.com/v2fly/v2ray-core/v5"
-	v2dns "github.com/v2fly/v2ray-core/v5/app/dns"
 	"github.com/v2fly/v2ray-core/v5/app/dispatcher"
+	v2dns "github.com/v2fly/v2ray-core/v5/app/dns"
 	"github.com/v2fly/v2ray-core/v5/app/log"
 	"github.com/v2fly/v2ray-core/v5/app/proxyman"
 	_ "github.com/v2fly/v2ray-core/v5/app/proxyman/inbound"

--- a/testing/scenarios/feature_test.go
+++ b/testing/scenarios/feature_test.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	core "github.com/v2fly/v2ray-core/v5"
+	v2dns "github.com/v2fly/v2ray-core/v5/app/dns"
 	"github.com/v2fly/v2ray-core/v5/app/dispatcher"
 	"github.com/v2fly/v2ray-core/v5/app/log"
 	"github.com/v2fly/v2ray-core/v5/app/proxyman"
@@ -555,7 +556,7 @@ func TestUDPConnection(t *testing.T) {
 }
 
 func TestDomainSniffing(t *testing.T) {
-	const domain = "localhost"
+	const domain = "sniffing.test"
 
 	targetServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -611,10 +612,19 @@ func TestDomainSniffing(t *testing.T) {
 			},
 			{
 				Tag:           "direct",
-				ProxySettings: serial.ToTypedMessage(&freedom.Config{}),
+				ProxySettings: serial.ToTypedMessage(&freedom.Config{DomainStrategy: freedom.Config_USE_IP}),
 			},
 		},
 		App: []*anypb.Any{
+			serial.ToTypedMessage(&v2dns.Config{
+				StaticHosts: []*v2dns.HostMapping{
+					{
+						Type:   v2dns.DomainMatchingType_Full,
+						Domain: domain,
+						Ip:     [][]byte{{127, 0, 0, 1}},
+					},
+				},
+			}),
 			serial.ToTypedMessage(&router.Config{
 				Rule: []*router.RoutingRule{
 					{


### PR DESCRIPTION
This PR is generated by GitHub Copilot Agent.

## Summary

Fixes two sources of CI failures: a data race / close-of-closed-channel panic in `app/stats.Channel`, and the network-dependent, deadline-less `TestDomainSniffing` scenario test.

## Changes

### `app/stats/channel.go` — fix race on channel restart

`Channel` can be stopped and restarted (`stats.SubscribeRunnableChannel` calls `Start()` when the subscriber list is empty, `UnsubscribeClosableChannel` calls `Close()` when the last subscriber leaves). The worker goroutine started by
`Start()` selected on the `c.closed` field, and on shutdown unsubscribed and closed every subscriber it saw:

- The field read raced with `Start()` reassigning `c.closed`, so an old goroutine could observe a new generation's close signal.
- Teardown took the lock only inside `Unsubscribe`, so subscribers registered after a restart could be closed by the previous goroutine — surfacing as `close of closed channel` / send-on-closed-channel panics and flaky `TestStatsChannel*` runs.

The goroutine now captures its own `closed` channel at launch, and on shutdown takes the write lock and only tears down subscribers if `c.closed` is still that same generation (i.e. the channel has not been restarted). The now-unused `common` import is dropped.

### `testing/scenarios/common.go` — bound writes with a deadline

`testTCPConn2` sets a write deadline (mirroring the read deadline already used by `readFrom2`) and clears it afterwards, so a stalled write returns a timeout error from the test helper instead of hanging until the whole test binary times out.

### `testing/scenarios/feature_test.go` — make `TestDomainSniffing` self-contained

The test previously proxied a real request to `https://www.github.com/` through dokodemo hardcoded to port 443, making it dependent on outbound internet access and on binding/reaching a privileged port. It now:

- starts a local `httptest.NewTLSServer` and points dokodemo at its ephemeral port;
- adds a static DNS host mapping `sniffing.test -> 127.0.0.1` and switches the `direct` outbound to `freedom` with `DomainStrategy: USE_IP`, so the sniffed domain resolves locally;
- sets `ServerName: sniffing.test` (with `InsecureSkipVerify`) on the client TLS config so the SNI value is what gets sniffed, and requests the local URL.

The routing/sniffing behaviour under test is unchanged; the test no longer requires network access.

## Validation

- `go test -race -count=4 ./app/stats/...` — pass
- `go test -run TestDomainSniffing ./testing/scenarios/` — pass (logs confirm `sniffed domain: sniffing.test`, detour `direct`, resolved to `127.0.0.1`)
- `go vet ./testing/scenarios/` — clean